### PR TITLE
Fix unwritable media folder handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,20 @@
 # GoonCave
 
-GoonCave is a local-first media library for scanning folders, browsing files, finding sources, syncing favorites, and tagging content.
+## What's gooncave?
 
-It is currently set up for local-network use with account isolation:
+Gooncave is a tool to store and sync your favorites from multiple booru sites in one place.
+Features:
 
-- each account has its own folders, files, favorites, settings, and credentials
-- each account gets its own library root under the shared media base
+- local-first media library
+- browse your files with a booru style interface
+- dual-way favorites sync and files tagging with e621 and danbooru
+- support for multiple accounts
+- star your favorite files
+- duplicate check system
 
-## Run Locally
+## Run the app locally
 
-Install dependencies:
-
-```bash
-npm install
-npm install --prefix backend
-npm install --prefix frontend
-```
-
-Start development mode:
-
-```bash
-npm run dev
-```
-
-Default URLs:
-
-- frontend: `http://localhost:5174`
-- backend: `http://localhost:4100`
-
-## Run With Docker
+### Run With Docker
 
 Start the stack:
 
@@ -36,11 +22,7 @@ Start the stack:
 docker compose up --build
 ```
 
-Services:
-
-- `api`: backend
-- `worker`: scanner/sync worker
-- `tagger`: WD14 tagger
+Default URL: `http://localhost:4100`
 
 Default media root inside the container:
 
@@ -48,15 +30,21 @@ Default media root inside the container:
 /gooncave-library
 ```
 
-Default compose mount:
-
-```yaml
-- ${MEDIA_DIR:-./gooncave-library}:/gooncave-library
-```
-
 For machine-specific local mounts, copy `docker-compose.override.yml.example` to `docker-compose.override.yml` and set your own values for `LOCAL_MEDIA_DIR` and `LOCAL_USER_ID`.
 
-## Multi-User Folders
+### Write Access Matters
+
+GoonCave can only upload files or sync favorites into folders it is allowed to write to.
+
+If uploads or favorites sync fail with a permission error, give write access to the folder you mounted into GoonCave:
+
+```bash
+sudo chmod -R g+rwX /path/to/your/folder
+sudo find /path/to/your/folder -type d -exec chmod g+s {} \;
+```
+
+
+### Multi-User Folders
 
 Each account gets a library root like:
 
@@ -70,7 +58,7 @@ Rules:
 - direct child folders under a user's library root are auto-detected by the app
 - for the simplest setup, mount folders directly into the user's library root
 
-### One User Example
+#### One User Example
 
 If the real host folder is:
 
@@ -93,7 +81,7 @@ services:
 
 Then that user logs in and the folder appears automatically in Settings.
 
-### Multiple Folders
+#### Multiple Folders
 
 One user can have more than one mounted folder. Mount each one as a direct child of the user root so it appears automatically.
 
@@ -110,13 +98,13 @@ services:
       - /mnt/videos:/gooncave-library/users/alice-123456/videos
 ```
 
-### Shared Host Folder Warning
+#### Shared Host Folder Warning
 
 If you mount the same real host folder into two different user roots, both accounts will see the same underlying files.
 
 That is a Docker choice, not automatic sharing by the app.
 
-### What Not To Do
+#### What Not To Do
 
 Do not mount folders outside the user's library root for normal multi-user usage.
 
@@ -126,7 +114,30 @@ Do not mount folders outside the user's library root for normal multi-user usage
 
 That folder exists in the container, but the user cannot claim it through the app.
 
-## Useful Environment Variables
+## Development
+
+### Run Locally
+
+Install dependencies:
+
+```bash
+npm install
+npm install --prefix backend
+npm install --prefix frontend
+```
+
+Start development mode:
+
+```bash
+npm run dev
+```
+
+Default URLs:
+
+- frontend: `http://localhost:5174`
+- backend: `http://localhost:4100`
+
+### Useful Environment Variables
 
 - `MEDIA_PATH`
 - `AUTH_USERS_DIR_NAME`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GoonCave
 
-## What's gooncave?
+## What's GoonCave?
 
-Gooncave is a tool to store and sync your favorites from multiple booru sites in one place.
+GoonCave is a tool to store and sync your favorites from multiple booru sites in one place.
 Features:
 
 - local-first media library

