### PR TITLE
fix: disable Secure cookie flag in default docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       # Default compose listens on plain HTTP, so the session cookie cannot use the
       # `Secure` attribute (browsers drop Secure cookies on http://). Flip this to
       # "true" if you put an HTTPS reverse proxy in front of the api.
-      AUTH_COOKIE_SECURE: "false"
+      AUTH_COOKIE_SECURE: "${AUTH_COOKIE_SECURE:-false}"
       TAGGER_URL: http://tagger:8000
       FOLDER_PATHS:
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,10 @@ services:
       PORT: 4100
       NODE_ENV: production
       ALLOWED_ORIGINS: http://localhost:4100
+      # Default compose listens on plain HTTP, so the session cookie cannot use the
+      # `Secure` attribute (browsers drop Secure cookies on http://). Flip this to
+      # "true" if you put an HTTPS reverse proxy in front of the api.
+      AUTH_COOKIE_SECURE: "false"
       TAGGER_URL: http://tagger:8000
       FOLDER_PATHS:
     volumes:


### PR DESCRIPTION
## Summary

Login worked, but immediately kicked the user back to the login screen. Root cause: the session cookie was being set with the `Secure` attribute, and the bundled compose listens on plain HTTP, so the browser silently dropped it. Next request had no cookie, hit the auth guard, returned 401, frontend cleared `authUser` and showed the login form again.

## What changed

`docker-compose.yml` (api service): set `AUTH_COOKIE_SECURE: "false"` and add a comment explaining when to flip it.

The default compose is the smoke-test config that ships to every fresh user — it has to work over `http://localhost:4100` out of the box. Users putting an HTTPS reverse proxy in front opt back in to Secure cookies via the env var.

## Why this happened

#46 hardened cookie security: it removed the hardcoded `secure: false` and made `cookieSecure` env-driven, defaulting to `true` when `NODE_ENV=production`. That's the right default for prod-fronted-by-HTTPS, but the bundled compose sets `NODE_ENV=production` while exposing plain HTTP. The two defaults collide and break login.

The env knob already exists in `backend/src/config.ts` (`AUTH_COOKIE_SECURE`); this PR just wires it correctly for the shipped compose.

## Why CI didn't catch it

`.github/workflows/ci.yml` only runs lint, typecheck, vite build, and `docker build`. No `npm test`, no integration test, no e2e. Filed #67 to expand CI coverage (Playwright e2e + auth/cookie unit tests would have caught this exact regression).

## Reviewer notes

- Single-file change. No code touched, only compose env.
- Security posture unchanged for non-default deployments: anyone running outside this compose still gets the production default (Secure=true).
- README does not currently document `AUTH_COOKIE_SECURE`. Worth a follow-up doc PR but kept out of scope here per AGENTS.md §19.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>