### PR TITLE
fix: codebase analysis findings 2026-05-09

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   backend:
     name: Backend lint and build

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -78,7 +78,8 @@ export const config = {
   auth: {
     cookieName: process.env.AUTH_COOKIE_NAME ?? 'gooncave_session',
     sessionTtlMs: toInt(process.env.AUTH_SESSION_TTL_HOURS, 24) * 60 * 60 * 1000,
-    usersRootDirName: process.env.AUTH_USERS_DIR_NAME ?? 'users'
+    usersRootDirName: process.env.AUTH_USERS_DIR_NAME ?? 'users',
+    cookieSecure: toBool(process.env.AUTH_COOKIE_SECURE, (process.env.NODE_ENV ?? 'development') === 'production')
   },
   background: {
     localRescanIntervalMs: toInt(process.env.LOCAL_RESCAN_INTERVAL_MINUTES, 0) * 60 * 1000

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -38,8 +38,11 @@ export const createServer = () => {
     }
   });
 
+  if (config.allowedOrigins.length === 0) {
+    app.log.warn('ALLOWED_ORIGINS is empty; cross-origin requests will be rejected');
+  }
   app.register(cors, {
-    origin: config.allowedOrigins.length ? config.allowedOrigins : true,
+    origin: config.allowedOrigins.length ? config.allowedOrigins : false,
     credentials: true
   });
 

