### PR TITLE
fix: codebase analysis findings 2026-04-11

### DIFF
--- a/backend/src/lib/dataStore.ts
+++ b/backend/src/lib/dataStore.ts
@@ -157,12 +157,17 @@ const defaultLegacyFile =
   config.storage.legacyDataFile ?? (rawDataFile.endsWith('.json') ? rawDataFile : 'storage/data.json');
 
 const isSQLiteFile = (filePath: string) => {
+  let fd: number | undefined;
   try {
-    const header = fs.readFileSync(filePath);
-    if (header.length < 16) return false;
-    return header.subarray(0, 16).toString('utf8') === 'SQLite format 3\u0000';
+    fd = fs.openSync(filePath, 'r');
+    const header = Buffer.alloc(16);
+    const bytesRead = fs.readSync(fd, header, 0, 16, 0);
+    if (bytesRead < 16) return false;
+    return header.toString('utf8') === 'SQLite format 3\u0000';
   } catch {
     return false;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
   }
 };
 
@@ -371,11 +376,9 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_file_tags_file_id ON file_tags(file_id);
   CREATE INDEX IF NOT EXISTS idx_file_tags_tag ON file_tags(tag);
   CREATE INDEX IF NOT EXISTS idx_file_tags_tag_file_id ON file_tags(tag, file_id);
-  CREATE INDEX IF NOT EXISTS idx_file_favorites_file_id ON file_favorites(file_id);
   CREATE INDEX IF NOT EXISTS idx_file_favorites_created_at ON file_favorites(created_at);
   CREATE INDEX IF NOT EXISTS idx_favorite_items_provider ON favorite_items(provider);
   CREATE INDEX IF NOT EXISTS idx_favorite_items_file_path ON favorite_items(file_path);
-  CREATE INDEX IF NOT EXISTS idx_provider_credentials_provider ON provider_credentials(provider);
   CREATE INDEX IF NOT EXISTS idx_file_manual_order_position ON file_manual_order(position);
   CREATE INDEX IF NOT EXISTS idx_file_signatures_sample_size_file_id ON file_signatures(sample_size, file_id);
   CREATE INDEX IF NOT EXISTS idx_files_media_type ON files(media_type);

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -362,7 +362,9 @@ export const registerFilesRoutes = (app: FastifyInstance) => {
       reply.header('Content-Length', fileSize);
       const stream = fs.createReadStream(localPath);
       stream.on('error', (err) => {
-        reply.code(500).send({ error: err.message });
+        if (!reply.sent) {
+          reply.code(500).send({ error: err.message });
+        }
       });
       return reply.send(stream);
     } catch (err) {

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -9,7 +9,7 @@ import { executeProviderRun, ProviderKind } from './lib/providerRunner';
 import { hasTargetSauce, normalizeSauceKey } from './lib/sauces';
 import { startFavoritesSync } from './services/favorites';
 import { ensureWd14Tags } from './services/tagging';
-import { iterateLocalMediaPaths, scanFolder, scanLocalFile, ScannedFile } from './lib/scanner';
+import { iterateLocalMediaPaths, scanLocalFile, ScannedFile } from './lib/scanner';
 
 const providerKinds: ProviderKind[] = ['SAUCENAO', 'FLUFFLE'];
 const dayMs = 24 * 60 * 60 * 1000;
@@ -529,7 +529,11 @@ const scheduleMissingProviderScan = () => {
   const delay =
     missingProviderMinMs + Math.floor(Math.random() * (missingProviderMaxMs - missingProviderMinMs + 1));
   missingProviderTimer = setTimeout(async () => {
-    await pickMissingProviderRun();
+    try {
+      await pickMissingProviderRun();
+    } catch (err) {
+      console.warn('[worker] pickMissingProviderRun error:', err);
+    }
     scheduleMissingProviderScan();
   }, delay);
 };


### PR DESCRIPTION
Closes #13

## Summary

### Bugs
- **isSQLiteFile resource exhaustion**: Now reads only 16-byte header instead of entire file via `fs.openSync`/`readSync`
- **Stream error handler**: Added `reply.sent` check on non-range file content responses to prevent double-response crash
- **Worker loop death**: Added `.catch()` to `scheduleMissingProviderScan` — unhandled errors no longer permanently kill the backfill loop

### Performance
- **Redundant indexes removed**: `idx_file_favorites_file_id` (file_id already PK) and `idx_provider_credentials_provider` (provider already PK) — saves write overhead and disk space

### Code Quality
- Removed unused `scanFolder` import from worker.ts

## Test plan
- [ ] Verify file content serving still works (range and non-range requests)
- [ ] Verify DB migrations apply cleanly (redundant indexes removed gracefully with IF NOT EXISTS)
- [ ] Verify worker starts without errors and missing-provider backfill continues running

---
*Generato automaticamente da Codebase Analyst*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in file streaming operations to prevent duplicate responses to clients
  * Added error handling for scheduled provider scans to prevent unhandled errors

* **Performance**
  * Optimized database indexes for improved query performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->