### PR TITLE
ci(security): add dependency-review for PRs (delta enforcement)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,6 +36,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  dependency-review:
+    name: Dependency review (PR delta)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Fails the PR only on dependencies the diff introduces or bumps to a
+      # vulnerable version. Absolute-state enforcement still happens on push
+      # to main and on the nightly schedule.
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+
   npm-audit:
     name: NPM audit (${{ matrix.package_dir }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `actions/dependency-review-action` job to `security.yml`, gated on `pull_request`.
- Fails a PR only on **new** dependencies (or bumps to vulnerable versions) at HIGH+ severity. Diffs against the base ref.
- Push to `main` and the nightly schedule keep enforcing absolute-state `npm audit` + Trivy scans, so world-changed CVEs still surface — just not as a PR-blocker for advisories the author didn't introduce.

## Why

PR #46 passed CI then turned `main` red because the existing PR thresholds are intentionally laxer (`AUDIT_LEVEL=critical`, Trivy `CRITICAL` + `exit-code: 0`) while push/main enforce `high`. That asymmetry is fine in principle but produced the "merged green, main red" surprise on the `fast-uri` HIGH advisories.

Aligning thresholds would have blocked PR #46 for an advisory it didn't introduce — that author would have inherited a dependency cleanup they weren't asked for. Delta-based review fixes the UX without giving up enforcement on `main`.

## Test plan

- [ ] CI runs `Dependency review (PR delta)` on this PR.
- [ ] Job is green here (this PR adds no dependencies).
- [ ] `npm-audit` and `container-scan` still run on this PR (PR-level thresholds unchanged).
- [ ] After merge, push-to-main run still enforces `high` / `HIGH,CRITICAL` exit-1.

Closes part of #52.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>