--- a/backend/src/lib/fsAccess.ts
+++ b/backend/src/lib/fsAccess.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import path from 'path';
+
+const writeErrorCodes = new Set(['EACCES', 'EPERM', 'EROFS']);
+
+const describeRuntimeIdentity = () => {
+  const parts: string[] = [];
+  if (typeof process.getuid === 'function') parts.push(`uid ${process.getuid()}`);
+  if (typeof process.getgid === 'function') parts.push(`gid ${process.getgid()}`);
+  return parts.length ? ` (${parts.join(', ')})` : '';
+};
+
+export class DirectoryWriteAccessError extends Error {
+  code?: string;
+
+  constructor(dirPath: string, operation: string, code?: string) {
+    super(
+      `${operation} failed because "${dirPath}" is not writable by the GoonCave container user${describeRuntimeIdentity()}. ` +
+        'Fix host folder permissions or run api and worker as a user/group that can write there.'
+    );
+    this.name = 'DirectoryWriteAccessError';
+    this.code = code;
+  }
+}
+
+export const ensureDirectoryWritable = async (dirPath: string, operation: string) => {
+  await fs.promises.mkdir(dirPath, { recursive: true });
+  const probePath = path.join(
+    dirPath,
+    `.gooncave-write-test-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  );
+
+  try {
+    const handle = await fs.promises.open(probePath, 'wx');
+    await handle.close();
+    await fs.promises.unlink(probePath);
+  } catch (error) {
+    await fs.promises.unlink(probePath).catch(() => undefined);
+    const err = error as NodeJS.ErrnoException;
+    if (err.code && writeErrorCodes.has(err.code)) {
+      throw new DirectoryWriteAccessError(dirPath, operation, err.code);
+    }
+    throw error;
+  }
+};

--- a/backend/src/routes/favorites.ts
+++ b/backend/src/routes/favorites.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 
 import { dataStore } from '../lib/dataStore';
+import { DirectoryWriteAccessError } from '../lib/fsAccess';
 
 const syncSchema = z.object({
   providers: z.array(z.string()).optional(),
@@ -61,7 +62,20 @@ export const registerFavoritesRoutes = (app: FastifyInstance) => {
       reply.code(400);
       return { error: 'No valid providers provided (use E621 or DANBOORU).' };
     }
-    const { startFavoritesSync } = await import('../services/favorites.js');
+    const { assertFavoritesSyncReady, startFavoritesSync } = await import('../services/favorites.js');
+    try {
+      await assertFavoritesSyncReady(userId);
+    } catch (error) {
+      if (error instanceof DirectoryWriteAccessError) {
+        reply.code(409);
+        return { error: error.message };
+      }
+      if (error instanceof Error && /favorites root not configured/i.test(error.message)) {
+        reply.code(400);
+        return { error: error.message };
+      }
+      throw error;
+    }
     return startFavoritesSync(userId, { providers, deleteMissing: parsed.data.deleteMissing });
   });
 };

--- a/backend/src/routes/folders.ts
+++ b/backend/src/routes/folders.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 
 import { config } from '../config';
 import { dataStore } from '../lib/dataStore';
+import { DirectoryWriteAccessError, ensureDirectoryWritable } from '../lib/fsAccess';
 import { detectMediaKind, scanLocalFile } from '../lib/scanner';
 import { isPathInside, resolveUserManagedPath } from '../services/auth';
 
@@ -141,7 +142,15 @@ export const registerFolderRoutes = (app: FastifyInstance) => {
       return { error: 'Only local folders support uploads' };
     }
 
-    await fs.promises.mkdir(folder.path, { recursive: true });
+    try {
+      await ensureDirectoryWritable(folder.path, 'Uploading files');
+    } catch (error) {
+      if (error instanceof DirectoryWriteAccessError) {
+        reply.code(409);
+        return { error: error.message };
+      }
+      throw error;
+    }
 
     const uploaded: Array<z.infer<typeof uploadResultItem>> = [];
     const rejected: Array<z.infer<typeof uploadResultItem>> = [];

--- a/backend/src/services/favorites.ts
+++ b/backend/src/services/favorites.ts
@@ -6,6 +6,7 @@ import { fetch } from 'undici';
 
 import { config } from '../config';
 import { dataStore, FavoriteProvider, FavoriteItemRecord, FileRecord } from '../lib/dataStore';
+import { ensureDirectoryWritable } from '../lib/fsAccess';
 import { scanLocalFile } from '../lib/scanner';
 import { resolveCredential } from './credentials';
 import { applyRemotePostTags } from './tagging';
@@ -86,13 +87,13 @@ const ensureFavoritesRoot = async (userId: string) => {
   if (settings.favoritesRootId) {
     const folder = await dataStore.findFolderById(settings.favoritesRootId, userId);
     if (folder?.type === 'LOCAL') {
-      await fs.promises.mkdir(folder.path, { recursive: true });
+      await ensureDirectoryWritable(folder.path, 'Favorites sync');
       return folder.path;
     }
   }
   const user = await dataStore.findUserById(userId);
   if (user?.libraryRoot) {
-    await fs.promises.mkdir(user.libraryRoot, { recursive: true });
+    await ensureDirectoryWritable(user.libraryRoot, 'Favorites sync');
     return user.libraryRoot;
   }
   const folders = await dataStore.listFolders(userId);
@@ -100,8 +101,12 @@ const ensureFavoritesRoot = async (userId: string) => {
   if (!localFolder?.path) {
     throw new Error('Favorites root not configured. Add a local folder for this account.');
   }
-  await fs.promises.mkdir(localFolder.path, { recursive: true });
+  await ensureDirectoryWritable(localFolder.path, 'Favorites sync');
   return localFolder.path;
+};
+
+export const assertFavoritesSyncReady = async (userId: string) => {
+  await ensureFavoritesRoot(userId);
 };
 
 const ensureFavoritesFolder = async (root: string, userId: string) => {

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,7 +1,12 @@
 services:
   api:
+    # LOCAL_USER_ID means the GoonCave user folder name, like alice-123456.
+    # It does NOT mean your Linux user id like 1000.
+    # The real host folder still must allow Docker to write into it,
+    # or uploads and favorites sync will fail.
     volumes:
       - ${LOCAL_MEDIA_DIR}:/gooncave-library/users/${LOCAL_USER_ID}/downloads
   worker:
+    # Keep the same mount here so background scans and favorite downloads
     volumes:
       - ${LOCAL_MEDIA_DIR}:/gooncave-library/users/${LOCAL_USER_ID}/downloads


### PR DESCRIPTION
## Summary
- fail fast when upload or favorites sync target folders are not writable
- return clear API errors for unwritable local folders instead of long partial failures
- document folder write permission requirements and clarify override mount comments

## Verification
- npm run build --prefix backend
- npm run build --prefix frontend
- docker compose up -d --build api worker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured README to highlight core features, multi-account/favorites syncing, and development instructions.
  * Moved run/dev guidance and environment vars into a Development section; simplified Docker and mount guidance.
  * Added "Write Access Matters" troubleshooting for upload/sync permissions.

* **Bug Fixes**
  * Improved preflight checks and error handling for directory write permissions during uploads and favorites sync.
  * Clearer, user-facing error responses when write access is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->