--- a/backend/src/lib/dataStore.ts
+++ b/backend/src/lib/dataStore.ts
@@ -1851,6 +1851,7 @@ export const dataStore = {
     db.prepare('DELETE FROM file_tags WHERE file_id = ? AND tag = ? AND source = ?').run(fileId, tag, 'MANUAL');
   },
   async saveManualOrder(fileIds: string[], userId?: string) {
+    return withSqliteRetry(() => {
     const now = new Date().toISOString();
     const tx = db.transaction((order: string[], scopedUserId?: string) => {
       if (order.length === 0) {
@@ -1912,6 +1913,7 @@ export const dataStore = {
     });
 
     return tx(fileIds, userId);
+    });
   },
   async removeProviderRunResultForFile(fileId: string, sourceUrl: string) {
     const rows = db.prepare('SELECT * FROM provider_runs WHERE file_id = ?').all(fileId) as ProviderRunRow[];

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -322,7 +322,7 @@ export const registerFilesRoutes = (app: FastifyInstance) => {
 
       if (range) {
         const match = /^bytes=(\d*)-(\d*)$/.exec(range);
-        if (!match) {
+        if (!match || (!match[1] && !match[2])) {
           reply.code(416).header('Content-Range', `bytes */${fileSize}`);
           return reply.send();
         }

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -133,7 +133,7 @@ export const setSessionCookie = (reply: FastifyReply, token: string, expiresAt: 
     path: '/',
     httpOnly: true,
     sameSite: 'lax',
-    secure: false,
+    secure: config.auth.cookieSecure,
     expires: new Date(expiresAt)
   });
 };
@@ -143,7 +143,7 @@ export const clearSessionCookie = (reply: FastifyReply) => {
     path: '/',
     httpOnly: true,
     sameSite: 'lax',
-    secure: false
+    secure: config.auth.cookieSecure
   });
 };
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -216,7 +216,7 @@ const pickDuplicateSuggestion = (a: DuplicateFile, b: DuplicateFile) => {
     const winnerLabel = resolveFavoriteLabel(winner);
     if (rankA > 0 && rankB > 0) {
       return {
-        id: winner.id,
+        keepId: winner.id,
         reason: `preferred favorite source (${winnerLabel ?? 'favorite'})`
       };
     }
@@ -2006,7 +2006,7 @@ function App() {
       if (run.status === 'RUNNING' || run.status === 'PENDING') {
         activeRun = true;
       }
-      const runMs = new Date(run.completedAt ?? run.createdAt).getTime();
+      const runMs = new Date(run.completedAt || run.createdAt).getTime();
       if (!Number.isNaN(runMs) && runMs > latestRunMs) {
         latestRunMs = runMs;
       }
@@ -2014,7 +2014,7 @@ function App() {
         firstRunMs = runMs;
       }
       const existing = latestByProvider.get(run.provider);
-      const existingMs = existing ? new Date(existing.completedAt ?? existing.createdAt).getTime() : 0;
+      const existingMs = existing ? new Date(existing.completedAt || existing.createdAt).getTime() : 0;
       if (!existing || runMs > existingMs) {
         latestByProvider.set(run.provider, run);
       }
@@ -2183,7 +2183,7 @@ function App() {
         }, 220);
         return;
       }
-      const width = detailSwipeFrameRef.current?.clientWidth ?? window.innerWidth ?? 1;
+      const width = detailSwipeFrameRef.current?.clientWidth || window.innerWidth || 1;
       setDetailSwipeOffset(delta < 0 ? width : -width);
       clearDetailSwipeTimer();
       detailSwipeTimerRef.current = window.setTimeout(() => {
@@ -2253,7 +2253,7 @@ function App() {
     const dx = gesture.lastX - gesture.startX;
     const elapsed = Math.max(1, performance.now() - gesture.startedAt);
     const velocity = dx / elapsed;
-    const width = detailSwipeFrameRef.current?.clientWidth ?? window.innerWidth ?? 1;
+    const width = detailSwipeFrameRef.current?.clientWidth || window.innerWidth || 1;
     const threshold = Math.min(140, width * 0.22);
     if ((dx > threshold || (dx > 28 && velocity > 0.45)) && prevLoadedFile) {
       commitDetailSwipe(-1);


### PR DESCRIPTION
## Summary

Targeted fixes from the 2026-05-09 multi-axis codebase analysis (security, bugs, quality, deps, perf, tests). Only high-confidence, low-risk fixes are bundled here. Larger-scope items (App.tsx split, dataStore split, missing test infra, dependency upgrades, FLUFFLE distance/score conversion, missing DB indexes) intentionally deferred.

### Security
- **CORS fail-closed when `ALLOWED_ORIGINS` is empty** (`backend/src/index.ts`). The previous default was `origin: true`, which reflects any `Origin` header while `credentials: true` is set — that defeats `SameSite=Lax` against authenticated cross-site fetches and allows response exfiltration. Now empty list ⇒ origin denied + warning logged. **Operational note:** dev environments running the frontend on a different origin (e.g. Vite on `:5174` against backend on `:4100`) must now set `ALLOWED_ORIGINS=http://localhost:5174` (or equivalent).
- **Session cookie `secure` flag is now env-driven** (`backend/src/services/auth.ts`, `backend/src/config.ts`). Previously hardcoded to `false` so the auth cookie was emitted without the `Secure` attribute even in production behind an HTTPS proxy. New `AUTH_COOKIE_SECURE` env var; default `true` when `NODE_ENV=production`, `false` otherwise.
- **CI workflow top-level `permissions: contents: read`** (`.github/workflows/ci.yml`) per AGENTS.md §14. The workflow previously inherited the default token scope.

### Bug fixes
- `frontend/src/App.tsx` — `pickDuplicateSuggestion` returned `{ id, reason }` in the "preferred favorite source" branch while every other branch and every caller (`App.tsx:1846`, `1899-1904`) reads `keepId`. Result: when both files were synced favorites with different ranks, the suggested-keep id was silently dropped and auto-resolve fell into "keep both".
- `frontend/src/App.tsx` — `window.innerWidth ?? 1` (×2 sites). `innerWidth` is never nullish, only `0`. Switched to `||` so the `1` fallback actually engages.
- `frontend/src/App.tsx` — `new Date(run.completedAt ?? run.createdAt)`. `??` does not fall back on `""`, so when `completedAt` is the empty string the `Date('')` produces `NaN`, leaving `firstRunMs` at `Infinity` and `expired` always `false`. Switched to `||`.
- `backend/src/routes/files.ts` — Range header `bytes=-` (both bounds empty) used to be accepted by the regex and then resolved to `start=0`/`end=fileSize-1`, returning the full file with status 206. Now returns 416 per RFC 7233.
- `backend/src/lib/dataStore.ts` — `saveManualOrder` was the only write transaction not wrapped in `withSqliteRetry`. Concurrent reorders could surface `SQLITE_BUSY` to the HTTP caller. Now wrapped.

## Findings (not addressed in this PR)

The following are documented in the analysis output and will need their own PRs:

- **Security (high):** outbound credential leak in `services/favorites.ts` `downloadFile` (forwards Booru basic-auth header to whatever host the remote API returns), no rate-limit on `/auth/register` and `/auth/login`, session tokens stored cleartext in SQLite.
- **Bugs (critical):** mtime equality check in `lib/scanner.ts:174` and `worker.ts:242` re-hashes/re-thumbnails every file every scan due to float vs. ISO-truncated ms mismatch; FLUFFLE inverted-distance fallback in `services/tagging.ts:155-159` and `lib/sauces.ts:178` selects least-similar matches as candidates.
- **Quality:** `frontend/src/App.tsx` (4205 lines) and `backend/src/lib/dataStore.ts` (1990 lines) violate AGENTS.md §3; ~30 `console.*` call sites bypass the structured logger; ~25 silent `catch {}` blocks violate AGENTS.md §4.
- **Tests:** zero test runner installed in either backend or frontend; the entire ~6800 LOC backend surface (auth, path traversal guards, range parsing, provider rate-limit, duplicate scan engine, auto-resolve deletion logic, CORS allowlist) is untested.
- **Dependencies & infra:** Node 20 base images reached EOL 2026-04-30; backend `package.json` declares Fastify 5.x but lockfile resolves Fastify 4.29.1 (`npm ci` will install the wrong major); rollup/esbuild/postcss/lodash advisories pending `npm audit fix`.
- **Performance:** N+1 queries in `worker.ts` `runProviderRefresh` and `pickMissingProviderRun`; `findDuplicates` loads every `FileRecord` into memory before filtering by mediaType; `ORDER BY RANDOM()` full-scan in `listFilesWithoutProviderRun`; missing index on `folders.user_id`.

## Test plan
- [ ] Backend `npm run build` passes (verified locally).
- [ ] Frontend `vite build` passes (verified locally).
- [ ] Manual: in dev, set `ALLOWED_ORIGINS=http://localhost:5174` (or whatever the frontend origin is) and confirm the app loads and authenticates.
- [ ] Manual: in production behind HTTPS, confirm the `gooncave_session` cookie is now flagged `Secure` (DevTools → Application → Cookies).
- [ ] Manual: with two duplicate favorites of different ranks, confirm the "preferred favorite source" suggestion is now honored by auto-resolve.
- [ ] Manual: `curl -i -H 'Range: bytes=-' /files/<id>/content` returns 416 (was 206).

---
*Generated automatically by Codebase Analyst — 2026-05-09*