### PR TITLE
fix: codebase analysis findings 2026-05-16

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -37,8 +37,7 @@ export const config = {
   mediaPath: defaultMediaPath(),
   frontendDir: process.env.FRONTEND_DIR ?? 'public',
   allowedOrigins: [
-    'http://localhost:5174',
-    'http://127.0.0.1:5174',
+    ...((process.env.NODE_ENV ?? 'development') !== 'production' ? ['http://localhost:5174', 'http://127.0.0.1:5174'] : []),
     ...(process.env.ALLOWED_ORIGINS ?? '')
       .split(',')
       .map((origin) => origin.trim())

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -22,7 +22,8 @@ import { clearSessionCookie, getUserFromSessionToken } from './services/auth';
 const protectedRoutePrefixes = ['/folders', '/files', '/sauces', '/duplicates', '/favorites', '/credentials', '/scans'];
 
 const isProtectedPath = (url: string) => {
-  return protectedRoutePrefixes.some((prefix) => url === prefix || url.startsWith(`${prefix}/`));
+  const pathname = new URL(url, 'http://x').pathname;
+  return protectedRoutePrefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
 };
 
 export const createServer = () => {

--- a/backend/src/lib/dataStore.ts
+++ b/backend/src/lib/dataStore.ts
@@ -457,6 +457,8 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_files_media_type ON files(media_type);
   CREATE INDEX IF NOT EXISTS idx_provider_runs_provider_file_id ON provider_runs(provider, file_id);
   CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
+  CREATE INDEX IF NOT EXISTS idx_users_username_lower ON users(LOWER(username));
+  CREATE INDEX IF NOT EXISTS idx_provider_runs_provider_created_hit ON provider_runs(provider, created_at, cached_hit);
   CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
   CREATE INDEX IF NOT EXISTS idx_sessions_token ON sessions(token);
   CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);
@@ -1636,10 +1638,6 @@ export const dataStore = {
       );
       return run;
     });
