### PR TITLE
ci(pr-review): skip Dependabot PRs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -23,7 +23,13 @@ concurrency:
 jobs:
   review:
     # Skip forked PRs: secrets.CLAUDE_CODE_OAUTH_TOKEN non e' esposto su pull_request da fork.
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+    # Skip Dependabot PRs: girano con Dependabot secrets (store separato), CLAUDE_CODE_OAUTH_TOKEN
+    # non e' disponibile -> l'action crasha. Bump deterministici di versione: il test suite e
+    # security.yml (npm-audit + dependency-review) sono il gate giusto, non la review LLM.
+    if: >-
+      github.event.pull_request.draft == false
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Skip the Claude review job for PRs authored by `dependabot[bot]`.
- Dependabot PRs run with **Dependabot secrets** — a separate restricted store where `CLAUDE_CODE_OAUTH_TOKEN` is not available. The action crashes at token init, producing a red check on every Dependabot PR (the latest batch shows six failed runs on PRs #55–#60).

## Why not just review them anyway

- Version bumps are deterministic. The right gate for breaking changes is the test suite + `security.yml` (`npm-audit` + the new `dependency-review`).
- Adding `CLAUDE_CODE_OAUTH_TOKEN` to Dependabot secrets would unblock review but spend tokens on diffs an LLM cannot meaningfully judge.
- Six failed checks per Dependabot batch creates noise that drowns real failures.

## Implementation

Extends the existing `if:` guard. Forked PRs and drafts are still skipped.

## Test plan

- [ ] This PR runs the review job (current branch is not Dependabot-authored).
- [ ] After merge, the next Dependabot PR shows the `review` job skipped, not failed.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>