### PR TITLE
fix: codebase analysis findings 2026-05-19

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,7 +19,7 @@ import { registerHealthRoutes } from './routes/health';
 import { registerSauceRoutes } from './routes/sauces';
 import { clearSessionCookie, getUserFromSessionToken } from './services/auth';
 
-const protectedRoutePrefixes = ['/folders', '/files', '/sauces', '/duplicates', '/favorites', '/credentials', '/scans'];
+const protectedRoutePrefixes = ['/folders', '/files', '/sauces', '/duplicates', '/favorites', '/credentials', '/scans', '/thumbnails'];
 
 const isProtectedPath = (url: string) => {
   const pathname = new URL(url, 'http://x').pathname;

--- a/backend/src/lib/dataStore.ts
+++ b/backend/src/lib/dataStore.ts
@@ -436,6 +436,8 @@ db.exec(`
   );
 
   CREATE INDEX IF NOT EXISTS idx_folders_path ON folders(path);
+  CREATE INDEX IF NOT EXISTS idx_folders_user_id ON folders(user_id);
+  CREATE INDEX IF NOT EXISTS idx_favorite_items_user_id_provider ON favorite_items(user_id, provider);
   CREATE INDEX IF NOT EXISTS idx_scans_folder_id ON scans(folder_id);
   CREATE INDEX IF NOT EXISTS idx_files_folder_id ON files(folder_id);
   CREATE INDEX IF NOT EXISTS idx_files_path ON files(path);
@@ -776,23 +778,15 @@ const purgeProviderRunsIfNeeded = () => {
   if (getMeta(purgeKey)) return;
   const providers: ProviderRunRecord['provider'][] = ['SAUCENAO', 'FLUFFLE'];
   const placeholders = providers.map(() => '?').join(',');
-  const result = db
-    .prepare(`DELETE FROM provider_runs WHERE provider IN (${placeholders})`)
-    .run(...providers);
+  db.prepare(`DELETE FROM provider_runs WHERE provider IN (${placeholders})`).run(...providers);
   setMeta(purgeKey, new Date().toISOString());
-  if (result.changes > 0) {
-    console.log(`[storage] purged ${result.changes} provider runs for ${providers.join(', ')}`);
-  }
 };
 
 const purgeFileTagsIfNeeded = () => {
   const purgeKey = 'purged_file_tags_v1';
   if (getMeta(purgeKey)) return;
-  const result = db.prepare('DELETE FROM file_tags').run();
+  db.prepare('DELETE FROM file_tags').run();
   setMeta(purgeKey, new Date().toISOString());
-  if (result.changes > 0) {
-    console.log(`[storage] purged ${result.changes} file tags`);
-  }
 };
 
 purgeProviderRunsIfNeeded();

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -10,7 +10,7 @@ const authSchema = z.object({
     .min(3, 'Username must be at least 3 characters')
     .max(32, 'Username must be at most 32 characters')
     .regex(/^[a-zA-Z0-9_-]+$/, 'Username can only contain letters, numbers, _ and -'),
-  password: z.string().min(8, 'Password must be at least 8 characters').max(1024, 'Password must be at most 1024 characters')
+  password: z.string().min(8, 'Password must be at least 8 characters').max(128, 'Password must be at most 128 characters')
 });
 
 export const registerAuthRoutes = (app: FastifyInstance) => {

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -132,7 +132,7 @@ export const setSessionCookie = (reply: FastifyReply, token: string, expiresAt: 
   reply.setCookie(sessionCookieName, token, {
     path: '/',
     httpOnly: true,
-    sameSite: 'lax',
+    sameSite: 'strict',
     secure: config.auth.cookieSecure,
     expires: new Date(expiresAt)
   });
@@ -142,7 +142,7 @@ export const clearSessionCookie = (reply: FastifyReply) => {
   reply.clearCookie(sessionCookieName, {
     path: '/',
     httpOnly: true,
-    sameSite: 'lax',
+    sameSite: 'strict',
     secure: config.auth.cookieSecure
   });
 };

--- a/backend/src/services/duplicateResolver.ts
+++ b/backend/src/services/duplicateResolver.ts
@@ -61,9 +61,9 @@ const pickSuggestion = (a: { id: string; favoriteProviders: FavoriteProvider[] }
 };
 
 const deleteFileRecord = async (fileId: string, userId: string) => {
-  const file = await dataStore.findFileById(fileId);
+  const file = await dataStore.findFileById(fileId, userId);
   if (!file) return false;
-  const folder = await dataStore.findFolderById(file.folderId);
+  const folder = await dataStore.findFolderById(file.folderId, userId);
   if (!folder || folder.type !== 'LOCAL') return false;
   const favoriteItem = await dataStore.findFavoriteItemByPath(file.path, userId);
   if (favoriteItem) return false;

--- a/backend/test/auth.production-cookie.test.ts
+++ b/backend/test/auth.production-cookie.test.ts
@@ -43,7 +43,7 @@ test('production env with AUTH_COOKIE_SECURE=false: Set-Cookie has no Secure fla
   const parsed = parseSetCookieFlags(getRawSetCookie(res.headers['set-cookie']));
   assert.equal(parsed.name, 'gooncave_session');
   assert.ok(parsed.flags.has('httponly'), 'cookie missing HttpOnly');
-  assert.equal(parsed.sameSite, 'lax');
+  assert.equal(parsed.sameSite, 'strict');
   assert.equal(
     parsed.flags.has('secure'),
     false,

--- a/backend/test/auth.routes.test.ts
+++ b/backend/test/auth.routes.test.ts
@@ -16,7 +16,7 @@ after(async () => {
   await app.close();
 });
 
-test('POST /auth/register creates user and sets HttpOnly+Lax cookie', async () => {
+test('POST /auth/register creates user and sets HttpOnly+Strict cookie', async () => {
   const res = await app.inject({
     method: 'POST',
     url: '/auth/register',
@@ -28,7 +28,7 @@ test('POST /auth/register creates user and sets HttpOnly+Lax cookie', async () =
   const parsed = parseSetCookieFlags(getRawSetCookie(res.headers['set-cookie']));
   assert.equal(parsed.name, 'gooncave_session');
   assert.ok(parsed.flags.has('httponly'), 'cookie missing HttpOnly');
-  assert.equal(parsed.sameSite, 'lax');
+  assert.equal(parsed.sameSite, 'strict');
   // NODE_ENV=test → cookieSecure should default to false. This is the
   // regression guard for #67 (Secure cookie on plain HTTP locked users out).
   assert.equal(parsed.flags.has('secure'), false, 'Secure must be off in non-prod');

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,7 @@ import {
   SauceSettings,
   SauceSource
 } from './api';
-import type { CredentialProvider, CredentialSummary, DuplicateScanStatus, FavoriteSyncStatus } from './api';
+import type { CredentialProvider, CredentialSummary, DuplicateScanStatus, FavoriteSyncStatus, ProviderRun } from './api';
 
 type FetchState = {
   loading: boolean;
@@ -347,7 +347,6 @@ const providerScoreThresholds: Record<ProviderKind, number> = {
   SAUCENAO: 90,
   FLUFFLE: 95
 };
-const showProviderRunButtons = false;
 const authUsernameRegex = /^[a-zA-Z0-9_-]+$/;
 
 const isCredentialReady = (provider: CredentialProvider, credential: CredentialSummary | undefined) => {
@@ -437,7 +436,7 @@ function App() {
   const [galleryTagQuery, setGalleryTagQuery] = useState('');
   const [galleryTagInput, setGalleryTagInput] = useState('');
   const [selectedFile, setSelectedFile] = useState<FileItem | null>(null);
-  const [providerInfo, setProviderInfo] = useState<any[]>([]);
+  const [providerInfo, setProviderInfo] = useState<ProviderRun[]>([]);
   const [providerState, setProviderState] = useState<FetchState>({ loading: false, error: null });
   const [viewMode, setViewMode] = useState<ViewMode>('gallery');
   const [fetchState, setFetchState] = useState<FetchState>({ loading: false, error: null });
@@ -4114,24 +4113,6 @@ function App() {
                   <span className="file-detail-button-text">Scan</span>
                 </button>
               </div>
-              {showProviderRunButtons ? (
-                <div className="d-flex flex-wrap gap-2 mb-2">
-                  <button
-                    className="btn btn-outline-light w-100"
-                    disabled={providerState.loading}
-                    onClick={() => void onRunProvider('saucenao')}
-                  >
-                    {providerState.loading ? 'Running...' : 'SauceNAO'}
-                  </button>
-                  <button
-                    className="btn btn-outline-light w-100"
-                    disabled={providerState.loading}
-                    onClick={() => void onRunProvider('fluffle')}
-                  >
-                    {providerState.loading ? 'Running...' : 'Fluffle'}
-                  </button>
-                </div>
-              ) : null}
               <div className="text-secondary small mb-3">
                 <div>
                   <span className="fw-semibold file-detail-label">Provider scans:</span>{' '}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -180,7 +180,7 @@ export type FolderUploadProgress = { loaded: number; total: number | null; perce
 type FilesResponse = { files: FileItem[]; total?: number };
 type SauceResponse = { sources: SauceSource[]; settings: SauceSettings; progress: SauceProgress };
 type TagsResponse = { tags: FileTag[] };
-type ProviderRun = {
+export type ProviderRun = {
   id: string;
   fileId: string;
   provider: 'SAUCENAO' | 'FLUFFLE';


### PR DESCRIPTION
## Summary

- **Security**: Reduce password max length 1024→128 bytes to limit Argon2id memory exhaustion under concurrent load
- **Security**: Add `/thumbnails/` to protected route prefixes — thumbnails were publicly accessible without authentication
- **Security**: Upgrade session cookie `sameSite: lax` → `strict` per AGENTS.md §10 (CSRF protection)
- **Bug (critical)**: Fix authorization bypass in `duplicateResolver.ts` — `findFileById`/`findFolderById` were called without `userId`, allowing cross-user file deletion in multi-user deployments
- **Quality**: Remove `console.log` from one-shot purge functions (`purgeProviderRunsIfNeeded`, `purgeFileTagsIfNeeded`)
- **Quality**: Remove dead `showProviderRunButtons = false` constant and permanently-dead JSX block it gated
- **Quality**: Fix `useState<any[]>` → `useState<ProviderRun[]>` in App.tsx; export `ProviderRun` type from api.ts
- **Performance**: Add `idx_folders_user_id` index — every `listFolders` query filters on `user_id` with no index
- **Performance**: Add `idx_favorite_items_user_id_provider` composite index — `listFavoriteItems` queries on `user_id + provider` with only a single-column `provider` index

## Findings (deferred — higher risk or larger scope)

- **Security**: No rate limiting on `POST /auth/login` and `POST /auth/register` — requires middleware (e.g. `@fastify/rate-limit`)
- **Security**: File upload validated by extension only, no magic-byte check — requires `file-type` package
- **Security**: Raw `Error.message` returned in 500 responses (exposes internal paths) — needs audit of all catch blocks
- **Bug**: `autoResolveDuplicates` hard-codes `listUsers()[0]` — silently skips all users except the first
- **Bug**: Parameter order mismatch in `listFilesPage` SQL when `sort=random` with filters — needs careful SQL audit
- **Bug**: Unguarded path traversal in `downloadFile` — `resolveFavoriteFilePath` can return paths outside library root
- **Bug**: Temp dir leak in `extractVideoFrames` on ffmpeg error — needs careful error-path cleanup
- **Deps**: Frontend lockfile stale — `vite@5.4.21` installed vs `^8.0.13` declared; requires manual `npm install --prefix frontend`
- **Deps**: `ws`, `ajv`, `brace-expansion` CVEs — all dev-only paths; fix via lockfile update
- **Quality**: Score thresholds duplicated in 4 places; `isPathInside` defined 3 times; `normalizeTag` duplicated
- **Quality**: `deleteExpiredSessions` called on every authenticated request — should move to worker periodic job
- **Performance**: `listFilesWithProviderRuns` unbounded SELECT (loads full library on every sauce page load)
- **Performance**: N+1 DB writes per synced favorite item in `syncProvider`

## Sub-analyst reports

- **Security**: Password DoS (Argon2id), unauthenticated thumbnails, no rate limiting on auth, extension-only upload validation, raw Error.message in 500s, sameSite=lax
- **Quality**: Dead params in duplicates, `any` type in state, 4× duplicated score thresholds, 3× `isPathInside`, dead `showProviderRunButtons`
- **Bugs**: Auth bypass in duplicateResolver (critical), single-user hardcode in autoResolveDuplicates, SQL param order bug, unguarded disk write in favorites
- **Tests**: Favorites routes (0 HTTP tests), `POST /files/:id/providers/:provider`, manual-order endpoint, `syncUserLibraryRoot` branches
- **Deps**: `ws` (vite transitive), `ajv`/`brace-expansion` (eslint transitive), floating GH Actions tags, stale frontend lockfile
- **Performance**: Missing `folders.user_id` index, missing `favorite_items(user_id,provider)` index, unbounded SELECT in sauces, N+1 in favorites sync

---
Generated automatically by Codebase Analyst — 2026-05-19