### PR TITLE
fix: codebase analysis findings 2026-05-02

### DIFF
--- a/backend/src/services/auth.test.ts
+++ b/backend/src/services/auth.test.ts
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const backendRoot = path.resolve(__dirname, '..', '..');
+const authModulePath = require.resolve('./auth');
+const configModulePath = require.resolve('../config');
+
+const loadAuthModule = () => {
+  delete require.cache[authModulePath];
+  delete require.cache[configModulePath];
+  return require('./auth') as typeof import('./auth');
+};
+
+test('resolveUserManagedPath rejects symlink escape when leaf does not exist', async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'gooncave-auth-'));
+  const libraryRoot = path.join(tempRoot, 'library');
+  const outsideRoot = path.join(tempRoot, 'outside');
+  const linkPath = path.join(libraryRoot, 'escape-link');
+
+  await fs.mkdir(libraryRoot, { recursive: true });
+  await fs.mkdir(outsideRoot, { recursive: true });
+  await fs.symlink(outsideRoot, linkPath, 'dir');
+
+  const { resolveUserManagedPath } = loadAuthModule();
+
+  await assert.rejects(
+    () => resolveUserManagedPath(libraryRoot, 'escape-link/new-folder'),
+    /Folder path must stay inside your library root/
+  );
+
+  await fs.rm(tempRoot, { recursive: true, force: true });
+});
+
+test('setSessionCookie uses secure cookies in production', () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  delete require.cache[authModulePath];
+  delete require.cache[configModulePath];
+  process.env.NODE_ENV = 'production';
+
+  const { setSessionCookie } = loadAuthModule();
+  const captured: Array<{ token: string; options: Record<string, unknown> }> = [];
+  const reply = {
+    setCookie(_name: string, token: string, options: Record<string, unknown>) {
+      captured.push({ token, options });
+    }
+  };
+
+  setSessionCookie(reply as never, 'session-token', '2030-01-01T00:00:00.000Z');
+
+  assert.equal(captured[0]?.token, 'session-token');
+  assert.equal(captured[0]?.options.secure, true);
+
+  if (previousNodeEnv === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = previousNodeEnv;
+  }
+});

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -115,25 +115,55 @@ export const isPathInside = (candidatePath: string, basePath: string) => {
   return resolvedCandidate === resolvedBase || resolvedCandidate.startsWith(`${resolvedBase}${path.sep}`);
 };
 
+const splitPathSegments = (candidatePath: string) => candidatePath.split(/[\\/]+/).filter(Boolean);
+
+const resolvePathWithinRoot = async (rootPath: string, requestedPath: string) => {
+  const relativePath = path.isAbsolute(requestedPath) ? path.relative(rootPath, path.resolve(requestedPath)) : requestedPath;
+  let currentPath = rootPath;
+
+  for (const segment of splitPathSegments(relativePath)) {
+    if (segment === '.') continue;
+    if (segment === '..') {
+      currentPath = path.resolve(currentPath, '..');
+    } else {
+      const nextPath = path.join(currentPath, segment);
+      const stats = await fs.promises.lstat(nextPath).catch(() => null);
+      if (stats?.isSymbolicLink()) {
+        currentPath = await fs.promises.realpath(nextPath);
+      } else {
+        currentPath = nextPath;
+      }
+    }
+
+    if (!isPathInside(currentPath, rootPath)) {
+      throw new Error('Folder path must stay inside your library root');
+    }
+  }
+
+  return currentPath;
+};
+
 export const resolveUserManagedPath = async (libraryRoot: string, rawPath: string) => {
   const requested = rawPath.trim();
   const resolvedRoot = await fs.promises.realpath(libraryRoot).catch(() => path.resolve(libraryRoot));
-  const initial = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(resolvedRoot, requested);
-  const resolvedCandidate = await fs.promises.realpath(initial).catch(() => initial);
-  if (!isPathInside(resolvedCandidate, resolvedRoot)) {
-    throw new Error('Folder path must stay inside your library root');
-  }
-  return resolvedCandidate;
+  return resolvePathWithinRoot(resolvedRoot, requested);
 };
 
 export const createSessionToken = () => randomBytes(32).toString('hex');
+
+export const isSecureCookieEnabled = (env: string, override?: string) => {
+  if (override === undefined || override === '') {
+    return env === 'production';
+  }
+  return override.toLowerCase() === 'true' || override === '1';
+};
 
 export const setSessionCookie = (reply: FastifyReply, token: string, expiresAt: string) => {
   reply.setCookie(sessionCookieName, token, {
     path: '/',
     httpOnly: true,
     sameSite: 'lax',
-    secure: false,
+    secure: isSecureCookieEnabled(config.env, process.env.AUTH_COOKIE_SECURE),
     expires: new Date(expiresAt)
   });
 };
@@ -143,7 +173,7 @@ export const clearSessionCookie = (reply: FastifyReply) => {
     path: '/',
     httpOnly: true,
     sameSite: 'lax',
-    secure: false
+    secure: isSecureCookieEnabled(config.env, process.env.AUTH_COOKIE_SECURE)
   });
 };
 


### PR DESCRIPTION
Closes #35

## Summary
- fix auth path validation so symlinked subpaths cannot escape a user's library root when the final folder does not exist
- send secure session cookies in production while preserving opt-in override control
- add backend regression tests for the symlink escape and production cookie behavior

## Verification
- `cd backend && npx tsx --test src/services/auth.test.ts`
- `cd backend && npm run build`

---
*Generated automatically by Codebase Analyst*