-  },
-  async listAllProviderRuns() {
-    const rows = db.prepare('SELECT * FROM provider_runs ORDER BY created_at DESC').all() as ProviderRunRow[];
-    return rows.map(mapProviderRunRow);
   },
   async listManualOrderPositions(fileIds: string[]) {
     if (fileIds.length === 0) return {};

--- a/backend/src/lib/providerRunner.ts
+++ b/backend/src/lib/providerRunner.ts
@@ -68,7 +68,6 @@ export const executeProviderRun = async (
         result.sourceUrl ?? 'n/a'
       }`;
       await logLine(message);
-      console.log(message);
     }
 
     if (updated) {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -10,7 +10,7 @@ const authSchema = z.object({
     .min(3, 'Username must be at least 3 characters')
     .max(32, 'Username must be at most 32 characters')
     .regex(/^[a-zA-Z0-9_-]+$/, 'Username can only contain letters, numbers, _ and -'),
-  password: z.string().min(8, 'Password must be at least 8 characters')
+  password: z.string().min(8, 'Password must be at least 8 characters').max(1024, 'Password must be at most 1024 characters')
 });
 
 export const registerAuthRoutes = (app: FastifyInstance) => {

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -30,7 +30,7 @@ const querySchema = z.object({
 });
 
 const manualOrderSchema = z.object({
-  order: z.array(z.string())
+  order: z.array(z.string()).max(10000)
 });
 
 const manualTagSchema = z.object({

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -31,7 +31,7 @@ export const toPublicUser = (user: UserRecord | AuthenticatedUser) => ({
 });
 
 export const hashPassword = async (password: string) => {
-  return argonHash(password, { type: argon2id });
+  return argonHash(password, { type: argon2id, memoryCost: 65536, timeCost: 3, parallelism: 4 });
 };
 
 export const verifyPassword = async (hash: string, password: string) => {

--- a/backend/src/services/favorites.ts
+++ b/backend/src/services/favorites.ts
@@ -274,8 +274,13 @@ const downloadFile = async (url: string, destPath: string, headers: Record<strin
     const text = await res.text();
     throw new Error(`Download failed (${res.status}): ${text.slice(0, 200)}`);
   }
-  await pipeline(Readable.fromWeb(res.body), fs.createWriteStream(tempPath));
-  await fs.promises.rename(tempPath, destPath);
+  try {
+    await pipeline(Readable.fromWeb(res.body), fs.createWriteStream(tempPath));
+    await fs.promises.rename(tempPath, destPath);
+  } catch (err) {
+    await fs.promises.unlink(tempPath).catch(() => undefined);
+    throw err;
+  }
 };
 
 const deleteFavoriteFile = async (userId: string, item: FavoriteItemRecord) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,7 @@ import {
   SauceSettings,
   SauceSource
 } from './api';
-import type { CredentialProvider, CredentialSummary, DuplicateScanStatus } from './api';
+import type { CredentialProvider, CredentialSummary, DuplicateScanStatus, FavoriteSyncStatus } from './api';
 
 type FetchState = {
   loading: boolean;
@@ -359,34 +359,6 @@ const isCredentialReady = (provider: CredentialProvider, credential: CredentialS
 const isGallerySort = (value: string | null): value is GallerySort =>
   value === 'manual' || value === 'mtime_desc' || value === 'mtime_asc' || value === 'random';
 
-type FavoriteSyncStatus = {
-  status: 'idle' | 'running' | 'done' | 'error';
-  message: string;
-  startedAt: string | null;
-  updatedAt: string;
-  progress: {
-    providers: {
-      provider: 'E621' | 'DANBOORU';
-      stage: 'idle' | 'fetching' | 'downloading' | 'deleting' | 'done' | 'error';
-      fetched: number;
-      total: number;
-      processed: number;
-      added: number;
-      removed: number;
-      skipped: number;
-      errors: string[];
-    }[];
-  } | null;
-  results: {
-    provider: 'E621' | 'DANBOORU';
-    fetched: number;
-    added: number;
-    removed: number;
-    skipped: number;
-    errors: string[];
-  }[];
-};
-
 const emptySauceProgress: SauceProgress = {
   total: 0,
   matched: 0,
@@ -439,6 +411,8 @@ type DuplicatePair = {
 };
 
 type DetailSwipeAxis = 'idle' | 'x' | 'y';
+
+const GALLERY_PAGE_SIZE = 200;
 
 function App() {
   const [authUser, setAuthUser] = useState<AuthUser | null>(null);
@@ -572,7 +546,6 @@ function App() {
   const [dragOverId, setDragOverId] = useState<string | null>(null);
   const [folderActionState, setFolderActionState] = useState<FetchState>({ loading: false, error: null });
   const [folderUploads, setFolderUploads] = useState<Record<string, FolderUploadState>>({});
-  const galleryPageSize = 200;
   const galleryMediaFilter =
     galleryFilters.photos && !galleryFilters.videos
       ? 'IMAGE'
@@ -688,7 +661,7 @@ function App() {
         setGalleryHasMore(cached.hasMore);
       }
       const offset = shouldPaginate ? (options.reset ? 0 : galleryOffsetRef.current) : undefined;
-      const limit = shouldPaginate ? galleryPageSize : undefined;
+      const limit = shouldPaginate ? GALLERY_PAGE_SIZE : undefined;
       setGalleryPageState({ loading: true, error: null });
       try {
         const data = await api.getFiles(galleryFolderId || undefined, gallerySort, galleryTagQuery, {
@@ -731,7 +704,7 @@ function App() {
         }
       }
     },
-    [galleryFavoritesOnly, galleryFolderId, galleryMediaFilter, galleryPageSize, galleryRandomSeed, gallerySort, galleryTagQuery]
+    [galleryFavoritesOnly, galleryFolderId, galleryMediaFilter, GALLERY_PAGE_SIZE, galleryRandomSeed, gallerySort, galleryTagQuery]
   );
 
   const refreshFolders = useCallback(async (options: { silent?: boolean } = {}) => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -229,7 +229,7 @@ type FavoriteSyncProgress = {
   skipped: number;
   errors: string[];
 };
-type FavoriteSyncStatus = {
+export type FavoriteSyncStatus = {
   status: 'idle' | 'running' | 'done' | 'error';
   message: string;
   startedAt: string | null;


### PR DESCRIPTION
## Summary

- **[security]** `auth`: add `password.max(1024)` — argon2id hashes full input, 10MB payload pegs CPU
- **[security]** `server`: strip query string before auth guard path check — `/files?x=y` was not matching `/files` prefix
- **[security]** `auth`: pin explicit argon2id params (`memoryCost: 65536, timeCost: 3, parallelism: 4`) so upstream lib default changes don't silently alter hashing behavior
- **[security]** `config`: localhost dev origins excluded in production (`NODE_ENV === 'production'`)
- **[bug]** `favorites`: cleanup `.part` temp file in `finally` block — previously leaked on network/disk error
- **[bug]** `files`: cap `manualOrderSchema` array at 10,000 items — unbounded array caused unbounded memory + SQLite `IN (...)` clause
- **[perf]** `dataStore`: add `idx_users_username_lower ON users(LOWER(username))` — case-insensitive lookup bypassed existing index
- **[perf]** `dataStore`: add `idx_provider_runs_provider_created_hit ON provider_runs(provider, created_at, cached_hit)` — rate-limit queries ran full scan per request
- **[quality]** `dataStore`: remove dead export `listAllProviderRuns` — unbounded `SELECT *` with no WHERE/LIMIT, zero callers
- **[quality]** `providerRunner`: remove redundant `console.log` — `logLine` already persists FLUFFLE debug
- **[quality]** `api/App`: export `FavoriteSyncStatus` from `api.ts`, delete duplicate local type in `App.tsx`
- **[quality]** `App`: hoist gallery page size to module-level `GALLERY_PAGE_SIZE` constant

## Findings (deferred)

- **[security-HIGH]** Thumbnails served unauthenticated — `/thumbnails` prefix missing from `protectedRoutePrefixes`; needs careful integration with `@fastify/static` hook system
- **[security-HIGH]** `autoResolveDuplicates` always uses `listUsers()[0]` — multi-user ownership concern; requires broader refactor
- **[security-MED]** Session cookie `Secure` defaults to `false` in docker-compose — deployment config, not code bug; document in README
- **[deps-HIGH]** Node.js 20 EOL (expired 2026-04-30) — bump to Node 22 in Dockerfiles + CI; deferred because it touches build config (issue-triage autofix forbidden path)
- **[deps-HIGH]** GitHub Actions floating tags (`actions/checkout@v4`, `actions/setup-node@v4`, `aquasecurity/trivy-action@v0.36.0`) — blocked by security hook; pin manually
- **[deps-MED]** `brace-expansion < 1.1.13` ReDoS in dev deps — run `npm audit fix --prefix backend`
- **[perf-HIGH]** `listFilesWithProviderRuns` unbounded SELECT in `/sauces` route — needs pagination; larger refactor
- **[perf-HIGH]** `findDuplicates` loads entire `files` table — needs streaming via `listFilesBatch`; larger refactor
- **[test]** Zero tests for upload pipeline, `autoResolveDuplicates`, cross-user IDOR, `DELETE /files/:id`

## Sub-analyst reports

- **Security**: argon2id DoS (no max), auth guard query-string bypass, unauthenticated thumbnail serving
- **Quality**: dead `listAllProviderRuns`, duplicate `FavoriteSyncStatus` type, localhost origins in prod config
- **Bugs**: `.part` file resource leak in download, unbounded `manualOrderSchema` array, `fs.existsSync` blocking in sync loop
- **Tests**: upload pipeline has zero coverage, `autoResolveDuplicates` has zero tests, no cross-user IDOR test
- **Deps**: Node 20 EOL, floating GitHub Actions tags, `brace-expansion` ReDoS in devDeps
- **Performance**: two missing DB indexes, unbounded `listFilesWithProviderRuns`, N+1 writes in `removeProviderRunResultForFile`

---
Generated automatically by Codebase Analyst — 2026-05-16