### PR TITLE
CI: add build and security workflows with clean backend linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/ci.yml
+      - backend/**
+      - frontend/**
+      - tagger/**
+      - docker-compose.yml
+      - docker-compose.override.yml.example
+      - package.json
+      - package-lock.json
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/ci.yml
+      - backend/**
+      - frontend/**
+      - tagger/**
+      - docker-compose.yml
+      - docker-compose.override.yml.example
+      - package.json
+      - package-lock.json
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies
+        run: npm ci --prefix backend
+
+      - name: Build backend
+        run: npm run build --prefix backend
+
+  frontend:
+    name: Frontend build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci --prefix frontend
+
+      - name: Build frontend
+        run: npm run build --prefix frontend
+
+  docker:
+    name: Docker image builds
+    runs-on: ubuntu-latest
+    needs: [backend, frontend]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build app image
+        run: docker build --file backend/Dockerfile --tag gooncave-app:ci .
+
+      - name: Build tagger image
+        run: docker build --file tagger/Dockerfile --tag gooncave-tagger:ci tagger

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   backend:
-    name: Backend build
+    name: Backend lint and build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -46,6 +46,9 @@ jobs:
 
       - name: Install backend dependencies
         run: npm ci --prefix backend
+
+      - name: Lint backend
+        run: npm run lint --prefix backend
 
       - name: Build backend
         run: npm run build --prefix backend

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,99 @@
+name: Security
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/security.yml
+      - backend/**
+      - frontend/**
+      - tagger/**
+      - docker-compose.yml
+      - docker-compose.override.yml.example
+      - package.json
+      - package-lock.json
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/security.yml
+      - backend/**
+      - frontend/**
+      - tagger/**
+      - docker-compose.yml
+      - docker-compose.override.yml.example
+      - package.json
+      - package-lock.json
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  npm-audit:
+    name: NPM audit (${{ matrix.package_dir }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package_dir: [backend, frontend]
+    env:
+      AUDIT_LEVEL: ${{ github.event_name == 'pull_request' && 'critical' || 'high' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ${{ matrix.package_dir }}/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefix ${{ matrix.package_dir }}
+
+      - name: Audit production dependencies
+        run: npm audit --prefix ${{ matrix.package_dir }} --omit=dev --audit-level $AUDIT_LEVEL
+
+  container-scan:
+    name: Container scan (${{ matrix.image_name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image_name: app
+            image_ref: gooncave-app:security
+            dockerfile: backend/Dockerfile
+            context: .
+          - image_name: tagger
+            image_ref: gooncave-tagger:security
+            dockerfile: tagger/Dockerfile
+            context: tagger
+    env:
+      TRIVY_SEVERITY: ${{ github.event_name == 'pull_request' && 'CRITICAL' || 'HIGH,CRITICAL' }}
+      TRIVY_EXIT_CODE: ${{ github.event_name == 'pull_request' && '0' || '1' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build --file ${{ matrix.dockerfile }} --tag ${{ matrix.image_ref }} ${{ matrix.context }}
+
+      # PRs stay informative and lighter. main/nightly become enforcement.
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ matrix.image_ref }}
+          format: table
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: ${{ env.TRIVY_SEVERITY }}
+          exit-code: ${{ env.TRIVY_EXIT_CODE }}

--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -16,6 +16,19 @@ module.exports = {
     'plugin:import/typescript',
     'prettier'
   ],
+  settings: {
+    'import/parsers': {
+      '@typescript-eslint/parser': ['.ts']
+    },
+    'import/resolver': {
+      typescript: {
+        project: './tsconfig.json'
+      },
+      node: {
+        extensions: ['.js', '.ts']
+      }
+    }
+  },
   rules: {
     'import/order': [
       'warn',

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2023,6 +2023,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/argon2": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
@@ -4948,6 +4960,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -5358,12 +5383,13 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -5578,6 +5604,18 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/real-require": {
@@ -6381,19 +6419,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -35,15 +35,39 @@
         "@typescript-eslint/parser": "^7.2.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-import-resolver-typescript": "^3.10.1",
         "eslint-plugin-import": "^2.29.1",
         "tsx": "^4.7.0",
         "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
       "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1240,6 +1264,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1278,6 +1315,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
     "node_modules/@phc/format": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
@@ -1299,6 +1346,17 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
@@ -1543,6 +1601,275 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -2805,6 +3132,41 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-module-utils": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
@@ -3343,6 +3705,24 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-entry-cache": {
@@ -4069,6 +4449,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -4655,6 +5045,22 @@
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -5733,6 +6139,13 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -5951,6 +6364,36 @@
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {
@@ -6200,6 +6643,41 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "@typescript-eslint/parser": "^7.2.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.29.1",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3"

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,7 +1,8 @@
-import dotenv from 'dotenv';
 import path from 'path';
 
-dotenv.config();
+import { config as loadEnv } from 'dotenv';
+
+loadEnv();
 
 const defaultMediaPath = () => {
   const envMediaPath = process.env.MEDIA_PATH;

--- a/backend/src/fastify.d.ts
+++ b/backend/src/fastify.d.ts
@@ -3,6 +3,7 @@ import '@fastify/multipart';
 import 'fastify';
 
 import type { CookieSerializeOptions } from '@fastify/cookie';
+
 import type { AuthenticatedUser } from './services/auth';
 
 declare module 'fastify' {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,22 +1,23 @@
-import cookie from '@fastify/cookie';
-import cors from '@fastify/cors';
-import multipart from '@fastify/multipart';
-import fastifyStatic from '@fastify/static';
-import Fastify from 'fastify';
-import websocket from '@fastify/websocket';
 import fs from 'fs';
 import path from 'path';
 
+import cookie from '@fastify/cookie';
+import cors from '@fastify/cors';
+import multipart from '@fastify/multipart';
+import fastifyStaticPlugin from '@fastify/static';
+import websocket from '@fastify/websocket';
+import Fastify from 'fastify';
+
 import { config } from './config';
 import { registerAdminRoutes } from './routes/admin';
-import { registerFolderRoutes } from './routes/folders';
-import { registerHealthRoutes } from './routes/health';
-import { registerFilesRoutes } from './routes/files';
-import { registerSauceRoutes } from './routes/sauces';
+import { registerAuthRoutes } from './routes/auth';
+import { registerCredentialRoutes } from './routes/credentials';
 import { registerDuplicateRoutes } from './routes/duplicates';
 import { registerFavoritesRoutes } from './routes/favorites';
-import { registerCredentialRoutes } from './routes/credentials';
-import { registerAuthRoutes } from './routes/auth';
+import { registerFilesRoutes } from './routes/files';
+import { registerFolderRoutes } from './routes/folders';
+import { registerHealthRoutes } from './routes/health';
+import { registerSauceRoutes } from './routes/sauces';
 import { clearSessionCookie, getUserFromSessionToken } from './services/auth';
 
 const protectedRoutePrefixes = ['/folders', '/files', '/sauces', '/duplicates', '/favorites', '/credentials', '/scans'];
@@ -76,7 +77,7 @@ export const createServer = () => {
   }
   const thumbnailsRoot = path.resolve(config.storage.thumbnailsDir);
   if (fs.existsSync(thumbnailsRoot)) {
-    app.register(fastifyStatic, {
+    app.register(fastifyStaticPlugin, {
       root: thumbnailsRoot,
       prefix: '/thumbnails/',
       decorateReply: false
@@ -86,7 +87,7 @@ export const createServer = () => {
   }
   const frontendRoot = config.frontendDir ? path.resolve(config.frontendDir) : null;
   if (frontendRoot && fs.existsSync(frontendRoot)) {
-    app.register(fastifyStatic, {
+    app.register(fastifyStaticPlugin, {
       root: frontendRoot,
       prefix: '/',
       decorateReply: true

--- a/backend/src/lib/dataStore.ts
+++ b/backend/src/lib/dataStore.ts
@@ -1,10 +1,11 @@
+import { createHash, randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import { createHash, randomUUID } from 'crypto';
 
-import Database from 'better-sqlite3';
+import BetterSqlite3 from 'better-sqlite3';
 
 import { config } from '../config';
+
 import type { MediaKind, ScannedFile } from './scanner';
 
 export type FolderStatus = 'IDLE' | 'SCANNING';
@@ -162,12 +163,120 @@ type FileBatchCursor = {
   createdAt: string;
   id: string;
 };
+
+type FolderRow = {
+  id: string;
+  user_id: string | null;
+  path: string;
+  type?: FolderType | null;
+  created_at: string;
+  updated_at: string;
+  last_scan_at?: string | null;
+  status: FolderStatus;
+};
+
+type ScanRow = {
+  id: string;
+  folder_id: string;
+  status: ScanStatus;
+  progress?: number | null;
+  error?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type FileRow = {
+  id: string;
+  folder_id: string;
+  location_type?: FolderType | null;
+  path: string;
+  size_bytes: number | string;
+  mtime: string;
+  sha256: string;
+  phash?: string | null;
+  media_type: MediaKind;
+  width?: number | null;
+  height?: number | null;
+  duration_ms?: number | null;
+  thumb_path?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type FileWithFavoriteRow = FileRow & {
+  is_favorite?: number | boolean | null;
+};
+
+type ProviderRunRow = {
+  id: string;
+  file_id: string;
+  provider: ProviderRunRecord['provider'];
+  status: ProviderRunRecord['status'];
+  cached_hit?: number | boolean | null;
+  score?: number | null;
+  source_url?: string | null;
+  thumb_url?: string | null;
+  results?: string | null;
+  created_at: string;
+  completed_at?: string | null;
+  error?: string | null;
+};
+
+type FileTagRow = {
+  file_id: string;
+  tag: string;
+  category: string;
+  source: TagSource;
+  score?: number | null;
+  source_url?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type CredentialRow = {
+  provider: CredentialProvider;
+  username?: string | null;
+  api_key?: string | null;
+  updated_at: string;
+};
+
+type FavoriteItemRow = {
+  provider: FavoriteProvider;
+  remote_id: string;
+  file_path: string;
+  source_url?: string | null;
+  file_url?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type UserRow = {
+  id: string;
+  username: string;
+  password_hash: string;
+  library_root: string;
+  created_at: string;
+  updated_at: string;
+  last_login_at?: string | null;
+};
+
+type SessionRow = {
+  id: string;
+  user_id: string;
+  token: string;
+  created_at: string;
+  expires_at: string;
+};
+
+type MetaRow = {
+  value: string;
+};
 const dataFile = config.storage.dataFile ?? 'storage/data.db';
 const dataDir = path.dirname(dataFile);
 
 fs.mkdirSync(dataDir, { recursive: true });
 
-const db = new Database(dataFile);
+const db = new BetterSqlite3(dataFile);
 
 db.function('stable_hash', { deterministic: true }, (seed: unknown, value: unknown) =>
   createHash('sha1').update(`${seed ?? ''}:${value ?? ''}`).digest('hex')
@@ -372,7 +481,7 @@ const isSqliteBusyError = (error: unknown) => {
 
 const withSqliteRetry = async <T>(operation: () => T | Promise<T>): Promise<T> => {
   let attempt = 0;
-  while (true) {
+  for (;;) {
     try {
       return await operation();
     } catch (error) {
@@ -394,16 +503,7 @@ const isSameOrInsideStoredPath = (candidatePath: string, basePath: string) => {
   return resolvedCandidate === resolvedBase || resolvedCandidate.startsWith(`${resolvedBase}${path.sep}`);
 };
 
-const replaceStoredPathPrefix = (filePath: string, sourceBasePath: string, targetBasePath: string) => {
-  const resolvedFilePath = normalizeStoredPath(filePath);
-  const resolvedSource = normalizeStoredPath(sourceBasePath);
-  const resolvedTarget = normalizeStoredPath(targetBasePath);
-  if (resolvedFilePath === resolvedSource) return resolvedTarget;
-  if (!resolvedFilePath.startsWith(`${resolvedSource}${path.sep}`)) return resolvedFilePath;
-  return path.resolve(resolvedTarget, path.relative(resolvedSource, resolvedFilePath));
-};
-
-const mapFolderRow = (row: any): FolderRecord => ({
+const mapFolderRow = (row: FolderRow): FolderRecord => ({
   id: row.id,
   userId: row.user_id ?? null,
   path: row.path,
@@ -414,7 +514,7 @@ const mapFolderRow = (row: any): FolderRecord => ({
   status: row.status as FolderStatus
 });
 
-const mapScanRow = (row: any): ScanRecord => ({
+const mapScanRow = (row: ScanRow): ScanRecord => ({
   id: row.id,
   folderId: row.folder_id,
   status: row.status as ScanStatus,
@@ -424,7 +524,7 @@ const mapScanRow = (row: any): ScanRecord => ({
   updatedAt: row.updated_at
 });
 
-const mapFileRow = (row: any): FileRecord => ({
+const mapFileRow = (row: FileRow): FileRecord => ({
   id: row.id,
   folderId: row.folder_id,
   locationType: (row.location_type ?? 'LOCAL') as FolderType,
@@ -442,12 +542,12 @@ const mapFileRow = (row: any): FileRecord => ({
   updatedAt: row.updated_at
 });
 
-const mapFileRowWithFavorite = (row: any): FileRecord => ({
+const mapFileRowWithFavorite = (row: FileWithFavoriteRow): FileRecord => ({
   ...mapFileRow(row),
   isFavorite: Boolean(row.is_favorite)
 });
 
-const mapProviderRunRow = (row: any): ProviderRunRecord => ({
+const mapProviderRunRow = (row: ProviderRunRow): ProviderRunRecord => ({
   id: row.id,
   fileId: row.file_id,
   provider: row.provider,
@@ -462,7 +562,7 @@ const mapProviderRunRow = (row: any): ProviderRunRecord => ({
   error: row.error ?? null
 });
 
-const mapTagRow = (row: any): FileTagRecord => ({
+const mapTagRow = (row: FileTagRow): FileTagRecord => ({
   fileId: row.file_id,
   tag: row.tag,
   category: row.category,
@@ -574,14 +674,14 @@ const buildPaginationClause = (limit?: number, offset?: number) => {
   return { clause: '', params: [] as unknown[] };
 };
 
-const mapCredentialRow = (row: any): CredentialRecord => ({
+const mapCredentialRow = (row: CredentialRow): CredentialRecord => ({
   provider: row.provider as CredentialProvider,
   username: row.username ?? null,
   apiKey: row.api_key ?? null,
   updatedAt: row.updated_at
 });
 
-const mapFavoriteRow = (row: any): FavoriteItemRecord => ({
+const mapFavoriteRow = (row: FavoriteItemRow): FavoriteItemRecord => ({
   provider: row.provider as FavoriteProvider,
   remoteId: row.remote_id,
   filePath: row.file_path,
@@ -591,7 +691,7 @@ const mapFavoriteRow = (row: any): FavoriteItemRecord => ({
   updatedAt: row.updated_at
 });
 
-const mapUserRow = (row: any): UserRecord => ({
+const mapUserRow = (row: UserRow): UserRecord => ({
   id: row.id,
   username: row.username,
   passwordHash: row.password_hash,
@@ -601,7 +701,7 @@ const mapUserRow = (row: any): UserRecord => ({
   lastLoginAt: row.last_login_at ?? null
 });
 
-const mapSessionRow = (row: any): SessionRecord => ({
+const mapSessionRow = (row: SessionRow): SessionRecord => ({
   id: row.id,
   userId: row.user_id,
   token: row.token,
@@ -610,16 +710,12 @@ const mapSessionRow = (row: any): SessionRecord => ({
 });
 
 const getMeta = (key: string) => {
-  const row = db.prepare('SELECT value FROM meta WHERE key = ?').get(key) as { value: string } | undefined;
+  const row = db.prepare('SELECT value FROM meta WHERE key = ?').get(key) as MetaRow | undefined;
   return row?.value ?? null;
 };
 
 const setMeta = (key: string, value: string) => {
   db.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)').run(key, value);
-};
-
-const deleteMeta = (key: string) => {
-  db.prepare('DELETE FROM meta WHERE key = ?').run(key);
 };
 
 const normalizeKeyList = (value: string[] | undefined) => {
@@ -705,15 +801,15 @@ export const dataStore = {
     return Number(row?.count ?? 0);
   },
   async listUsers() {
-    const rows = db.prepare('SELECT * FROM users ORDER BY created_at ASC').all() as any[];
+    const rows = db.prepare('SELECT * FROM users ORDER BY created_at ASC').all() as UserRow[];
     return rows.map(mapUserRow);
   },
   async findUserById(id: string) {
-    const row = db.prepare('SELECT * FROM users WHERE id = ?').get(id) as any | undefined;
+    const row = db.prepare('SELECT * FROM users WHERE id = ?').get(id) as UserRow | undefined;
     return row ? mapUserRow(row) : null;
   },
   async findUserByUsername(username: string) {
-    const row = db.prepare('SELECT * FROM users WHERE LOWER(username) = LOWER(?)').get(username) as any | undefined;
+    const row = db.prepare('SELECT * FROM users WHERE LOWER(username) = LOWER(?)').get(username) as UserRow | undefined;
     return row ? mapUserRow(row) : null;
   },
   async findUserByFolderId(folderId: string) {
@@ -724,7 +820,7 @@ export const dataStore = {
          JOIN folders f ON f.user_id = u.id
          WHERE f.id = ?`
       )
-      .get(folderId) as any | undefined;
+      .get(folderId) as UserRow | undefined;
     return row ? mapUserRow(row) : null;
   },
   async findUserByFileId(fileId: string) {
@@ -736,7 +832,7 @@ export const dataStore = {
          JOIN files fi ON fi.folder_id = f.id
          WHERE fi.id = ?`
       )
-      .get(fileId) as any | undefined;
+      .get(fileId) as UserRow | undefined;
     return row ? mapUserRow(row) : null;
   },
   async createUser(input: { id?: string; username: string; passwordHash: string; libraryRoot: string }) {
@@ -779,7 +875,7 @@ export const dataStore = {
     return session;
   },
   async findSessionByToken(token: string) {
-    const row = db.prepare('SELECT * FROM sessions WHERE token = ?').get(token) as any | undefined;
+    const row = db.prepare('SELECT * FROM sessions WHERE token = ?').get(token) as SessionRow | undefined;
     return row ? mapSessionRow(row) : null;
   },
   async deleteSessionByToken(token: string) {
@@ -821,7 +917,7 @@ export const dataStore = {
     `;
     const rows = db
       .prepare(pageSql)
-      .all(...tagJoin.params, ...pageWhere.params, ...order.params, ...pagination.params);
+      .all(...tagJoin.params, ...pageWhere.params, ...order.params, ...pagination.params) as FileWithFavoriteRow[];
     return {
       files: rows.map(mapFileRowWithFavorite),
       total
@@ -829,7 +925,7 @@ export const dataStore = {
   },
   async listFilesWithProviderRuns(folderId?: string, tagTerms?: string[], userId?: string) {
     const normalizedTerms = (tagTerms ?? []).map((term) => term.trim()).filter(Boolean);
-    let files: any[];
+    let files: FileRow[];
 
     if (normalizedTerms.length > 0) {
       const termPlaceholders = normalizedTerms.map(() => '?').join(',');
@@ -852,22 +948,22 @@ export const dataStore = {
         ...normalizedTerms,
         normalizedTerms.length
       ];
-      files = db.prepare(sql).all(...params);
+      files = db.prepare(sql).all(...params) as FileRow[];
     } else {
       if (folderId && userId) {
         files = db
           .prepare(
             `SELECT * FROM files WHERE folder_id = ? AND folder_id IN (SELECT id FROM folders WHERE user_id = ?) ORDER BY created_at DESC`
           )
-          .all(folderId, userId);
+          .all(folderId, userId) as FileRow[];
       } else if (folderId) {
-        files = db.prepare('SELECT * FROM files WHERE folder_id = ? ORDER BY created_at DESC').all(folderId);
+        files = db.prepare('SELECT * FROM files WHERE folder_id = ? ORDER BY created_at DESC').all(folderId) as FileRow[];
       } else if (userId) {
         files = db
           .prepare(`SELECT * FROM files WHERE folder_id IN (SELECT id FROM folders WHERE user_id = ?) ORDER BY created_at DESC`)
-          .all(userId);
+          .all(userId) as FileRow[];
       } else {
-        files = db.prepare('SELECT * FROM files ORDER BY created_at DESC').all();
+        files = db.prepare('SELECT * FROM files ORDER BY created_at DESC').all() as FileRow[];
       }
     }
     const fileRecords = files.map(mapFileRow);
@@ -880,10 +976,11 @@ export const dataStore = {
       const placeholders = ids.map(() => '?').join(',');
       const runs = db
         .prepare(`SELECT * FROM provider_runs WHERE file_id IN (${placeholders})`)
-        .all(...ids)
+        .all(...ids) as ProviderRunRow[];
+      const mappedRuns = runs
         .map(mapProviderRunRow);
 
-      for (const run of runs) {
+      for (const run of mappedRuns) {
         if (!providerRunsByFile[run.fileId]) providerRunsByFile[run.fileId] = [];
         providerRunsByFile[run.fileId].push(run);
       }
@@ -919,7 +1016,7 @@ export const dataStore = {
 
     const tx = db.transaction(() => {
       for (const folderPath of folderPaths) {
-        const existing = (userId ? selectByPath.get(folderPath, userId) : selectByPath.get(folderPath)) as any | undefined;
+        const existing = (userId ? selectByPath.get(folderPath, userId) : selectByPath.get(folderPath)) as FolderRow | undefined;
         if (!existing) {
           const folder: FolderRecord = {
             id: randomUUID(),
@@ -963,20 +1060,20 @@ export const dataStore = {
   },
   async listFolders(userId?: string) {
     const rows = userId
-      ? db.prepare('SELECT * FROM folders WHERE user_id = ? ORDER BY created_at DESC').all(userId)
-      : db.prepare('SELECT * FROM folders ORDER BY created_at DESC').all();
+      ? (db.prepare('SELECT * FROM folders WHERE user_id = ? ORDER BY created_at DESC').all(userId) as FolderRow[])
+      : (db.prepare('SELECT * FROM folders ORDER BY created_at DESC').all() as FolderRow[]);
     return rows.map(mapFolderRow);
   },
   async findFolderById(id: string, userId?: string) {
     const row = (userId
       ? db.prepare('SELECT * FROM folders WHERE id = ? AND user_id = ?').get(id, userId)
-      : db.prepare('SELECT * FROM folders WHERE id = ?').get(id)) as any | undefined;
+      : db.prepare('SELECT * FROM folders WHERE id = ?').get(id)) as FolderRow | undefined;
     return row ? mapFolderRow(row) : null;
   },
   async findFolderByPath(folderPath: string, userId?: string) {
     const row = (userId
       ? db.prepare('SELECT * FROM folders WHERE path = ? AND user_id = ?').get(folderPath, userId)
-      : db.prepare('SELECT * FROM folders WHERE path = ?').get(folderPath)) as any | undefined;
+      : db.prepare('SELECT * FROM folders WHERE path = ?').get(folderPath)) as FolderRow | undefined;
     return row ? mapFolderRow(row) : null;
   },
   async addFolder(folderPath: string, userId?: string) {
@@ -1075,8 +1172,8 @@ export const dataStore = {
              WHERE f.user_id = ?
              ORDER BY s.created_at DESC`
           )
-          .all(userId)
-      : db.prepare('SELECT * FROM scans ORDER BY created_at DESC').all();
+          .all(userId) as ScanRow[]
+      : (db.prepare('SELECT * FROM scans ORDER BY created_at DESC').all() as ScanRow[]);
     return rows.map(mapScanRow);
   },
   async findScanById(id: string, userId?: string) {
@@ -1089,7 +1186,7 @@ export const dataStore = {
              WHERE s.id = ? AND f.user_id = ?`
           )
           .get(id, userId)
-      : db.prepare('SELECT * FROM scans WHERE id = ?').get(id)) as any | undefined;
+        : db.prepare('SELECT * FROM scans WHERE id = ?').get(id)) as ScanRow | undefined;
     return row ? mapScanRow(row) : null;
   },
   async createScan(folderId: string) {
@@ -1188,7 +1285,7 @@ export const dataStore = {
   async upsertFile(folderId: string, file: ScannedFile) {
     const existingRow = db
       .prepare('SELECT * FROM files WHERE folder_id = ? AND path = ?')
-      .get(folderId, file.path) as any | undefined;
+      .get(folderId, file.path) as FileRow | undefined;
     const now = new Date().toISOString();
 
     if (existingRow) {
@@ -1266,21 +1363,21 @@ export const dataStore = {
     return record;
   },
   async listFiles(folderId?: string, userId?: string) {
-    let rows: any[];
+    let rows: FileRow[];
     if (folderId && userId) {
       rows = db
         .prepare(
           `SELECT * FROM files WHERE folder_id = ? AND folder_id IN (SELECT id FROM folders WHERE user_id = ?) ORDER BY created_at DESC`
         )
-        .all(folderId, userId);
+        .all(folderId, userId) as FileRow[];
     } else if (folderId) {
-      rows = db.prepare('SELECT * FROM files WHERE folder_id = ? ORDER BY created_at DESC').all(folderId);
+      rows = db.prepare('SELECT * FROM files WHERE folder_id = ? ORDER BY created_at DESC').all(folderId) as FileRow[];
     } else if (userId) {
       rows = db
         .prepare(`SELECT * FROM files WHERE folder_id IN (SELECT id FROM folders WHERE user_id = ?) ORDER BY created_at DESC`)
-        .all(userId);
+        .all(userId) as FileRow[];
     } else {
-      rows = db.prepare('SELECT * FROM files ORDER BY created_at DESC').all();
+      rows = db.prepare('SELECT * FROM files ORDER BY created_at DESC').all() as FileRow[];
     }
     return rows.map(mapFileRow);
   },
@@ -1303,7 +1400,7 @@ export const dataStore = {
     const whereClause = where.length ? ` WHERE ${where.join(' AND ')}` : '';
     const rows = db
       .prepare(`SELECT * FROM files${whereClause} ORDER BY created_at DESC, id DESC LIMIT ?`)
-      .all(...params, limit);
+      .all(...params, limit) as FileRow[];
     const files = rows.map(mapFileRow);
     const last = files[files.length - 1];
     return {
@@ -1327,7 +1424,7 @@ export const dataStore = {
              ORDER BY RANDOM()
              LIMIT ?`
           )
-          .all(provider, userId, limit)
+           .all(provider, userId, limit) as FileRow[]
       : db
           .prepare(
             `SELECT * FROM files
@@ -1335,7 +1432,7 @@ export const dataStore = {
              ORDER BY RANDOM()
              LIMIT ?`
           )
-          .all(provider, limit);
+           .all(provider, limit) as FileRow[];
     return rows.map(mapFileRow);
   },
   async listFavoriteFileIds(fileIds: string[]) {
@@ -1368,7 +1465,7 @@ export const dataStore = {
              WHERE fi.id = ? AND f.user_id = ?`
           )
           .get(id, userId)
-      : db.prepare('SELECT * FROM files WHERE id = ?').get(id)) as any | undefined;
+        : db.prepare('SELECT * FROM files WHERE id = ?').get(id)) as FileRow | undefined;
     return row ? mapFileRow(row) : null;
   },
   async findFileByPath(filePath: string, userId?: string) {
@@ -1381,7 +1478,7 @@ export const dataStore = {
              WHERE fi.path = ? AND f.user_id = ?`
           )
           .get(filePath, userId)
-      : db.prepare('SELECT * FROM files WHERE path = ?').get(filePath)) as any | undefined;
+      : db.prepare('SELECT * FROM files WHERE path = ?').get(filePath)) as FileRow | undefined;
     return row ? mapFileRow(row) : null;
   },
   async deleteFile(id: string) {
@@ -1393,7 +1490,7 @@ export const dataStore = {
   async listProviderRuns(fileId: string) {
     const rows = db
       .prepare('SELECT * FROM provider_runs WHERE file_id = ? ORDER BY COALESCE(completed_at, created_at) DESC')
-      .all(fileId);
+      .all(fileId) as ProviderRunRow[];
     return rows.map(mapProviderRunRow);
   },
   async listProviderRunsByFileIds(fileIds: string[]) {
@@ -1406,7 +1503,7 @@ export const dataStore = {
          WHERE file_id IN (${placeholders})
          ORDER BY file_id ASC, COALESCE(completed_at, created_at) DESC`
       )
-      .all(...fileIds);
+      .all(...fileIds) as ProviderRunRow[];
     for (const row of rows) {
       const run = mapProviderRunRow(row);
       if (!grouped[run.fileId]) grouped[run.fileId] = [];
@@ -1514,7 +1611,7 @@ export const dataStore = {
   },
   async updateProviderRun(id: string, updates: Partial<Omit<ProviderRunRecord, 'id' | 'fileId'>>) {
     return withSqliteRetry(() => {
-      const existingRow = db.prepare('SELECT * FROM provider_runs WHERE id = ?').get(id) as any | undefined;
+      const existingRow = db.prepare('SELECT * FROM provider_runs WHERE id = ?').get(id) as ProviderRunRow | undefined;
       if (!existingRow) return null;
       const existing = mapProviderRunRow(existingRow);
       const run: ProviderRunRecord = {
@@ -1540,7 +1637,7 @@ export const dataStore = {
     });
   },
   async listAllProviderRuns() {
-    const rows = db.prepare('SELECT * FROM provider_runs ORDER BY created_at DESC').all();
+    const rows = db.prepare('SELECT * FROM provider_runs ORDER BY created_at DESC').all() as ProviderRunRow[];
     return rows.map(mapProviderRunRow);
   },
   async listManualOrderPositions(fileIds: string[]) {
@@ -1556,22 +1653,22 @@ export const dataStore = {
     return positions;
   },
   async listTagsForFile(fileId: string) {
-    const rows = db.prepare('SELECT * FROM file_tags WHERE file_id = ? ORDER BY tag ASC').all(fileId);
+    const rows = db.prepare('SELECT * FROM file_tags WHERE file_id = ? ORDER BY tag ASC').all(fileId) as FileTagRow[];
     return rows.map(mapTagRow);
   },
   async getCredential(provider: CredentialProvider, userId: string) {
     const row = db.prepare('SELECT * FROM provider_credentials WHERE provider = ? AND user_id = ?').get(provider, userId) as
-      | any
+      | CredentialRow
       | undefined;
     return row ? mapCredentialRow(row) : null;
   },
   async listCredentials(userId: string) {
-    const rows = db.prepare('SELECT * FROM provider_credentials WHERE user_id = ?').all(userId) as any[];
+    const rows = db.prepare('SELECT * FROM provider_credentials WHERE user_id = ?').all(userId) as CredentialRow[];
     return rows.map(mapCredentialRow);
   },
   async upsertCredential(provider: CredentialProvider, updates: { username?: string; apiKey?: string }, userId: string) {
     const existingRow = db.prepare('SELECT * FROM provider_credentials WHERE provider = ? AND user_id = ?').get(provider, userId) as
-      | any
+      | CredentialRow
       | undefined;
     const existing = existingRow ? mapCredentialRow(existingRow) : null;
     const nextUsername =
@@ -1605,16 +1702,16 @@ export const dataStore = {
     } as CredentialRecord;
   },
   async listFavoriteItems(provider: FavoriteProvider | undefined, userId: string) {
-    let rows: any[];
+    let rows: FavoriteItemRow[];
     if (provider) {
-      rows = db.prepare('SELECT * FROM favorite_items WHERE provider = ? AND user_id = ? ORDER BY updated_at DESC').all(provider, userId);
+      rows = db.prepare('SELECT * FROM favorite_items WHERE provider = ? AND user_id = ? ORDER BY updated_at DESC').all(provider, userId) as FavoriteItemRow[];
     } else {
-      rows = db.prepare('SELECT * FROM favorite_items WHERE user_id = ? ORDER BY updated_at DESC').all(userId);
+      rows = db.prepare('SELECT * FROM favorite_items WHERE user_id = ? ORDER BY updated_at DESC').all(userId) as FavoriteItemRow[];
     }
     return rows.map(mapFavoriteRow);
   },
   async findFavoriteItemByPath(filePath: string, userId: string) {
-    const row = db.prepare('SELECT * FROM favorite_items WHERE file_path = ? AND user_id = ?').get(filePath, userId) as any | undefined;
+    const row = db.prepare('SELECT * FROM favorite_items WHERE file_path = ? AND user_id = ?').get(filePath, userId) as FavoriteItemRow | undefined;
     return row ? mapFavoriteRow(row) : null;
   },
   async upsertFavoriteItem(item: {
@@ -1627,7 +1724,7 @@ export const dataStore = {
     const now = new Date().toISOString();
     const existing = db
       .prepare('SELECT * FROM favorite_items WHERE provider = ? AND remote_id = ? AND user_id = ?')
-      .get(item.provider, item.remoteId, userId) as any | undefined;
+      .get(item.provider, item.remoteId, userId) as FavoriteItemRow | undefined;
     if (existing) {
       db.prepare(
         `UPDATE favorite_items
@@ -1817,7 +1914,7 @@ export const dataStore = {
     return tx(fileIds, userId);
   },
   async removeProviderRunResultForFile(fileId: string, sourceUrl: string) {
-    const rows = db.prepare('SELECT * FROM provider_runs WHERE file_id = ?').all(fileId) as any[];
+    const rows = db.prepare('SELECT * FROM provider_runs WHERE file_id = ?').all(fileId) as ProviderRunRow[];
     let removed = 0;
     for (const row of rows) {
       const run = mapProviderRunRow(row);

--- a/backend/src/lib/duplicates.ts
+++ b/backend/src/lib/duplicates.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import ffmpeg from 'fluent-ffmpeg';
+import ffmpeg, { ffprobe } from 'fluent-ffmpeg';
 import sharp from 'sharp';
 
 import { dataStore } from './dataStore';
@@ -99,10 +99,7 @@ const resolvePathInDir = (baseDir: string, childName: string) => {
   return guardedChild;
 };
 
-const resolveReadablePath = async (
-  file: FileRecord,
-  _folderById: Map<string, FolderRecord>
-): Promise<ResolvedPath | null> => {
+const resolveReadablePath = async (file: FileRecord): Promise<ResolvedPath | null> => {
   const candidates: string[] = [file.path];
   if (file.thumbPath) {
     candidates.push(file.thumbPath);
@@ -121,7 +118,8 @@ const resolveReadablePath = async (
 };
 
 const buildImageSignature = async (file: FileRecord, sampleSize: number, folderById: Map<string, FolderRecord>) => {
-  const resolved = await resolveReadablePath(file, folderById);
+  void folderById;
+  const resolved = await resolveReadablePath(file);
   if (!resolved) return null;
   try {
     const buffer = await sharp(resolved.path)
@@ -140,7 +138,7 @@ const buildImageSignature = async (file: FileRecord, sampleSize: number, folderB
 
 const getDurationSeconds = async (filePath: string) => {
   return new Promise<number>((resolve) => {
-    ffmpeg.ffprobe(filePath, (err: Error | undefined, data) => {
+    ffprobe(filePath, (err: Error | undefined, data) => {
       if (err) {
         resolve(0);
         return;
@@ -202,7 +200,8 @@ const buildVideoSignature = async (
   frameCount: number,
   folderById: Map<string, FolderRecord>
 ) => {
-  const resolved = await resolveReadablePath(file, folderById);
+  void folderById;
+  const resolved = await resolveReadablePath(file);
   if (!resolved) return null;
   const frameWidth = Math.max(sampleSize * 2, 128);
   try {

--- a/backend/src/lib/providerRunner.ts
+++ b/backend/src/lib/providerRunner.ts
@@ -1,9 +1,10 @@
-import path from 'path';
 import { appendFile } from 'fs/promises';
+import path from 'path';
 
-import { FileRecord, ProviderRunRecord, dataStore } from './dataStore';
 import { runFluffle, runSauceNao } from '../services/providers';
 import { refreshTagsFromProviderRun } from '../services/tagging';
+
+import { FileRecord, ProviderRunRecord, dataStore } from './dataStore';
 
 export type ProviderKind = 'SAUCENAO' | 'FLUFFLE';
 

--- a/backend/src/lib/scanner.ts
+++ b/backend/src/lib/scanner.ts
@@ -2,14 +2,14 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
-import ffmpeg from 'fluent-ffmpeg';
-import sharp from 'sharp';
+import ffmpeg, { ffprobe } from 'fluent-ffmpeg';
+import sharp, { cache as configureSharpCache, concurrency as configureSharpConcurrency, simd as configureSharpSimd } from 'sharp';
 
 import { FileRecord, FolderRecord } from './dataStore';
 
-sharp.cache(false);
-sharp.concurrency(1);
-sharp.simd(false);
+configureSharpCache(false);
+configureSharpConcurrency(1);
+configureSharpSimd(false);
 
 export type MediaKind = 'IMAGE' | 'VIDEO';
 
@@ -124,7 +124,7 @@ const getVideoMeta = (
   filePath: string
 ): Promise<{ width: number | null; height: number | null; durationMs: number | null }> => {
   return new Promise((resolve) => {
-    ffmpeg.ffprobe(filePath, (err: Error | undefined, data) => {
+    ffprobe(filePath, (err: Error | undefined, data) => {
       if (err) {
         resolve({ width: null, height: null, durationMs: null });
         return;

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,8 +1,8 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 
-import { clearSessionCookie, createSessionForUser, loginLocalUser, registerLocalUser, setSessionCookie, toPublicUser } from '../services/auth';
 import { dataStore } from '../lib/dataStore';
+import { clearSessionCookie, createSessionForUser, loginLocalUser, registerLocalUser, setSessionCookie, toPublicUser } from '../services/auth';
 
 const authSchema = z.object({
   username: z

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -2,11 +2,11 @@ import fs from 'fs';
 import path from 'path';
 
 import { FastifyInstance } from 'fastify';
+import { lookup as lookupMime } from 'mime-types';
 import { z } from 'zod';
 
 import { dataStore } from '../lib/dataStore';
 import type { ProviderKind } from '../lib/providerRunner';
-import mime from 'mime-types';
 
 const booleanQueryParam = z.preprocess((value) => {
   if (typeof value === 'boolean') return value;
@@ -312,7 +312,7 @@ export const registerFilesRoutes = (app: FastifyInstance) => {
       const stat = await fs.promises.stat(localPath);
       const fileSize = stat.size;
       const range = request.headers.range;
-      const contentType = mime.lookup(file.path) || 'application/octet-stream';
+      const contentType = lookupMime(file.path) || 'application/octet-stream';
       reply.type(contentType);
       reply.header('X-Content-Type-Options', 'nosniff');
       if (query.download === '1') {

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -1,8 +1,8 @@
+import { randomBytes, randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import { randomBytes, randomUUID } from 'crypto';
 
-import argon2 from 'argon2';
+import { argon2id, hash as argonHash, verify as argonVerify } from 'argon2';
 import { FastifyReply } from 'fastify';
 
 import { config } from '../config';
@@ -31,11 +31,11 @@ export const toPublicUser = (user: UserRecord | AuthenticatedUser) => ({
 });
 
 export const hashPassword = async (password: string) => {
-  return argon2.hash(password, { type: argon2.argon2id });
+  return argonHash(password, { type: argon2id });
 };
 
 export const verifyPassword = async (hash: string, password: string) => {
-  return argon2.verify(hash, password);
+  return argonVerify(hash, password);
 };
 
 const buildUserDirectorySuffix = (userId: string) => {
@@ -176,7 +176,6 @@ export const registerLocalUser = async (username: string, password: string) => {
   if (existing) {
     throw new Error('Username already exists');
   }
-  const userCount = await dataStore.countUsers();
   const passwordHash = await hashPassword(password);
   const userId = randomUUID();
   const libraryRoot = buildUserLibraryRoot(normalizedUsername, userId);

--- a/backend/src/services/duplicateResolver.ts
+++ b/backend/src/services/duplicateResolver.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
-import { findDuplicates } from '../lib/duplicates';
 import { dataStore, FavoriteProvider } from '../lib/dataStore';
+import { findDuplicates } from '../lib/duplicates';
 
 const favoriteProviderPriority: FavoriteProvider[] = ['E621', 'DANBOORU'];
 

--- a/backend/src/services/favorites.ts
+++ b/backend/src/services/favorites.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { Readable } from 'stream';
 import { pipeline } from 'stream/promises';
 
 import { fetch } from 'undici';
@@ -8,6 +9,7 @@ import { config } from '../config';
 import { dataStore, FavoriteProvider, FavoriteItemRecord, FileRecord } from '../lib/dataStore';
 import { ensureDirectoryWritable } from '../lib/fsAccess';
 import { scanLocalFile } from '../lib/scanner';
+
 import { resolveCredential } from './credentials';
 import { applyRemotePostTags } from './tagging';
 
@@ -17,6 +19,25 @@ type FavoriteRemote = {
   sourceUrl: string;
   fileUrl: string | null;
 };
+
+type E621FavoritePost = {
+  id?: number | string | null;
+  file?: {
+    url?: string | null;
+  } | null;
+};
+
+type E621FavoritesResponse = {
+  posts?: E621FavoritePost[] | null;
+};
+
+type DanbooruFavoritePost = {
+  id?: number | string | null;
+  file_url?: string | null;
+  large_file_url?: string | null;
+};
+
+type DanbooruFavoritesResponse = DanbooruFavoritePost[] | { posts?: DanbooruFavoritePost[] | null };
 
 type SyncResult = {
   provider: FavoriteProvider;
@@ -248,7 +269,7 @@ const downloadFile = async (url: string, destPath: string, headers: Record<strin
     const text = await res.text();
     throw new Error(`Download failed (${res.status}): ${text.slice(0, 200)}`);
   }
-  await pipeline(res.body as any, fs.createWriteStream(tempPath));
+  await pipeline(Readable.fromWeb(res.body), fs.createWriteStream(tempPath));
   await fs.promises.rename(tempPath, destPath);
 };
 
@@ -329,7 +350,7 @@ const fetchE621Favorites = async (userId: string, onPage?: (page: number, count:
   const items: FavoriteRemote[] = [];
   const limit = 320;
   let page = 1;
-  while (true) {
+  for (;;) {
     const params = new URLSearchParams({
       tags: `fav:${auth.username}`,
       limit: String(limit),
@@ -340,13 +361,13 @@ const fetchE621Favorites = async (userId: string, onPage?: (page: number, count:
     if (!res.ok) {
       throw new Error(`e621 favorites failed (${res.status}): ${text.slice(0, 200)}`);
     }
-    let data: any;
+    let data: E621FavoritesResponse;
     try {
-      data = JSON.parse(text);
+      data = JSON.parse(text) as E621FavoritesResponse;
     } catch {
       throw new Error(`e621 favorites parse failed: ${text.slice(0, 200)}`);
     }
-    const posts: any[] = Array.isArray(data?.posts) ? data.posts : [];
+    const posts = Array.isArray(data.posts) ? data.posts : [];
     if (!posts.length) break;
     onPage?.(page, posts.length);
     for (const post of posts) {
@@ -380,7 +401,7 @@ const fetchDanbooruFavorites = async (userId: string, onPage?: (page: number, co
   const items: FavoriteRemote[] = [];
   const limit = 200;
   let page = 1;
-  while (true) {
+  for (;;) {
     const params = new URLSearchParams({
       tags: `fav:${auth.username}`,
       limit: String(limit),
@@ -391,13 +412,13 @@ const fetchDanbooruFavorites = async (userId: string, onPage?: (page: number, co
     if (!res.ok) {
       throw new Error(`danbooru favorites failed (${res.status}): ${text.slice(0, 200)}`);
     }
-    let data: any;
+    let data: DanbooruFavoritesResponse;
     try {
-      data = JSON.parse(text);
+      data = JSON.parse(text) as DanbooruFavoritesResponse;
     } catch {
       throw new Error(`danbooru favorites parse failed: ${text.slice(0, 200)}`);
     }
-    const posts: any[] = Array.isArray(data) ? data : Array.isArray(data?.posts) ? data.posts : [];
+    const posts = Array.isArray(data) ? data : Array.isArray(data.posts) ? data.posts : [];
     if (!posts.length) break;
     onPage?.(page, posts.length);
     for (const post of posts) {

--- a/backend/src/services/providers.ts
+++ b/backend/src/services/providers.ts
@@ -2,11 +2,12 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { FormData } from 'undici';
-import ffmpeg from 'fluent-ffmpeg';
-import mime from 'mime-types';
+import ffmpeg, { ffprobe } from 'fluent-ffmpeg';
+import { lookup as lookupMime } from 'mime-types';
+import { FormData, fetch } from 'undici';
 
 import { FileRecord, dataStore } from '../lib/dataStore';
+
 import { resolveCredential } from './credentials';
 
 const resolveFileUserId = async (file: FileRecord) => {
@@ -45,6 +46,48 @@ type ResolvedPath = {
   cleanup: () => Promise<void>;
 };
 
+type SauceNaoHeader = {
+  similarity?: string | null;
+  thumbnail?: string | null;
+  index_name?: string | null;
+  minimum_similarity?: string | number | null;
+  short_remaining?: string | number | null;
+  long_remaining?: string | number | null;
+};
+
+type SauceNaoData = {
+  e621_id?: number | string | null;
+  e621Id?: number | string | null;
+  danbooru_id?: number | string | null;
+  danbooruId?: number | string | null;
+  ext_urls?: string[] | null;
+  source?: string | null;
+};
+
+type SauceNaoMatch = {
+  header?: SauceNaoHeader | null;
+  data?: SauceNaoData | null;
+};
+
+type SauceNaoResponse = {
+  header?: SauceNaoHeader | null;
+  results?: SauceNaoMatch[] | null;
+};
+
+type FluffleMatch = {
+  score?: number | null;
+  distance?: number | null;
+  url?: string | null;
+  platform?: string | null;
+  thumbnail?: {
+    url?: string | null;
+  } | null;
+};
+
+type FluffleResponse = {
+  results?: FluffleMatch[] | null;
+};
+
 const noopCleanup = async () => undefined;
 
 const resolveReadablePath = async (candidate: string | null | undefined) => {
@@ -73,7 +116,7 @@ const cleanupTempFile = async (filePath: string) => {
 
 const getVideoDurationSeconds = async (filePath: string) => {
   return new Promise<number>((resolve) => {
-    ffmpeg.ffprobe(filePath, (err: Error | undefined, data) => {
+    ffprobe(filePath, (err: Error | undefined, data) => {
       if (err) {
         resolve(0);
         return;
@@ -147,7 +190,7 @@ const resolveUploadSource = async (file: FileRecord): Promise<UploadSource> => {
       return {
         sourcePath: fallbackThumb,
         filename,
-        mimeType: (mime.lookup(filename) || 'image/jpeg') as string,
+        mimeType: (lookupMime(filename) || 'image/jpeg') as string,
         cleanup: noopCleanup
       };
     }
@@ -160,12 +203,12 @@ const resolveUploadSource = async (file: FileRecord): Promise<UploadSource> => {
     const resolved = await resolveReadablePath(candidate);
     if (!resolved) continue;
     const filename = path.basename(resolved) || 'file';
-    const mimeType = (mime.lookup(filename) || 'application/octet-stream') as string;
+    const mimeType = (lookupMime(filename) || 'application/octet-stream') as string;
     return { sourcePath: resolved, filename, mimeType, cleanup: noopCleanup };
   }
   const fallback = path.resolve(file.path);
   const filename = path.basename(fallback) || 'file';
-  const mimeType = (mime.lookup(filename) || 'application/octet-stream') as string;
+  const mimeType = (lookupMime(filename) || 'application/octet-stream') as string;
   return { sourcePath: fallback, filename, mimeType, cleanup: noopCleanup };
 };
 
@@ -176,7 +219,7 @@ const pickSauceUrl = (urls: string[] | null | undefined) => {
   return prefer ?? urls[0] ?? null;
 };
 
-const pickSaucePostUrl = (data: any) => {
+const pickSaucePostUrl = (data: SauceNaoData | null | undefined) => {
   const e621Id = data?.e621_id ?? data?.e621Id ?? null;
   const danbooruId = data?.danbooru_id ?? data?.danbooruId ?? null;
   const toId = (value: unknown) => {
@@ -211,21 +254,21 @@ export const runSauceNao = async (file: FileRecord): Promise<ProviderResult> => 
         headers: {
           Accept: 'application/json',
           'User-Agent': 'ImageSearch/0.1 (+local)'
-        } as any,
-        body: form as any
+          },
+          body: form
       });
       const text = await res.text();
       if (!res.ok) {
         return { score: null, sourceUrl: null, thumbUrl: null, error: `HTTP ${res.status}: ${text}` };
       }
-      let data: any;
+        let data: SauceNaoResponse;
       try {
-        data = JSON.parse(text);
+          data = JSON.parse(text) as SauceNaoResponse;
       } catch {
         return { score: null, sourceUrl: null, thumbUrl: null, error: `Non-JSON response (status ${res.status}): ${text}` };
       }
       const header = data?.header ?? {};
-      const results: any[] = Array.isArray(data?.results) ? data.results : [];
+        const results = Array.isArray(data.results) ? data.results : [];
       if (!results.length) {
         return {
           score: null,
@@ -301,20 +344,20 @@ export const runFluffle = async (file: FileRecord): Promise<ProviderResult> => {
         headers: {
           'User-Agent': 'ImageSearch/0.1 (by local)',
           Accept: 'application/json'
-        } as any,
-        body: form as any
+          },
+          body: form
       });
       const text = await res.text();
       if (!res.ok) {
         return { score: null, sourceUrl: null, thumbUrl: null, error: `HTTP ${res.status}: ${text}` };
       }
-      let data: any;
+        let data: FluffleResponse;
       try {
-        data = JSON.parse(text);
+          data = JSON.parse(text) as FluffleResponse;
       } catch {
         return { score: null, sourceUrl: null, thumbUrl: null, error: `Non-JSON response: ${text}` };
       }
-      const results: any[] = Array.isArray(data?.results) ? data.results : [];
+        const results = Array.isArray(data.results) ? data.results : [];
       if (!results.length) {
         return { score: null, sourceUrl: null, thumbUrl: null, results: [], error: 'No results returned' };
       }
@@ -358,7 +401,13 @@ export const runFluffle = async (file: FileRecord): Promise<ProviderResult> => {
         score: top?.score ?? null,
         sourceUrl: top?.sourceUrl ?? null,
         thumbUrl: top?.thumbUrl ?? null,
-        results: sorted.map(({ rawScore, rawDistance, similarity, ...rest }) => rest),
+          results: sorted.map((item) => ({
+            score: item.score,
+            distance: item.distance,
+            sourceUrl: item.sourceUrl,
+            sourceName: item.sourceName,
+            thumbUrl: item.thumbUrl
+          })),
         debug
       };
     } finally {

--- a/backend/src/services/tagging.ts
+++ b/backend/src/services/tagging.ts
@@ -1,14 +1,15 @@
+import { Blob } from 'buffer';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { Blob } from 'buffer';
 
-import ffmpeg from 'fluent-ffmpeg';
+import ffmpeg, { ffprobe } from 'fluent-ffmpeg';
 import sharp from 'sharp';
 import { FormData, fetch } from 'undici';
 
 import { config } from '../config';
 import { dataStore, FileRecord, ProviderRunRecord, TagSource } from '../lib/dataStore';
+
 import { resolveCredential } from './credentials';
 
 type TagCandidateSource = 'E621' | 'DANBOORU' | 'GELBOORU' | 'YANDERE' | 'KONACHAN' | 'SANKAKU' | 'IDOL_COMPLEX';
@@ -27,6 +28,83 @@ type TagResult = {
   category: string;
   score?: number | null;
   sourceUrl?: string | null;
+};
+
+type E621TagBuckets = {
+  general?: string[];
+  artist?: string[];
+  character?: string[];
+  species?: string[];
+  meta?: string[];
+  lore?: string[];
+  invalid?: string[];
+};
+
+type E621Post = {
+  id?: number | string | null;
+  tags?: E621TagBuckets | null;
+};
+
+type E621Response = {
+  post?: E621Post | null;
+  posts?: E621Post[] | null;
+};
+
+type DanbooruPost = {
+  id?: number | string | null;
+  tag_string_general?: string;
+  tag_string_artist?: string;
+  tag_string_character?: string;
+  tag_string_copyright?: string;
+  tag_string_meta?: string;
+};
+
+type DanbooruResponse = DanbooruPost[] | { post?: DanbooruPost | null; posts?: DanbooruPost[] | null };
+
+type GelbooruPost = {
+  tags?: string | null;
+};
+
+type GelbooruEnvelope = {
+  post?: GelbooruPost | null;
+};
+
+type GelbooruResponse = GelbooruPost[] | GelbooruEnvelope | GelbooruPost;
+
+type MoebooruPost = {
+  tags_general?: string;
+  tags?: string;
+  tags_artist?: string;
+  tags_character?: string;
+  tags_copyright?: string;
+  tags_meta?: string;
+};
+
+type MoebooruResponse = MoebooruPost[] | MoebooruPost;
+
+type SankakuTagEntry = {
+  name?: string;
+  type?: string | number;
+};
+
+type SankakuPost = {
+  tags?: SankakuTagEntry[] | string;
+};
+
+type SankakuResponse = SankakuPost[] | SankakuPost;
+
+type Wd14Tag = {
+  tag: string;
+  score: number;
+  category: string;
+};
+
+type Wd14Response = {
+  tags?: Wd14Tag[] | null;
+};
+
+const isGelbooruEnvelope = (value: GelbooruResponse): value is GelbooruEnvelope => {
+  return !Array.isArray(value) && Object.prototype.hasOwnProperty.call(value, 'post');
 };
 
 const providerScoreThresholds: Record<ProviderRunRecord['provider'], number> = {
@@ -205,7 +283,7 @@ const resolveTagCandidate = (
   return null;
 };
 
-const buildE621Tags = (tags: any) => {
+const buildE621Tags = (tags: E621TagBuckets | null | undefined) => {
   if (!tags) return [];
   const bucket: TagResult[] = [];
   const pushTags = (category: string, values: string[]) => {
@@ -224,7 +302,7 @@ const buildE621Tags = (tags: any) => {
   return bucket;
 };
 
-const buildDanbooruTags = (data: any) => {
+const buildDanbooruTags = (data: DanbooruPost | null | undefined) => {
   const bucket: TagResult[] = [];
   const pushTags = (category: string, value?: string) => {
     if (!value) return;
@@ -298,9 +376,9 @@ const fetchE621Tags = async (postId: string, userId?: string) => {
     console.warn(`[tags] e621 fetch failed (${res.status}): ${text.slice(0, 200)}`);
     return [];
   }
-  let data: any;
+  let data: E621Response;
   try {
-    data = JSON.parse(text);
+    data = JSON.parse(text) as E621Response;
   } catch {
     console.warn(`[tags] e621 parse failed: ${text.slice(0, 200)}`);
     return [];
@@ -324,9 +402,9 @@ const fetchE621TagsByMd5 = async (md5: string, userId?: string) => {
     console.warn(`[tags] e621 md5 fetch failed (${res.status}): ${text.slice(0, 200)}`);
     return { tags: [], sourceUrl: null };
   }
-  let data: any;
+  let data: E621Response;
   try {
-    data = JSON.parse(text);
+    data = JSON.parse(text) as E621Response;
   } catch {
     console.warn(`[tags] e621 md5 parse failed: ${text.slice(0, 200)}`);
     return { tags: [], sourceUrl: null };
@@ -352,9 +430,9 @@ const fetchDanbooruTags = async (postId: string, userId?: string) => {
     console.warn(`[tags] danbooru fetch failed (${res.status}): ${text.slice(0, 200)}`);
     return [];
   }
-  let data: any;
+  let data: DanbooruPost;
   try {
-    data = JSON.parse(text);
+    data = JSON.parse(text) as DanbooruPost;
   } catch {
     console.warn(`[tags] danbooru parse failed: ${text.slice(0, 200)}`);
     return [];
@@ -377,9 +455,9 @@ const fetchDanbooruTagsByMd5 = async (md5: string, userId?: string) => {
     console.warn(`[tags] danbooru md5 fetch failed (${res.status}): ${text.slice(0, 200)}`);
     return { tags: [], sourceUrl: null };
   }
-  let data: any;
+  let data: DanbooruResponse;
   try {
-    data = JSON.parse(text);
+    data = JSON.parse(text) as DanbooruResponse;
   } catch {
     console.warn(`[tags] danbooru md5 parse failed: ${text.slice(0, 200)}`);
     return { tags: [], sourceUrl: null };
@@ -413,14 +491,14 @@ const fetchGelbooruTags = async (postId: string) => {
     console.warn(`[tags] gelbooru fetch failed (${res.status}): ${text.slice(0, 200)}`);
     return [];
   }
-  let data: any;
+  let data: GelbooruResponse;
   try {
-    data = JSON.parse(text);
+    data = JSON.parse(text) as GelbooruResponse;
   } catch {
     console.warn(`[tags] gelbooru parse failed: ${text.slice(0, 200)}`);
     return [];
   }
-  const entry = Array.isArray(data) ? data[0] : data?.post ?? data;
+  const entry: GelbooruPost | null = Array.isArray(data) ? (data[0] ?? null) : isGelbooruEnvelope(data) ? (data.post ?? null) : data;
   const rawTags = typeof entry?.tags === 'string' ? entry.tags : '';
   if (!rawTags) return [];
   return rawTags
@@ -443,9 +521,9 @@ const fetchMoebooruTags = async (baseUrl: string, postId: string) => {
       console.warn(`[tags] moebooru fetch failed (${res.status}): ${text.slice(0, 200)}`);
       continue;
     }
-    let data: any;
+    let data: MoebooruResponse;
     try {
-      data = JSON.parse(text);
+      data = JSON.parse(text) as MoebooruResponse;
     } catch {
       console.warn(`[tags] moebooru parse failed: ${text.slice(0, 200)}`);
       continue;
@@ -489,9 +567,9 @@ const fetchSankakuTags = async (postId: string, baseUrl: string) => {
       console.warn(`[tags] sankaku fetch failed (${res.status}): ${text.slice(0, 200)}`);
       continue;
     }
-    let data: any;
+    let data: SankakuResponse;
     try {
-      data = JSON.parse(text);
+      data = JSON.parse(text) as SankakuResponse;
     } catch {
       console.warn(`[tags] sankaku parse failed: ${text.slice(0, 200)}`);
       continue;
@@ -555,14 +633,14 @@ const runWd14Tagger = async (imagePath: string) => {
   if (!res.ok) {
     throw new Error(`tagger error: ${res.status}`);
   }
-  const data = (await res.json()) as any;
-  return (data?.tags ?? []) as { tag: string; score: number; category: string }[];
+  const data = (await res.json()) as Wd14Response;
+  return Array.isArray(data.tags) ? data.tags : [];
 };
 
 const extractVideoFrames = async (filePath: string, count: number) => {
   const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'imagesearch-frames-'));
   const durationSeconds = await new Promise<number>((resolve) => {
-    ffmpeg.ffprobe(filePath, (err, data) => {
+    ffprobe(filePath, (err, data) => {
       if (err) {
         resolve(0);
         return;
@@ -749,6 +827,7 @@ const applyCombinedTags = async (file: FileRecord, candidates: TagCandidate[]) =
 };
 
 export const refreshTagsFromProviderRun = async (file: FileRecord, _run: ProviderRunRecord) => {
+  void _run;
   try {
     const runs = await dataStore.listProviderRuns(file.id);
     const candidates = collectCandidatesFromRuns(runs);

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -1,16 +1,16 @@
 import fs from 'fs';
 import path from 'path';
 
-import chokidar from 'chokidar';
+import { FSWatcher, watch } from 'chokidar';
 import { fetch } from 'undici';
 
 import { config } from './config';
 import { dataStore, FileRecord, FolderRecord, ProviderRunRecord } from './lib/dataStore';
 import { executeProviderRun, ProviderKind } from './lib/providerRunner';
 import { hasTargetSauce, normalizeSauceKey } from './lib/sauces';
+import { iterateLocalMediaPaths, scanLocalFile, ScannedFile } from './lib/scanner';
 import { startFavoritesSync } from './services/favorites';
 import { ensureWd14Tags } from './services/tagging';
-import { iterateLocalMediaPaths, scanFolder, scanLocalFile, ScannedFile } from './lib/scanner';
 
 const providerKinds: ProviderKind[] = ['SAUCENAO', 'FLUFFLE'];
 const dayMs = 24 * 60 * 60 * 1000;
@@ -33,7 +33,7 @@ const scanFileTimeoutMs = 30 * 1000;
 const scanFileRetryDelayMs = 10 * 1000;
 const scanFileRetryLimit = 2;
 
-const watchers = new Map<string, chokidar.FSWatcher>();
+const watchers = new Map<string, FSWatcher>();
 const scanStates = new Map<string, ScanState>();
 const folderMtimeCache = new Map<string, number>();
 let providerRefreshRunning = false;
@@ -382,7 +382,7 @@ const startScanSession = async (folderId: string, reason: string) => {
     await dataStore.updateFolder(folderId, { status: 'SCANNING', lastScanAt: new Date().toISOString() });
     console.log(`[auto-scan] started scan ${scanId} for folder ${folder.path} (${reason})`);
 
-    while (true) {
+    for (;;) {
       if (state.needsFullScan) {
         state.needsFullScan = false;
         await runFullLocalScan(folder, state);
@@ -434,7 +434,7 @@ const startFolderWatch = (folderId: string, folderPath: string) => {
     console.warn(`[auto-scan] watch skipped, path not found: ${folderPath}`);
     return false;
   }
-  const watcher = chokidar.watch(folderPath, {
+  const watcher = watch(folderPath, {
     ignoreInitial: true,
     awaitWriteFinish: {
       stabilityThreshold: 2000,
@@ -656,7 +656,7 @@ const runWd14Backfill = async () => {
   wd14BackfillRunning = true;
   try {
     let cursor: { createdAt: string; id: string } | null = null;
-    while (true) {
+    for (;;) {
       const batch = await dataStore.listFilesBatch({
         limit: wd14BackfillBatchSize,
         after: cursor,


### PR DESCRIPTION
This branch adds the first CI workflows for the repo and makes backend linting clean enough to enforce in CI.

What changed:
- Added a build CI workflow that runs on PR updates and pushes to main.
- The build CI covers backend lint/build, frontend build, and Docker image builds.
- Added a security workflow for dependency and container scanning on PRs, pushes to main, nightly schedule, and manual runs.
- Cleaned up backend lint blockers and remaining warnings so backend lint now runs cleanly.
- Added the ESLint TypeScript import resolver needed to support the repo's Node16 and .js import setup without breaking builds.

Commits in this branch:
- 0ea6815 ci: add build workflow
- e29d874 ci: add security workflow
- 87d8e6d ci: enable clean backend linting

Validation:
- npm run lint --prefix backend
- npm run build --prefix backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration and deployment pipeline with automated security scanning for dependencies and container images.
  * Improved code quality infrastructure with better TypeScript support in linting tools.
  * Refactored internal imports and dependencies for improved code maintainability and stability.
  * Strengthened type safety throughout the codebase for more robust error prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->