### PR TITLE
fix(duplicates): tighten default thresholds, collapse advanced UI

### DIFF
--- a/backend/src/lib/duplicates.ts
+++ b/backend/src/lib/duplicates.ts
@@ -65,8 +65,8 @@ type ResolvedPath = { path: string; cleanup: () => Promise<void> };
 
 const defaultOptions = {
   mediaType: 'ALL' as const,
-  pixelThreshold: 0.02,
-  sampleSize: 64,
+  pixelThreshold: 0.005,
+  sampleSize: 96,
   videoFrames: 3,
   maxComparisons: 2000
 };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3356,8 +3356,12 @@ function App() {
                     <summary className="text-secondary small">Advanced</summary>
                     <div className="d-flex flex-wrap gap-3 align-items-end mt-2">
                       <div>
-                        <div className="text-secondary small mb-1">Pixel threshold</div>
+                        <label className="text-secondary small mb-1 d-block" htmlFor="duplicate-pixel-threshold">
+                          Pixel threshold
+                        </label>
                         <input
+                          id="duplicate-pixel-threshold"
+                          name="pixelThreshold"
                           className="form-control form-control-sm bg-dark text-light border-secondary"
                           type="number"
                           step="0.005"
@@ -3373,8 +3377,12 @@ function App() {
                         />
                       </div>
                       <div>
-                        <div className="text-secondary small mb-1">Sample size</div>
+                        <label className="text-secondary small mb-1 d-block" htmlFor="duplicate-sample-size">
+                          Sample size
+                        </label>
                         <input
+                          id="duplicate-sample-size"
+                          name="sampleSize"
                           className="form-control form-control-sm bg-dark text-light border-secondary"
                           type="number"
                           step="8"
@@ -3394,8 +3402,12 @@ function App() {
                         />
                       </div>
                       <div>
-                        <div className="text-secondary small mb-1">Video frames</div>
+                        <label className="text-secondary small mb-1 d-block" htmlFor="duplicate-video-frames">
+                          Video frames
+                        </label>
                         <input
+                          id="duplicate-video-frames"
+                          name="videoFrames"
                           className="form-control form-control-sm bg-dark text-light border-secondary"
                           type="number"
                           step="1"
@@ -3415,8 +3427,12 @@ function App() {
                         />
                       </div>
                       <div>
-                        <div className="text-secondary small mb-1">Max comparisons</div>
+                        <label className="text-secondary small mb-1 d-block" htmlFor="duplicate-max-comparisons">
+                          Max comparisons
+                        </label>
                         <input
+                          id="duplicate-max-comparisons"
+                          name="maxComparisons"
                           className="form-control form-control-sm bg-dark text-light border-secondary"
                           type="number"
                           step="100"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -522,8 +522,8 @@ function App() {
   const [duplicateSettings, setDuplicateSettings] = useState<DuplicateSettings>({ autoResolve: false });
   const [duplicateOptions, setDuplicateOptions] = useState<DuplicateScanOptions>({
     mediaType: 'ALL',
-    pixelThreshold: 0.02,
-    sampleSize: 64,
+    pixelThreshold: 0.005,
+    sampleSize: 96,
     videoFrames: 3,
     maxComparisons: 2000
   });
@@ -3344,86 +3344,6 @@ function App() {
                         <option value="VIDEO">Videos</option>
                       </select>
                     </div>
-                    <div>
-                      <div className="text-secondary small mb-1">Pixel threshold</div>
-                      <input
-                        className="form-control form-control-sm bg-dark text-light border-secondary"
-                        type="number"
-                        step="0.01"
-                        min={0}
-                        max={0.2}
-                        value={duplicateOptions.pixelThreshold ?? 0.02}
-                        onChange={(event) =>
-                          setDuplicateOptions((prev) => ({
-                            ...prev,
-                            pixelThreshold: clamp(toNumberOr(event.target.value, prev.pixelThreshold ?? 0.02), 0, 0.2)
-                          }))
-                        }
-                      />
-                    </div>
-                    <div>
-                      <div className="text-secondary small mb-1">Sample size</div>
-                      <input
-                        className="form-control form-control-sm bg-dark text-light border-secondary"
-                        type="number"
-                        step="8"
-                        min={8}
-                        max={256}
-                        value={duplicateOptions.sampleSize ?? 64}
-                        onChange={(event) =>
-                          setDuplicateOptions((prev) => ({
-                            ...prev,
-                            sampleSize: clamp(
-                              Number.parseInt(event.target.value, 10) || (prev.sampleSize ?? 64),
-                              8,
-                              256
-                            )
-                          }))
-                        }
-                      />
-                    </div>
-                    <div>
-                      <div className="text-secondary small mb-1">Video frames</div>
-                      <input
-                        className="form-control form-control-sm bg-dark text-light border-secondary"
-                        type="number"
-                        step="1"
-                        min={1}
-                        max={8}
-                        value={duplicateOptions.videoFrames ?? 3}
-                        onChange={(event) =>
-                          setDuplicateOptions((prev) => ({
-                            ...prev,
-                            videoFrames: clamp(
-                              Number.parseInt(event.target.value, 10) || (prev.videoFrames ?? 3),
-                              1,
-                              8
-                            )
-                          }))
-                        }
-                      />
-                    </div>
-                    <div>
-                      <div className="text-secondary small mb-1">Max comparisons</div>
-                      <input
-                        className="form-control form-control-sm bg-dark text-light border-secondary"
-                        type="number"
-                        step="100"
-                        min={1}
-                        max={100000}
-                        value={duplicateOptions.maxComparisons ?? 2000}
-                        onChange={(event) =>
-                          setDuplicateOptions((prev) => ({
-                            ...prev,
-                            maxComparisons: clamp(
-                              Number.parseInt(event.target.value, 10) || (prev.maxComparisons ?? 2000),
-                              1,
-                              100000
-                            )
-                          }))
-                        }
-                      />
-                    </div>
                     <button
                       className="btn btn-outline-light btn-sm"
                       onClick={() => void loadDuplicates()}
@@ -3432,6 +3352,91 @@ function App() {
                       {duplicateState.loading ? 'Scanning…' : 'Run scan'}
                     </button>
                   </div>
+                  <details className="mb-3">
+                    <summary className="text-secondary small">Advanced</summary>
+                    <div className="d-flex flex-wrap gap-3 align-items-end mt-2">
+                      <div>
+                        <div className="text-secondary small mb-1">Pixel threshold</div>
+                        <input
+                          className="form-control form-control-sm bg-dark text-light border-secondary"
+                          type="number"
+                          step="0.005"
+                          min={0}
+                          max={0.2}
+                          value={duplicateOptions.pixelThreshold ?? 0.005}
+                          onChange={(event) =>
+                            setDuplicateOptions((prev) => ({
+                              ...prev,
+                              pixelThreshold: clamp(toNumberOr(event.target.value, prev.pixelThreshold ?? 0.005), 0, 0.2)
+                            }))
+                          }
+                        />
+                      </div>
+                      <div>
+                        <div className="text-secondary small mb-1">Sample size</div>
+                        <input
+                          className="form-control form-control-sm bg-dark text-light border-secondary"
+                          type="number"
+                          step="8"
+                          min={8}
+                          max={256}
+                          value={duplicateOptions.sampleSize ?? 96}
+                          onChange={(event) =>
+                            setDuplicateOptions((prev) => ({
+                              ...prev,
+                              sampleSize: clamp(
+                                Number.parseInt(event.target.value, 10) || (prev.sampleSize ?? 96),
+                                8,
+                                256
+                              )
+                            }))
+                          }
+                        />
+                      </div>
+                      <div>
+                        <div className="text-secondary small mb-1">Video frames</div>
+                        <input
+                          className="form-control form-control-sm bg-dark text-light border-secondary"
+                          type="number"
+                          step="1"
+                          min={1}
+                          max={8}
+                          value={duplicateOptions.videoFrames ?? 3}
+                          onChange={(event) =>
+                            setDuplicateOptions((prev) => ({
+                              ...prev,
+                              videoFrames: clamp(
+                                Number.parseInt(event.target.value, 10) || (prev.videoFrames ?? 3),
+                                1,
+                                8
+                              )
+                            }))
+                          }
+                        />
+                      </div>
+                      <div>
+                        <div className="text-secondary small mb-1">Max comparisons</div>
+                        <input
+                          className="form-control form-control-sm bg-dark text-light border-secondary"
+                          type="number"
+                          step="100"
+                          min={1}
+                          max={100000}
+                          value={duplicateOptions.maxComparisons ?? 2000}
+                          onChange={(event) =>
+                            setDuplicateOptions((prev) => ({
+                              ...prev,
+                              maxComparisons: clamp(
+                                Number.parseInt(event.target.value, 10) || (prev.maxComparisons ?? 2000),
+                                1,
+                                100000
+                              )
+                            }))
+                          }
+                        />
+                      </div>
+                    </div>
+                  </details>
                   {duplicateState.error ? <div className="text-danger mb-2">Error: {duplicateState.error}</div> : null}
                   {duplicateState.loading && duplicateScanStatus?.progress ? (
                     <div className="mb-3">


### PR DESCRIPTION
## Summary
- Default `pixelThreshold` drops from 0.02 to 0.005 and `sampleSize` rises from 64 to 96 so the scanner discriminates true re-encodes from booru alternates (recolors, dialogue swaps, expression edits) that share resolution and global structure.
- Pixel threshold, sample size, video frames, and max comparisons inputs move into an `<details>` "Advanced" disclosure. Above the fold: Auto-resolve toggle, Media filter, Run scan button — the only controls a typical user needs to reason about.
- Algorithm unchanged. Only defaults + UI shift, so opening Advanced and restoring `pixelThreshold = 0.02` reproduces previous behavior.

## Why
Issue #71 attached six pairs of distinct artworks (e621-5070673 vs 5070671, e621-4543984 vs 4543982, e621-5219356 vs 5757357, etc.) flagged as duplicates because raw L1 pixel diff under 2% with 64×64 sampling collapses localized differences (dialogue, recoloring) into a sub-threshold mean. Tighter threshold + finer grid surfaces those differences. Five unexplained numeric knobs in the default UI also added cognitive load with no clear hint to the user what each does.

## Test plan
- [x] `cd backend && npm run build` — clean
- [x] `cd frontend && npm run build` — clean
- [x] `cd backend && npm test` — 28/28 pass
- [x] `cd frontend && npm test` — 28/28 pass
- [ ] Manual: re-run scan on the `xxx/` folder pairs from issue #71 — confirm alternates no longer flagged
- [ ] Manual: re-encode one image to a new JPEG quality, scan — confirm still flagged as duplicate
- [ ] Manual: open Advanced, set `pixelThreshold` back to 0.02, scan — confirm legacy behavior reproduced

Closes #71

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>