### PR TITLE
feat(booru): per-user booru sites with engine abstraction (#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Features:
 
 - local-first media library
 - browse your files with a booru style interface
-- dual-way favorites sync and files tagging with e621 and danbooru
+- add your own booru sites per account — the engine (Danbooru, e621, Moebooru, Gelbooru, Sankaku, Philomena, Shimmie2, Szurubooru) is auto-detected from the URL
+- dual-way favorites sync (e621/Danbooru) and tag fetch / source matching across every configured site
 - support for multiple accounts
 - star your favorite files
 - duplicate check system

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,8 +8,10 @@ import fastifyStaticPlugin from '@fastify/static';
 import Fastify from 'fastify';
 
 import { config } from './config';
+import { seedBooruSitesFromLegacyCredentials } from './lib/booruSitesSeed';
 import { registerAdminRoutes } from './routes/admin';
 import { registerAuthRoutes } from './routes/auth';
+import { registerBooruSiteRoutes } from './routes/booruSites';
 import { registerCredentialRoutes } from './routes/credentials';
 import { registerDuplicateRoutes } from './routes/duplicates';
 import { registerFavoritesRoutes } from './routes/favorites';
@@ -19,7 +21,7 @@ import { registerHealthRoutes } from './routes/health';
 import { registerSauceRoutes } from './routes/sauces';
 import { clearSessionCookie, getUserFromSessionToken } from './services/auth';
 
-const protectedRoutePrefixes = ['/folders', '/files', '/sauces', '/duplicates', '/favorites', '/credentials', '/scans', '/thumbnails'];
+const protectedRoutePrefixes = ['/folders', '/files', '/sauces', '/duplicates', '/favorites', '/credentials', '/booru-sites', '/scans', '/thumbnails'];
 
 const isProtectedPath = (url: string) => {
   const pathname = new URL(url, 'http://x').pathname;
@@ -107,6 +109,7 @@ export const createServer = () => {
   registerDuplicateRoutes(app);
   registerFavoritesRoutes(app);
   registerCredentialRoutes(app);
+  registerBooruSiteRoutes(app);
 
   return app;
 };
@@ -114,6 +117,13 @@ export const createServer = () => {
 const start = async () => {
   const app = createServer();
   try {
+    const seedResult = await seedBooruSitesFromLegacyCredentials();
+    if (seedResult.insertedRows > 0) {
+      app.log.info(
+        { ...seedResult },
+        `Seeded ${seedResult.insertedRows} booru preset row(s) from existing credentials`
+      );
+    }
     await app.listen({ port: config.port, host: config.host });
     app.log.info(`Server listening on ${config.host}:${config.port}`);
   } catch (err) {

--- a/backend/src/lib/booruEngines/danbooru.ts
+++ b/backend/src/lib/booruEngines/danbooru.ts
@@ -1,0 +1,210 @@
+import { fetch } from 'undici';
+
+import { config } from '../../config';
+import type { BooruSiteRecord } from '../dataStore';
+
+import { basicAuthHeader, normalizeTag, safeJoin } from './helpers';
+import type { BooruEngineModule, BooruRemoteFavorite, TagResult } from './types';
+
+type DanbooruPost = {
+  id?: number | string | null;
+  file_url?: string | null;
+  large_file_url?: string | null;
+  preview_file_url?: string | null;
+  image_width?: number | null;
+  image_height?: number | null;
+  rating?: string | null;
+  tag_string?: string | null;
+  tag_string_general?: string;
+  tag_string_artist?: string;
+  tag_string_character?: string;
+  tag_string_copyright?: string;
+  tag_string_meta?: string;
+};
+
+type DanbooruResponse =
+  | DanbooruPost[]
+  | { post?: DanbooruPost | null; posts?: DanbooruPost[] | null };
+
+const userAgent = () => config.e621.userAgent;
+
+const escapeRegex = (value: string): string => value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+
+const buildDanbooruTags = (data: DanbooruPost | null | undefined): TagResult[] => {
+  const bucket: TagResult[] = [];
+  const pushTags = (category: string, value?: string) => {
+    if (!value) return;
+    value
+      .split(' ')
+      .map((tag) => normalizeTag(tag))
+      .filter(Boolean)
+      .forEach((tag) => bucket.push({ tag, category }));
+  };
+  pushTags('general', data?.tag_string_general);
+  pushTags('artist', data?.tag_string_artist);
+  pushTags('character', data?.tag_string_character);
+  pushTags('copyright', data?.tag_string_copyright);
+  pushTags('meta', data?.tag_string_meta);
+  return bucket;
+};
+
+const buildHeaders = (site: BooruSiteRecord): Record<string, string> => {
+  const headers: Record<string, string> = { 'User-Agent': userAgent() };
+  if (site.username && site.apiKey) {
+    headers.Authorization = basicAuthHeader(site.username, site.apiKey);
+  }
+  return headers;
+};
+
+const danbooruRegex = (host: string) =>
+  new RegExp(`^https?://(?:www\\.)?${escapeRegex(host)}/(?:posts|post/show)/(\\d+)`, 'i');
+
+export const danbooruEngine: BooruEngineModule = {
+  type: 'danbooru',
+  credentialSchema: 'username+apikey',
+  defaultCapabilities: { favorites: true, tags: true, sourceMatch: true, search: true },
+  defaultUserAgent: '',
+  probePath: '/posts.json?limit=1',
+  probeMatches: (body: unknown): boolean => {
+    if (!Array.isArray(body) || body.length === 0) return false;
+    const first = body[0];
+    if (!first || typeof first !== 'object') return false;
+    return typeof (first as DanbooruPost).tag_string_general === 'string';
+  },
+  probeSample: (body: unknown) => {
+    const post = Array.isArray(body) ? (body[0] as DanbooruPost | undefined) : null;
+    if (!post?.id) return null;
+    const id = String(post.id);
+    return {
+      postId: id,
+      thumbUrl: post.preview_file_url ?? null,
+      postPath: `/posts/${id}`
+    };
+  },
+
+  async fetchPostTags(site, postId): Promise<TagResult[]> {
+    if (!site.username || !site.apiKey) return [];
+    const res = await fetch(safeJoin(site.baseUrl, `/posts/${postId}.json`), { headers: buildHeaders(site) });
+    const text = await res.text();
+    if (!res.ok) {
+      console.warn(`[tags] danbooru fetch failed (${res.status}): ${text.slice(0, 200)}`);
+      return [];
+    }
+    let data: DanbooruPost;
+    try {
+      data = JSON.parse(text) as DanbooruPost;
+    } catch {
+      console.warn(`[tags] danbooru parse failed: ${text.slice(0, 200)}`);
+      return [];
+    }
+    return buildDanbooruTags(data);
+  },
+
+  async fetchPostByMd5(site, md5) {
+    if (!site.username || !site.apiKey) return null;
+    const res = await fetch(safeJoin(site.baseUrl, `/posts.json?md5=${md5}`), { headers: buildHeaders(site) });
+    const text = await res.text();
+    if (!res.ok) {
+      console.warn(`[tags] danbooru md5 fetch failed (${res.status}): ${text.slice(0, 200)}`);
+      return null;
+    }
+    let data: DanbooruResponse;
+    try {
+      data = JSON.parse(text) as DanbooruResponse;
+    } catch {
+      console.warn(`[tags] danbooru md5 parse failed: ${text.slice(0, 200)}`);
+      return null;
+    }
+    const post = Array.isArray(data)
+      ? data[0]
+      : data?.post ?? (Array.isArray(data?.posts) ? data!.posts![0] : null);
+    if (!post) return null;
+    const tags = buildDanbooruTags(post);
+    const postId = post.id ? String(post.id) : null;
+    return { tags, sourceUrl: postId ? safeJoin(site.baseUrl, `/posts/${postId}`) : null };
+  },
+
+  async fetchFavorites(site, ctx) {
+    if (!site.username || !site.apiKey) {
+      throw new Error(`${site.name} credentials missing`);
+    }
+    const headers = buildHeaders(site);
+    const items: BooruRemoteFavorite[] = [];
+    const limit = 200;
+    let page = 1;
+    for (;;) {
+      const params = new URLSearchParams({
+        tags: `fav:${site.username}`,
+        limit: String(limit),
+        page: String(page)
+      });
+      const res = await fetch(safeJoin(site.baseUrl, `/posts.json?${params.toString()}`), { headers });
+      const text = await res.text();
+      if (!res.ok) {
+        throw new Error(`${site.name} favorites failed (${res.status}): ${text.slice(0, 200)}`);
+      }
+      let data: DanbooruResponse;
+      try {
+        data = JSON.parse(text) as DanbooruResponse;
+      } catch {
+        throw new Error(`${site.name} favorites parse failed: ${text.slice(0, 200)}`);
+      }
+      const posts = Array.isArray(data) ? data : Array.isArray(data.posts) ? data.posts : [];
+      if (!posts.length) break;
+      ctx?.onPage?.(page, posts.length);
+      for (const post of posts) {
+        const id = post?.id ? String(post.id) : null;
+        const fileUrl = post?.file_url ?? post?.large_file_url ?? null;
+        if (!id) continue;
+        items.push({
+          provider: site.id,
+          remoteId: id,
+          sourceUrl: safeJoin(site.baseUrl, `/posts/${id}`),
+          fileUrl
+        });
+      }
+      if (posts.length < limit) break;
+      page += 1;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+    return { items, downloadHeaders: headers };
+  },
+
+  async favorite(site, postId) {
+    if (!site.username || !site.apiKey) throw new Error(`${site.name} credentials missing`);
+    const body = new URLSearchParams({ post_id: postId });
+    const res = await fetch(safeJoin(site.baseUrl, '/favorites.json'), {
+      method: 'POST',
+      headers: {
+        ...buildHeaders(site),
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body
+    });
+    if (res.ok || res.status === 422) return;
+    const text = await res.text();
+    throw new Error(`${site.name} favorite failed (${res.status}): ${text.slice(0, 200)}`);
+  },
+
+  async unfavorite(site, postId) {
+    if (!site.username || !site.apiKey) throw new Error(`${site.name} credentials missing`);
+    const res = await fetch(safeJoin(site.baseUrl, `/favorites/${postId}.json`), {
+      method: 'DELETE',
+      headers: buildHeaders(site)
+    });
+    if (res.ok || res.status === 404) return;
+    const text = await res.text();
+    throw new Error(`${site.name} unfavorite failed (${res.status}): ${text.slice(0, 200)}`);
+  },
+
+  extractIdFromUrl(url, site) {
+    const host = new URL(site.baseUrl).hostname.replace(/^www\./, '').toLowerCase();
+    const match = url.match(danbooruRegex(host));
+    if (!match?.[1]) return null;
+    return { remoteId: match[1] };
+  },
+
+  buildPostUrl(site, postId) {
+    return safeJoin(site.baseUrl, `/posts/${postId}`);
+  }
+};

--- a/backend/src/lib/booruEngines/detect.test.ts
+++ b/backend/src/lib/booruEngines/detect.test.ts
@@ -1,0 +1,109 @@
+// Detection is the riskiest new logic (AGENTS.md §9): hostname lookup, a
+// parallel probe race, JSON-vs-XML body dispatch, and unreachable-vs-unknown
+// classification. We pin it with undici's MockAgent so no real network is hit.
+import '../../../test/helpers/setupEnv';
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+
+import { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from 'undici';
+
+import { detectEngine } from './detect';
+
+let mockAgent: MockAgent;
+let originalDispatcher: ReturnType<typeof getGlobalDispatcher>;
+
+beforeEach(() => {
+  originalDispatcher = getGlobalDispatcher();
+  mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+});
+
+afterEach(async () => {
+  setGlobalDispatcher(originalDispatcher);
+  await mockAgent.close();
+});
+
+// Helper: reply 200 with the given JSON to the engine's probe path, and 404 to
+// any other path on that origin so the non-matching engines settle cleanly.
+const replyJson = (origin: string, path: string, body: unknown) => {
+  const pool = mockAgent.get(origin);
+  // .persist() because some engines share a probe path (e621 and danbooru both
+  // GET /posts.json?limit=1); both requests must receive the same body so the
+  // shape check decides the winner, not request ordering.
+  pool.intercept({ path, method: 'GET' }).reply(200, JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' }
+  }).persist();
+};
+
+test('detectEngine identifies danbooru by its probe shape', async () => {
+  const origin = 'https://booru.example.com';
+  // danbooru probe path is /posts.json?limit=1; reply with the flat
+  // tag_string_general shape only danbooru matches.
+  replyJson(origin, '/posts.json?limit=1', [
+    { id: 5, tag_string_general: 'cat dog', preview_file_url: '/p/5.jpg' }
+  ]);
+  // Every other engine probe on this origin 404s.
+  mockAgent.get(origin).intercept({ path: /.*/, method: 'GET' }).reply(404, '').persist();
+
+  const result = await detectEngine(origin);
+  assert.ok('engine' in result, `expected success, got ${JSON.stringify(result)}`);
+  if ('engine' in result) {
+    assert.equal(result.engine, 'danbooru');
+    assert.equal(result.confidence, 'probe');
+    assert.equal(result.sample?.postId, '5');
+  }
+});
+
+test('detectEngine returns unknown when every engine responds 200 but none match', async () => {
+  const origin = 'https://mystery.example.com';
+  // All probe paths reply 200 with a body no engine recognizes.
+  mockAgent
+    .get(origin)
+    .intercept({ path: /.*/, method: 'GET' })
+    .reply(200, JSON.stringify({ unrelated: true }), { headers: { 'content-type': 'application/json' } })
+    .persist();
+
+  const result = await detectEngine(origin);
+  assert.ok('error' in result);
+  if ('error' in result) {
+    assert.equal(result.error, 'unknown');
+    assert.ok(result.attempts.length > 0);
+    assert.ok(result.attempts.every((a) => a.status === 'no-match'));
+  }
+});
+
+test('detectEngine returns unreachable when no engine gets an HTTP reply', async () => {
+  // No intercepts registered + disableNetConnect => every probe rejects at the
+  // network level, which must classify as unreachable, not unknown.
+  const result = await detectEngine('https://offline.example.com');
+  assert.ok('error' in result);
+  if ('error' in result) {
+    assert.equal(result.error, 'unreachable');
+  }
+});
+
+test('detectEngine rejects non-http(s) URLs without probing', async () => {
+  const result = await detectEngine('ftp://example.com');
+  assert.ok('error' in result);
+  if ('error' in result) {
+    assert.equal(result.error, 'unknown');
+    assert.equal(result.attempts.length, 0);
+  }
+});
+
+test('detectEngine uses hostname lookup for known hosts (confidence: hostname)', async () => {
+  // e621.net is in HOSTNAME_MAP. The hostname path still probes for a sample;
+  // reply with a valid e621 body so the sample is populated.
+  replyJson('https://e621.net', '/posts.json?limit=1', {
+    posts: [{ id: 7, preview: { url: '/p/7.jpg' }, tags: { general: ['cat'] } }]
+  });
+  const result = await detectEngine('https://e621.net');
+  assert.ok('engine' in result);
+  if ('engine' in result) {
+    assert.equal(result.engine, 'e621');
+    assert.equal(result.confidence, 'hostname');
+    assert.equal(result.sample?.postId, '7');
+  }
+});

--- a/backend/src/lib/booruEngines/detect.ts
+++ b/backend/src/lib/booruEngines/detect.ts
@@ -1,0 +1,210 @@
+import { fetch } from 'undici';
+
+import { config } from '../../config';
+import type { BooruEngineType } from '../dataStore';
+
+import { safeJoin, stripTrailingSlash } from './helpers';
+import { ENGINE_REGISTRY } from './index';
+import type { ProbeSample } from './types';
+
+export type DetectionAttemptStatus =
+  | 'matched'
+  | 'no-match'
+  | 'http-error'
+  | 'network-error'
+  | 'timeout';
+
+export type DetectionAttempt = {
+  engine: BooruEngineType;
+  status: DetectionAttemptStatus;
+  httpStatus?: number;
+  error?: string;
+};
+
+export type DetectionResult = {
+  engine: BooruEngineType;
+  confidence: 'hostname' | 'probe';
+  sample: ProbeSample | null;
+  attempts: DetectionAttempt[];
+};
+
+export type DetectionFailure =
+  | { error: 'unknown'; tried: BooruEngineType[]; attempts: DetectionAttempt[] }
+  | { error: 'unreachable'; message: string; attempts: DetectionAttempt[] };
+
+const HOSTNAME_MAP: Array<{ pattern: RegExp; engine: BooruEngineType }> = [
+  { pattern: /(^|\.)e621\.net$/i, engine: 'e621' },
+  { pattern: /(^|\.)e926\.net$/i, engine: 'e621' },
+  { pattern: /(^|\.)donmai\.us$/i, engine: 'danbooru' },
+  { pattern: /^gelbooru\.com$/i, engine: 'gelbooru' },
+  { pattern: /^rule34\.xxx$/i, engine: 'gelbooru' },
+  { pattern: /^safebooru\.org$/i, engine: 'gelbooru' },
+  { pattern: /^realbooru\.com$/i, engine: 'gelbooru' },
+  { pattern: /^tbib\.org$/i, engine: 'gelbooru' },
+  { pattern: /^yande\.re$/i, engine: 'moebooru' },
+  { pattern: /^konachan\.(com|net)$/i, engine: 'moebooru' },
+  { pattern: /(^|\.)sankakucomplex\.com$/i, engine: 'sankaku' },
+  { pattern: /^derpibooru\.org$/i, engine: 'philomena' },
+  { pattern: /^ponybooru\.org$/i, engine: 'philomena' },
+  { pattern: /^twibooru\.org$/i, engine: 'philomena' },
+  { pattern: /^rule34\.paheal\.net$/i, engine: 'shimmie' }
+];
+
+// Probe race ordering: more-specific shapes first so we don't accidentally
+// classify an e621 response as danbooru (both share /posts.json but the
+// shape differs). Shimmie probes XML, so it's well-isolated from the JSON
+// engines and order is not critical for it; szurubooru returns a distinct
+// envelope shape and is also unambiguous.
+const PROBE_ORDER: BooruEngineType[] = [
+  'e621',
+  'danbooru',
+  'philomena',
+  'moebooru',
+  'gelbooru',
+  'sankaku',
+  'szurubooru',
+  'shimmie'
+];
+
+const PROBE_TIMEOUT_MS = 4000;
+
+const hostnameLookup = (baseUrl: string): BooruEngineType | null => {
+  let host: string;
+  try {
+    host = new URL(baseUrl).hostname.replace(/^www\./, '').toLowerCase();
+  } catch {
+    return null;
+  }
+  for (const entry of HOSTNAME_MAP) {
+    if (entry.pattern.test(host)) return entry.engine;
+  }
+  return null;
+};
+
+const fetchWithTimeout = async (url: string, timeoutMs: number) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': config.e621.userAgent,
+        Accept: 'application/json, application/xml;q=0.8, */*;q=0.5'
+      },
+      signal: controller.signal
+    });
+    return res;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+type ProbeOutcome =
+  | { result: 'matched'; sample: ProbeSample | null; httpStatus: number }
+  | { result: 'no-match'; httpStatus: number }
+  | { result: 'http-error'; httpStatus: number; error?: string }
+  | { result: 'network-error'; error: string }
+  | { result: 'timeout' };
+
+const probeEngine = async (baseUrl: string, engine: BooruEngineType): Promise<ProbeOutcome> => {
+  const module = ENGINE_REGISTRY[engine];
+  const url = safeJoin(baseUrl, module.probePath);
+  let res;
+  try {
+    res = await fetchWithTimeout(url, PROBE_TIMEOUT_MS);
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (msg.includes('aborted')) return { result: 'timeout' };
+    return { result: 'network-error', error: msg };
+  }
+  if (!res.ok) {
+    return { result: 'http-error', httpStatus: res.status, error: `HTTP ${res.status}` };
+  }
+  const text = await res.text();
+  // Try JSON first, fall back to raw text for XML-based engines (shimmie).
+  let body: unknown = text;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    // not JSON — keep `body = text` so XML-shaped engines can match
+  }
+  if (!module.probeMatches(body)) {
+    return { result: 'no-match', httpStatus: res.status };
+  }
+  const sample = module.probeSample ? module.probeSample(body) : null;
+  return { result: 'matched', sample, httpStatus: res.status };
+};
+
+const outcomeToAttempt = (engine: BooruEngineType, outcome: ProbeOutcome): DetectionAttempt => {
+  switch (outcome.result) {
+    case 'matched':
+      return { engine, status: 'matched', httpStatus: outcome.httpStatus };
+    case 'no-match':
+      return { engine, status: 'no-match', httpStatus: outcome.httpStatus };
+    case 'http-error':
+      return { engine, status: 'http-error', httpStatus: outcome.httpStatus, error: outcome.error };
+    case 'network-error':
+      return { engine, status: 'network-error', error: outcome.error };
+    case 'timeout':
+      return { engine, status: 'timeout' };
+  }
+};
+
+export const detectEngine = async (baseUrl: string): Promise<DetectionResult | DetectionFailure> => {
+  const normalized = stripTrailingSlash(baseUrl);
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    return { error: 'unknown', tried: [], attempts: [] };
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { error: 'unknown', tried: [], attempts: [] };
+  }
+
+  const hostnameEngine = hostnameLookup(normalized);
+  if (hostnameEngine) {
+    // Still run the matched engine's probe so the caller gets a sample
+    // thumbnail — hostname lookup alone has no proof-of-life.
+    const outcome = await probeEngine(normalized, hostnameEngine);
+    const attempts = [outcomeToAttempt(hostnameEngine, outcome)];
+    const sample = outcome.result === 'matched' ? outcome.sample : null;
+    return { engine: hostnameEngine, confidence: 'hostname', sample, attempts };
+  }
+
+  // Race every engine in parallel. Each settles to its own outcome, none
+  // throw — outcomes are aggregated into the attempts log so the UI can
+  // explain WHY a detection failed.
+  const settled = await Promise.allSettled(PROBE_ORDER.map((engine) => probeEngine(normalized, engine)));
+
+  const attempts: DetectionAttempt[] = settled.map((entry, idx) => {
+    const engine = PROBE_ORDER[idx];
+    if (entry.status === 'fulfilled') return outcomeToAttempt(engine, entry.value);
+    return { engine, status: 'network-error', error: String(entry.reason ?? 'unknown error') };
+  });
+
+  // If every engine failed at the network level (no HTTP reply at all), the
+  // site is genuinely unreachable, not just unidentified.
+  const anyHttpResponse = attempts.some((attempt) =>
+    attempt.status === 'matched' ||
+      attempt.status === 'no-match' ||
+      attempt.status === 'http-error'
+  );
+  if (!anyHttpResponse) {
+    const firstNetworkError = attempts.find((a) => a.status === 'network-error' || a.status === 'timeout');
+    return {
+      error: 'unreachable',
+      message: firstNetworkError?.error ?? `No response from ${normalized}`,
+      attempts
+    };
+  }
+
+  // Walk PROBE_ORDER (most-specific shape first) and return the first match.
+  for (let i = 0; i < settled.length; i++) {
+    const entry = settled[i];
+    if (entry.status === 'fulfilled' && entry.value.result === 'matched') {
+      const engine = PROBE_ORDER[i];
+      return { engine, confidence: 'probe', sample: entry.value.sample, attempts };
+    }
+  }
+  return { error: 'unknown', tried: PROBE_ORDER, attempts };
+};

--- a/backend/src/lib/booruEngines/detect.ts
+++ b/backend/src/lib/booruEngines/detect.ts
@@ -4,8 +4,9 @@ import { config } from '../../config';
 import type { BooruEngineType } from '../dataStore';
 
 import { safeJoin, stripTrailingSlash } from './helpers';
-import { ENGINE_REGISTRY } from './index';
 import type { ProbeSample } from './types';
+
+import { ENGINE_REGISTRY } from './index';
 
 export type DetectionAttemptStatus =
   | 'matched'

--- a/backend/src/lib/booruEngines/e621.ts
+++ b/backend/src/lib/booruEngines/e621.ts
@@ -1,0 +1,215 @@
+import { fetch } from 'undici';
+
+import { config } from '../../config';
+import type { BooruSiteRecord } from '../dataStore';
+
+import { basicAuthHeader, normalizeTag, safeJoin } from './helpers';
+import type { BooruEngineModule, BooruRemoteFavorite, TagResult } from './types';
+
+type E621TagBuckets = {
+  general?: string[];
+  artist?: string[];
+  character?: string[];
+  species?: string[];
+  meta?: string[];
+  lore?: string[];
+  invalid?: string[];
+};
+
+type E621Post = {
+  id?: number | string | null;
+  file?: { url?: string | null; width?: number | null; height?: number | null } | null;
+  preview?: { url?: string | null } | null;
+  tags?: E621TagBuckets | null;
+  rating?: string | null;
+};
+
+type E621Response = {
+  post?: E621Post | null;
+  posts?: E621Post[] | null;
+};
+
+const userAgent = () => config.e621.userAgent;
+
+const buildE621Tags = (tags: E621TagBuckets | null | undefined): TagResult[] => {
+  if (!tags) return [];
+  const bucket: TagResult[] = [];
+  const pushTags = (category: string, values: string[]) => {
+    for (const tag of values ?? []) {
+      const cleaned = normalizeTag(tag);
+      if (cleaned) bucket.push({ tag: cleaned, category });
+    }
+  };
+  pushTags('general', tags.general ?? []);
+  pushTags('artist', tags.artist ?? []);
+  pushTags('character', tags.character ?? []);
+  pushTags('species', tags.species ?? []);
+  pushTags('meta', tags.meta ?? []);
+  pushTags('lore', tags.lore ?? []);
+  pushTags('invalid', tags.invalid ?? []);
+  return bucket;
+};
+
+const buildHeaders = (site: BooruSiteRecord): Record<string, string> => {
+  const headers: Record<string, string> = { 'User-Agent': userAgent() };
+  if (site.username && site.apiKey) {
+    headers.Authorization = basicAuthHeader(site.username, site.apiKey);
+  }
+  return headers;
+};
+
+const e621Regex = (host: string) => new RegExp(`^https?://(?:www\\.)?${escapeRegex(host)}/(?:posts|post/show)/(\\d+)`, 'i');
+
+const escapeRegex = (value: string): string => value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+
+export const e621Engine: BooruEngineModule = {
+  type: 'e621',
+  credentialSchema: 'username+apikey',
+  defaultCapabilities: { favorites: true, tags: true, sourceMatch: true, search: true },
+  defaultUserAgent: '',
+  probePath: '/posts.json?limit=1',
+  probeMatches: (body: unknown): boolean => {
+    if (!body || typeof body !== 'object') return false;
+    const posts = (body as { posts?: unknown }).posts;
+    if (!Array.isArray(posts) || posts.length === 0) return Array.isArray(posts);
+    const first = posts[0];
+    if (!first || typeof first !== 'object') return false;
+    const tags = (first as { tags?: unknown }).tags;
+    return !!tags && typeof tags === 'object' && Array.isArray((tags as { general?: unknown }).general);
+  },
+  probeSample: (body: unknown) => {
+    const posts = (body as { posts?: E621Post[] | null } | null)?.posts ?? null;
+    const post = Array.isArray(posts) ? posts[0] : null;
+    if (!post?.id) return null;
+    const id = String(post.id);
+    return {
+      postId: id,
+      thumbUrl: post.preview?.url ?? null,
+      postPath: `/posts/${id}`
+    };
+  },
+
+  async fetchPostTags(site, postId): Promise<TagResult[]> {
+    if (!site.username || !site.apiKey) return [];
+    const res = await fetch(safeJoin(site.baseUrl, `/posts/${postId}.json`), { headers: buildHeaders(site) });
+    const text = await res.text();
+    if (!res.ok) {
+      console.warn(`[tags] e621 fetch failed (${res.status}): ${text.slice(0, 200)}`);
+      return [];
+    }
+    let data: E621Response;
+    try {
+      data = JSON.parse(text) as E621Response;
+    } catch {
+      console.warn(`[tags] e621 parse failed: ${text.slice(0, 200)}`);
+      return [];
+    }
+    return buildE621Tags(data?.post?.tags);
+  },
+
+  async fetchPostByMd5(site, md5) {
+    if (!site.username || !site.apiKey) return null;
+    const res = await fetch(safeJoin(site.baseUrl, `/posts.json?md5=${md5}`), { headers: buildHeaders(site) });
+    const text = await res.text();
+    if (!res.ok) {
+      console.warn(`[tags] e621 md5 fetch failed (${res.status}): ${text.slice(0, 200)}`);
+      return null;
+    }
+    let data: E621Response;
+    try {
+      data = JSON.parse(text) as E621Response;
+    } catch {
+      console.warn(`[tags] e621 md5 parse failed: ${text.slice(0, 200)}`);
+      return null;
+    }
+    const post = data?.post ?? (Array.isArray(data?.posts) ? data!.posts![0] : null);
+    if (!post) return null;
+    const tags = buildE621Tags(post.tags ?? null);
+    const postId = post.id ? String(post.id) : null;
+    return { tags, sourceUrl: postId ? safeJoin(site.baseUrl, `/posts/${postId}`) : null };
+  },
+
+  async fetchFavorites(site, ctx) {
+    if (!site.username || !site.apiKey) {
+      throw new Error(`${site.name} credentials missing`);
+    }
+    const headers = buildHeaders(site);
+    const items: BooruRemoteFavorite[] = [];
+    const limit = 320;
+    let page = 1;
+    for (;;) {
+      const params = new URLSearchParams({
+        tags: `fav:${site.username}`,
+        limit: String(limit),
+        page: String(page)
+      });
+      const res = await fetch(safeJoin(site.baseUrl, `/posts.json?${params.toString()}`), { headers });
+      const text = await res.text();
+      if (!res.ok) {
+        throw new Error(`${site.name} favorites failed (${res.status}): ${text.slice(0, 200)}`);
+      }
+      let data: E621Response;
+      try {
+        data = JSON.parse(text) as E621Response;
+      } catch {
+        throw new Error(`${site.name} favorites parse failed: ${text.slice(0, 200)}`);
+      }
+      const posts = Array.isArray(data.posts) ? data.posts : [];
+      if (!posts.length) break;
+      ctx?.onPage?.(page, posts.length);
+      for (const post of posts) {
+        const id = post?.id ? String(post.id) : null;
+        const fileUrl = post?.file?.url ?? null;
+        if (!id) continue;
+        items.push({
+          provider: site.id,
+          remoteId: id,
+          sourceUrl: safeJoin(site.baseUrl, `/posts/${id}`),
+          fileUrl
+        });
+      }
+      if (posts.length < limit) break;
+      page += 1;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+    return { items, downloadHeaders: headers };
+  },
+
+  async favorite(site, postId) {
+    if (!site.username || !site.apiKey) throw new Error(`${site.name} credentials missing`);
+    const body = new URLSearchParams({ post_id: postId });
+    const res = await fetch(safeJoin(site.baseUrl, '/favorites.json'), {
+      method: 'POST',
+      headers: {
+        ...buildHeaders(site),
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body
+    });
+    if (res.ok || res.status === 422) return;
+    const text = await res.text();
+    throw new Error(`${site.name} favorite failed (${res.status}): ${text.slice(0, 200)}`);
+  },
+
+  async unfavorite(site, postId) {
+    if (!site.username || !site.apiKey) throw new Error(`${site.name} credentials missing`);
+    const res = await fetch(safeJoin(site.baseUrl, `/favorites/${postId}.json`), {
+      method: 'DELETE',
+      headers: buildHeaders(site)
+    });
+    if (res.ok || res.status === 404) return;
+    const text = await res.text();
+    throw new Error(`${site.name} unfavorite failed (${res.status}): ${text.slice(0, 200)}`);
+  },
+
+  extractIdFromUrl(url, site) {
+    const host = new URL(site.baseUrl).hostname.replace(/^www\./, '').toLowerCase();
+    const match = url.match(e621Regex(host));
+    if (!match?.[1]) return null;
+    return { remoteId: match[1] };
+  },
+
+  buildPostUrl(site, postId) {
+    return safeJoin(site.baseUrl, `/posts/${postId}`);
+  }
+};

--- a/backend/src/lib/booruEngines/engines.test.ts
+++ b/backend/src/lib/booruEngines/engines.test.ts
@@ -1,0 +1,249 @@
+// Unit tests for the engine modules' pure pieces — probe shape detection and
+// URL → post-id extraction. No network. No DB. These pin the contract that the
+// detection module and the URL matcher rely on.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { BooruSiteRecord } from '../dataStore';
+
+import { danbooruEngine } from './danbooru';
+import { e621Engine } from './e621';
+import { gelbooruEngine } from './gelbooru';
+import { moebooruEngine } from './moebooru';
+import { philomenaEngine } from './philomena';
+import { sankakuEngine } from './sankaku';
+import { shimmieEngine } from './shimmie';
+import { szurubooruEngine } from './szurubooru';
+
+const baseSite = (overrides: Partial<BooruSiteRecord>): BooruSiteRecord => ({
+  id: 'site-1',
+  userId: 'user-1',
+  name: 'test',
+  engine: 'e621',
+  baseUrl: 'https://e621.net',
+  username: null,
+  apiKey: null,
+  isPreset: false,
+  presetKey: null,
+  enabled: true,
+  capFavorites: false,
+  capTags: true,
+  capSourceMatch: true,
+  capSearch: true,
+  sortOrder: 0,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  ...overrides
+});
+
+test('e621 probe matches typed-tag-bucket shape', () => {
+  const body = { posts: [{ tags: { general: ['cat'] } }] };
+  assert.equal(e621Engine.probeMatches(body), true);
+});
+
+test('e621 probe rejects flat tag-string shape (danbooru-style)', () => {
+  const body = { posts: [{ tag_string_general: 'cat' }] };
+  assert.equal(e621Engine.probeMatches(body), false);
+});
+
+test('danbooru probe matches flat tag-string shape', () => {
+  const body = [{ tag_string_general: 'cat' }];
+  assert.equal(danbooruEngine.probeMatches(body), true);
+});
+
+test('danbooru probe rejects e621-style body', () => {
+  const body = { posts: [{ tags: { general: ['x'] } }] };
+  assert.equal(danbooruEngine.probeMatches(body), false);
+});
+
+test('moebooru probe matches flat string tags + md5', () => {
+  const body = [{ tags: 'cat dog', md5: 'abcd' }];
+  assert.equal(moebooruEngine.probeMatches(body), true);
+});
+
+test('moebooru probe rejects danbooru-style flat tag-string', () => {
+  const body = [{ tags: 'a', md5: 'x', tag_string_general: 'cat' }];
+  assert.equal(moebooruEngine.probeMatches(body), false);
+});
+
+test('gelbooru probe matches object envelope', () => {
+  const body = { post: [{ tags: 'x', file_url: 'https://example.com/x.jpg' }] };
+  assert.equal(gelbooruEngine.probeMatches(body), true);
+});
+
+test('philomena probe matches images array with tag arrays', () => {
+  const body = { images: [{ id: 1, tags: ['a'] }] };
+  assert.equal(philomenaEngine.probeMatches(body), true);
+});
+
+test('sankaku probe matches typed tag entries', () => {
+  const body = [{ id: 1, tags: [{ name: 'cat', type: 0 }] }];
+  assert.equal(sankakuEngine.probeMatches(body), true);
+});
+
+test('e621 extractIdFromUrl matches canonical /posts/{id}', () => {
+  const site = baseSite({ engine: 'e621', baseUrl: 'https://e621.net' });
+  assert.deepEqual(e621Engine.extractIdFromUrl('https://e621.net/posts/12345', site), { remoteId: '12345' });
+});
+
+test('e621 extractIdFromUrl rejects wrong host', () => {
+  const site = baseSite({ engine: 'e621', baseUrl: 'https://e621.net' });
+  assert.equal(e621Engine.extractIdFromUrl('https://danbooru.donmai.us/posts/42', site), null);
+});
+
+test('danbooru extractIdFromUrl matches /posts/{id}', () => {
+  const site = baseSite({ engine: 'danbooru', baseUrl: 'https://danbooru.donmai.us' });
+  assert.deepEqual(
+    danbooruEngine.extractIdFromUrl('https://danbooru.donmai.us/posts/777', site),
+    { remoteId: '777' }
+  );
+});
+
+test('moebooru extractIdFromUrl matches /post/show/{id}', () => {
+  const site = baseSite({ engine: 'moebooru', baseUrl: 'https://yande.re' });
+  assert.deepEqual(moebooruEngine.extractIdFromUrl('https://yande.re/post/show/9001', site), { remoteId: '9001' });
+});
+
+test('gelbooru extractIdFromUrl reads id query parameter', () => {
+  const site = baseSite({ engine: 'gelbooru', baseUrl: 'https://gelbooru.com' });
+  assert.deepEqual(
+    gelbooruEngine.extractIdFromUrl('https://gelbooru.com/index.php?page=post&s=view&id=42', site),
+    { remoteId: '42' }
+  );
+});
+
+test('philomena extractIdFromUrl matches /images/{id}', () => {
+  const site = baseSite({ engine: 'philomena', baseUrl: 'https://derpibooru.org' });
+  assert.deepEqual(
+    philomenaEngine.extractIdFromUrl('https://derpibooru.org/images/12345', site),
+    { remoteId: '12345' }
+  );
+});
+
+test('sankaku extractIdFromUrl matches /post/show/{id}', () => {
+  const site = baseSite({ engine: 'sankaku', baseUrl: 'https://chan.sankakucomplex.com' });
+  assert.deepEqual(
+    sankakuEngine.extractIdFromUrl('https://chan.sankakucomplex.com/post/show/42', site),
+    { remoteId: '42' }
+  );
+});
+
+test('engine buildPostUrl returns canonical URL', () => {
+  const site = baseSite({ engine: 'e621', baseUrl: 'https://e621.net' });
+  assert.equal(e621Engine.buildPostUrl(site, '42'), 'https://e621.net/posts/42');
+});
+
+// --- szurubooru ---------------------------------------------------------
+
+test('szurubooru probe matches the szurubooru search envelope', () => {
+  const body = {
+    query: '',
+    offset: 0,
+    limit: 1,
+    total: 99,
+    results: [{ id: 7, tags: [{ names: ['cat'], category: 'general' }], thumbnailUrl: '/t/7.jpg' }]
+  };
+  assert.equal(szurubooruEngine.probeMatches(body), true);
+});
+
+test('szurubooru probe matches empty boards (count zero is still a valid szurubooru)', () => {
+  const body = { query: '', offset: 0, limit: 1, total: 0, results: [] };
+  assert.equal(szurubooruEngine.probeMatches(body), true);
+});
+
+test('szurubooru probe rejects danbooru-style flat tag string', () => {
+  // Disambiguation: szurubooru tags are objects with `names: string[]`,
+  // never the flat `tag_string_general` shape that danbooru uses.
+  const body = { results: [{ id: 1, tag_string_general: 'cat' }] };
+  assert.equal(szurubooruEngine.probeMatches(body), false);
+});
+
+test('szurubooru probeSample returns id, thumbnail, and /post/{id} path', () => {
+  const body = {
+    results: [{ id: 42, thumbnailUrl: '/t/42.jpg', tags: [{ names: ['cat'], category: 'general' }] }]
+  };
+  const sample = szurubooruEngine.probeSample?.(body);
+  assert.deepEqual(sample, { postId: '42', thumbUrl: '/t/42.jpg', postPath: '/post/42' });
+});
+
+test('szurubooru extractIdFromUrl matches /post/{id}', () => {
+  const site = baseSite({ engine: 'szurubooru', baseUrl: 'https://booru.foalcon.com' });
+  assert.deepEqual(
+    szurubooruEngine.extractIdFromUrl('https://booru.foalcon.com/post/12345', site),
+    { remoteId: '12345' }
+  );
+});
+
+// --- shimmie ------------------------------------------------------------
+
+test('shimmie probe matches a danbooru-compat XML response with one post', () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<posts count="1" offset="0">
+  <tag name="cat" count="3" type="general"/>
+  <post id="1234" md5="abc" file_url="/f/1234.jpg" preview_url="/t/1234.jpg" tags="cat dog" rating="s"/>
+</posts>`;
+  assert.equal(shimmieEngine.probeMatches(xml), true);
+});
+
+test('shimmie probe accepts an empty board (zero-post XML envelope)', () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<posts count="0" offset="0"></posts>`;
+  assert.equal(shimmieEngine.probeMatches(xml), true);
+});
+
+test('shimmie probe rejects non-string bodies (defends against JSON misdispatch)', () => {
+  // The detect loop hands every engine the same parsed body. If JSON.parse
+  // succeeded upstream, shimmie must NOT match the resulting object — it
+  // only understands raw XML strings.
+  assert.equal(shimmieEngine.probeMatches({ posts: [{ id: 1 }] } as unknown), false);
+});
+
+test('shimmie probe rejects HTML / arbitrary text', () => {
+  assert.equal(shimmieEngine.probeMatches('<!DOCTYPE html><html><body>nope</body></html>'), false);
+  assert.equal(shimmieEngine.probeMatches('plain text'), false);
+});
+
+test('shimmie probeSample pulls id + preview_url out of the first <post> element', () => {
+  const xml = `<posts count="1" offset="0">
+    <post id="5678" md5="deadbeef" preview_url="/t/5678.jpg" tags="foo bar"/>
+  </posts>`;
+  const sample = shimmieEngine.probeSample?.(xml);
+  assert.deepEqual(sample, { postId: '5678', thumbUrl: '/t/5678.jpg', postPath: '/post/view/5678' });
+});
+
+test('shimmie extractIdFromUrl matches /post/view/{id}', () => {
+  const site = baseSite({ engine: 'shimmie', baseUrl: 'https://cascards.fluffyquack.com' });
+  assert.deepEqual(
+    shimmieEngine.extractIdFromUrl('https://cascards.fluffyquack.com/post/view/42', site),
+    { remoteId: '42' }
+  );
+});
+
+// --- probeSample on the original six engines ---------------------------
+
+test('e621 probeSample returns first post id + preview', () => {
+  const body = { posts: [{ id: 9, preview: { url: '/p/9.jpg' }, tags: { general: ['cat'] } }] };
+  assert.deepEqual(e621Engine.probeSample?.(body), {
+    postId: '9',
+    thumbUrl: '/p/9.jpg',
+    postPath: '/posts/9'
+  });
+});
+
+test('danbooru probeSample returns first post id + preview_file_url', () => {
+  const body = [{ id: 1, preview_file_url: '/p/1.jpg', tag_string_general: 'cat' }];
+  assert.deepEqual(danbooruEngine.probeSample?.(body), {
+    postId: '1',
+    thumbUrl: '/p/1.jpg',
+    postPath: '/posts/1'
+  });
+});
+
+test('philomena probeSample returns image id + thumb representation', () => {
+  const body = { images: [{ id: 42, representations: { thumb: '/t/42.jpg' }, tags: ['a'] }] };
+  assert.deepEqual(philomenaEngine.probeSample?.(body), {
+    postId: '42',
+    thumbUrl: '/t/42.jpg',
+    postPath: '/images/42'
+  });
+});

--- a/backend/src/lib/booruEngines/gelbooru.ts
+++ b/backend/src/lib/booruEngines/gelbooru.ts
@@ -1,0 +1,139 @@
+import { fetch } from 'undici';
+
+import { config } from '../../config';
+import type { BooruSiteRecord } from '../dataStore';
+
+import { normalizeTag, safeJoin } from './helpers';
+import type { BooruEngineModule, TagResult } from './types';
+
+type GelbooruPost = {
+  id?: number | string | null;
+  file_url?: string | null;
+  preview_url?: string | null;
+  sample_url?: string | null;
+  width?: number | null;
+  height?: number | null;
+  rating?: string | null;
+  tags?: string | null;
+};
+
+type GelbooruEnvelope = {
+  post?: GelbooruPost | GelbooruPost[] | null;
+};
+
+type GelbooruResponse = GelbooruPost[] | GelbooruEnvelope | GelbooruPost;
+
+const userAgent = () => config.e621.userAgent;
+
+const buildHeaders = (): Record<string, string> => ({ 'User-Agent': userAgent() });
+
+const buildBaseQuery = (site: BooruSiteRecord, extra: Record<string, string>): URLSearchParams => {
+  const params = new URLSearchParams({
+    page: 'dapi',
+    s: 'post',
+    q: 'index',
+    json: '1',
+    ...extra
+  });
+  // gelbooru uses user_id (numeric) + api_key
+  if (site.username && site.apiKey) {
+    params.set('user_id', site.username);
+    params.set('api_key', site.apiKey);
+  }
+  return params;
+};
+
+const isEnvelope = (value: GelbooruResponse): value is GelbooruEnvelope =>
+  !Array.isArray(value) && Object.prototype.hasOwnProperty.call(value, 'post');
+
+const extractPosts = (data: GelbooruResponse): GelbooruPost[] => {
+  if (Array.isArray(data)) return data;
+  if (isEnvelope(data)) {
+    if (Array.isArray(data.post)) return data.post;
+    if (data.post) return [data.post];
+    return [];
+  }
+  return [data];
+};
+
+export const gelbooruEngine: BooruEngineModule = {
+  type: 'gelbooru',
+  credentialSchema: 'userid+apikey',
+  defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true },
+  defaultUserAgent: '',
+  probePath: '/index.php?page=dapi&s=post&q=index&json=1&limit=1',
+  probeMatches: (body: unknown): boolean => {
+    let posts: unknown;
+    if (Array.isArray(body)) {
+      posts = body;
+    } else if (body && typeof body === 'object') {
+      const env = body as GelbooruEnvelope;
+      if (Array.isArray(env.post)) posts = env.post;
+      else if (env.post) posts = [env.post];
+    }
+    if (!Array.isArray(posts) || posts.length === 0) return false;
+    const first = posts[0];
+    if (!first || typeof first !== 'object') return false;
+    const p = first as GelbooruPost;
+    return typeof p.tags === 'string' && (typeof p.file_url === 'string' || typeof p.sample_url === 'string');
+  },
+  probeSample: (body: unknown) => {
+    const posts = extractPosts(body as GelbooruResponse);
+    const post = posts[0];
+    if (!post?.id) return null;
+    const id = String(post.id);
+    return {
+      postId: id,
+      thumbUrl: post.preview_url ?? null,
+      // Gelbooru uses query string, not path — keep absolute-style postPath
+      // with leading ?param to make safeJoin() produce a usable URL.
+      postPath: `/index.php?page=post&s=view&id=${id}`
+    };
+  },
+
+  async fetchPostTags(site, postId): Promise<TagResult[]> {
+    const params = buildBaseQuery(site, { id: postId, limit: '1' });
+    const res = await fetch(safeJoin(site.baseUrl, `/index.php?${params.toString()}`), {
+      headers: buildHeaders()
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      console.warn(`[tags] gelbooru fetch failed (${res.status}): ${text.slice(0, 200)}`);
+      return [];
+    }
+    let data: GelbooruResponse;
+    try {
+      data = JSON.parse(text) as GelbooruResponse;
+    } catch {
+      console.warn(`[tags] gelbooru parse failed: ${text.slice(0, 200)}`);
+      return [];
+    }
+    const posts = extractPosts(data);
+    const entry = posts[0];
+    const rawTags = typeof entry?.tags === 'string' ? entry.tags : '';
+    if (!rawTags) return [];
+    return rawTags
+      .split(' ')
+      .map((tag) => normalizeTag(tag))
+      .filter(Boolean)
+      .map((tag) => ({ tag, category: 'general' }));
+  },
+
+  extractIdFromUrl(url, site) {
+    try {
+      const parsed = new URL(url);
+      const siteHost = new URL(site.baseUrl).hostname.replace(/^www\./, '').toLowerCase();
+      const host = parsed.hostname.replace(/^www\./, '').toLowerCase();
+      if (host !== siteHost) return null;
+      const idParam = parsed.searchParams.get('id');
+      if (!idParam || !/^\d+$/.test(idParam)) return null;
+      return { remoteId: idParam };
+    } catch {
+      return null;
+    }
+  },
+
+  buildPostUrl(site, postId) {
+    return `${site.baseUrl.replace(/\/+$/, '')}/index.php?page=post&s=view&id=${postId}`;
+  }
+};

--- a/backend/src/lib/booruEngines/helpers.ts
+++ b/backend/src/lib/booruEngines/helpers.ts
@@ -1,0 +1,25 @@
+export const normalizeTag = (value: string): string =>
+  value
+    .trim()
+    .replace(/\s+/g, '_')
+    .replace(/[^\w:()-]+/g, '')
+    .toLowerCase();
+
+export const stripTrailingSlash = (url: string): string => url.replace(/\/+$/, '');
+
+export const safeJoin = (base: string, path: string): string => {
+  const trimmedBase = stripTrailingSlash(base);
+  if (!path.startsWith('/')) return `${trimmedBase}/${path}`;
+  return `${trimmedBase}${path}`;
+};
+
+export const hostnameOf = (url: string): string | null => {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '').toLowerCase();
+  } catch {
+    return null;
+  }
+};
+
+export const basicAuthHeader = (username: string, apiKey: string): string =>
+  `Basic ${Buffer.from(`${username}:${apiKey}`).toString('base64')}`;

--- a/backend/src/lib/booruEngines/index.ts
+++ b/backend/src/lib/booruEngines/index.ts
@@ -1,0 +1,43 @@
+import type { BooruEngineType } from '../dataStore';
+
+import { danbooruEngine } from './danbooru';
+import { e621Engine } from './e621';
+import { gelbooruEngine } from './gelbooru';
+import { moebooruEngine } from './moebooru';
+import { philomenaEngine } from './philomena';
+import { sankakuEngine } from './sankaku';
+import { shimmieEngine } from './shimmie';
+import { szurubooruEngine } from './szurubooru';
+import type { BooruEngineModule, EngineRegistry } from './types';
+
+export const ENGINE_REGISTRY: EngineRegistry = {
+  danbooru: danbooruEngine,
+  e621: e621Engine,
+  moebooru: moebooruEngine,
+  gelbooru: gelbooruEngine,
+  sankaku: sankakuEngine,
+  philomena: philomenaEngine,
+  shimmie: shimmieEngine,
+  szurubooru: szurubooruEngine
+};
+
+export const getEngine = (type: BooruEngineType | string): BooruEngineModule | null => {
+  if (Object.prototype.hasOwnProperty.call(ENGINE_REGISTRY, type)) {
+    return ENGINE_REGISTRY[type as BooruEngineType];
+  }
+  return null;
+};
+
+export const listEngines = (): BooruEngineModule[] => Object.values(ENGINE_REGISTRY);
+
+export * from './types';
+export {
+  danbooruEngine,
+  e621Engine,
+  gelbooruEngine,
+  moebooruEngine,
+  philomenaEngine,
+  sankakuEngine,
+  shimmieEngine,
+  szurubooruEngine
+};

--- a/backend/src/lib/booruEngines/moebooru.ts
+++ b/backend/src/lib/booruEngines/moebooru.ts
@@ -1,7 +1,6 @@
 import { fetch } from 'undici';
 
 import { config } from '../../config';
-import type { BooruSiteRecord } from '../dataStore';
 
 import { normalizeTag, safeJoin } from './helpers';
 import type { BooruEngineModule, TagResult } from './types';

--- a/backend/src/lib/booruEngines/moebooru.ts
+++ b/backend/src/lib/booruEngines/moebooru.ts
@@ -1,0 +1,114 @@
+import { fetch } from 'undici';
+
+import { config } from '../../config';
+import type { BooruSiteRecord } from '../dataStore';
+
+import { normalizeTag, safeJoin } from './helpers';
+import type { BooruEngineModule, TagResult } from './types';
+
+type MoebooruPost = {
+  id?: number | string | null;
+  file_url?: string | null;
+  preview_url?: string | null;
+  sample_url?: string | null;
+  jpeg_url?: string | null;
+  width?: number | null;
+  height?: number | null;
+  rating?: string | null;
+  md5?: string | null;
+  tags?: string | null;
+  tags_general?: string | null;
+  tags_artist?: string | null;
+  tags_character?: string | null;
+  tags_copyright?: string | null;
+  tags_meta?: string | null;
+};
+
+type MoebooruResponse = MoebooruPost[] | MoebooruPost;
+
+const userAgent = () => config.e621.userAgent;
+
+const escapeRegex = (value: string): string => value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+
+const buildHeaders = (): Record<string, string> => ({ 'User-Agent': userAgent() });
+
+const moebooruRegex = (host: string) =>
+  new RegExp(`^https?://(?:www\\.)?${escapeRegex(host)}/post/show/(\\d+)`, 'i');
+
+export const moebooruEngine: BooruEngineModule = {
+  type: 'moebooru',
+  credentialSchema: 'none',
+  defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true },
+  defaultUserAgent: '',
+  probePath: '/post.json?limit=1',
+  probeMatches: (body: unknown): boolean => {
+    if (!Array.isArray(body) || body.length === 0) return false;
+    const first = body[0];
+    if (!first || typeof first !== 'object') return false;
+    const post = first as MoebooruPost;
+    const tagStr = (post as { tag_string_general?: unknown }).tag_string_general;
+    if (typeof tagStr === 'string') return false; // would match danbooru
+    return typeof post.tags === 'string' && typeof post.md5 === 'string';
+  },
+  probeSample: (body: unknown) => {
+    const post = Array.isArray(body) ? (body[0] as MoebooruPost | undefined) : null;
+    if (!post?.id) return null;
+    const id = String(post.id);
+    return {
+      postId: id,
+      thumbUrl: post.preview_url ?? null,
+      postPath: `/post/show/${id}`
+    };
+  },
+
+  async fetchPostTags(site, postId): Promise<TagResult[]> {
+    const endpoints = [
+      safeJoin(site.baseUrl, `/post/show/${postId}.json`),
+      safeJoin(site.baseUrl, `/post.json?tags=id:${postId}`)
+    ];
+    for (const endpoint of endpoints) {
+      const res = await fetch(endpoint, { headers: buildHeaders() });
+      const text = await res.text();
+      if (!res.ok) {
+        console.warn(`[tags] moebooru fetch failed (${res.status}): ${text.slice(0, 200)}`);
+        continue;
+      }
+      let data: MoebooruResponse;
+      try {
+        data = JSON.parse(text) as MoebooruResponse;
+      } catch {
+        console.warn(`[tags] moebooru parse failed: ${text.slice(0, 200)}`);
+        continue;
+      }
+      const entry = Array.isArray(data) ? data[0] : data;
+      if (!entry) continue;
+      const bucket: TagResult[] = [];
+      const pushTags = (category: string, value?: string | null) => {
+        if (!value) return;
+        value
+          .split(' ')
+          .map((tag) => normalizeTag(tag))
+          .filter(Boolean)
+          .forEach((tag) => bucket.push({ tag, category }));
+      };
+      pushTags('general', entry.tags_general ?? entry.tags ?? '');
+      pushTags('artist', entry.tags_artist ?? '');
+      pushTags('character', entry.tags_character ?? '');
+      pushTags('copyright', entry.tags_copyright ?? '');
+      pushTags('meta', entry.tags_meta ?? '');
+      return bucket;
+    }
+    return [];
+  },
+
+  extractIdFromUrl(url, site) {
+    const host = new URL(site.baseUrl).hostname.replace(/^www\./, '').toLowerCase();
+    const match = url.match(moebooruRegex(host));
+    if (!match?.[1]) return null;
+    return { remoteId: match[1] };
+  },
+
+  buildPostUrl(site, postId) {
+    return safeJoin(site.baseUrl, `/post/show/${postId}`);
+  }
+};

--- a/backend/src/lib/booruEngines/philomena.ts
+++ b/backend/src/lib/booruEngines/philomena.ts
@@ -1,0 +1,101 @@
+import { fetch } from 'undici';
+
+import { config } from '../../config';
+import type { BooruSiteRecord } from '../dataStore';
+
+import { normalizeTag, safeJoin } from './helpers';
+import type { BooruEngineModule, TagResult } from './types';
+
+type PhilomenaImage = {
+  id?: number | string | null;
+  view_url?: string | null;
+  representations?: {
+    thumb?: string | null;
+    medium?: string | null;
+    full?: string | null;
+  } | null;
+  width?: number | null;
+  height?: number | null;
+  tag_count?: number | null;
+  tags?: string[] | null;
+  rating?: string | null;
+};
+
+type PhilomenaSearchResponse = {
+  images?: PhilomenaImage[] | null;
+};
+
+type PhilomenaImageResponse = {
+  image?: PhilomenaImage | null;
+};
+
+const userAgent = () => config.e621.userAgent;
+
+const escapeRegex = (value: string): string => value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+
+const buildHeaders = (site: BooruSiteRecord): Record<string, string> => ({
+  'User-Agent': userAgent(),
+  ...(site.apiKey ? { 'x-philomena-api-key': site.apiKey } : {})
+});
+
+const philomenaRegex = (host: string) =>
+  new RegExp(`^https?://(?:www\\.)?${escapeRegex(host)}/images/(\\d+)`, 'i');
+
+export const philomenaEngine: BooruEngineModule = {
+  type: 'philomena',
+  credentialSchema: 'apikey-only',
+  defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true },
+  defaultUserAgent: '',
+  probePath: '/api/v1/json/search/images?per_page=1',
+  probeMatches: (body: unknown): boolean => {
+    if (!body || typeof body !== 'object') return false;
+    const images = (body as PhilomenaSearchResponse).images;
+    if (!Array.isArray(images) || images.length === 0) return false;
+    const first = images[0];
+    return !!first && Array.isArray(first.tags);
+  },
+  probeSample: (body: unknown) => {
+    const images = (body as PhilomenaSearchResponse | null)?.images;
+    const image = Array.isArray(images) ? images[0] : null;
+    if (!image?.id) return null;
+    const id = String(image.id);
+    return {
+      postId: id,
+      thumbUrl: image.representations?.thumb ?? image.representations?.medium ?? null,
+      postPath: `/images/${id}`
+    };
+  },
+
+  async fetchPostTags(site, postId): Promise<TagResult[]> {
+    const url = safeJoin(site.baseUrl, `/api/v1/json/images/${postId}`);
+    const res = await fetch(url, { headers: buildHeaders(site) });
+    const text = await res.text();
+    if (!res.ok) {
+      console.warn(`[tags] philomena fetch failed (${res.status}): ${text.slice(0, 200)}`);
+      return [];
+    }
+    let data: PhilomenaImageResponse;
+    try {
+      data = JSON.parse(text) as PhilomenaImageResponse;
+    } catch {
+      console.warn(`[tags] philomena parse failed: ${text.slice(0, 200)}`);
+      return [];
+    }
+    const tags = data.image?.tags ?? [];
+    return tags
+      .map((tag) => normalizeTag(tag))
+      .filter(Boolean)
+      .map((tag) => ({ tag, category: 'general' }));
+  },
+
+  extractIdFromUrl(url, site) {
+    const host = new URL(site.baseUrl).hostname.replace(/^www\./, '').toLowerCase();
+    const match = url.match(philomenaRegex(host));
+    if (!match?.[1]) return null;
+    return { remoteId: match[1] };
+  },
+
+  buildPostUrl(site, postId) {
+    return safeJoin(site.baseUrl, `/images/${postId}`);
+  }
+};

--- a/backend/src/lib/booruEngines/presets.ts
+++ b/backend/src/lib/booruEngines/presets.ts
@@ -1,0 +1,90 @@
+import type { BooruEngineType } from '../dataStore';
+
+export type BooruPreset = {
+  key: string;
+  name: string;
+  engine: BooruEngineType;
+  baseUrl: string;
+  defaultCapabilities: {
+    favorites: boolean;
+    tags: boolean;
+    sourceMatch: boolean;
+    search: boolean;
+  };
+};
+
+export const BOORU_PRESETS: BooruPreset[] = [
+  {
+    key: 'E621',
+    name: 'e621',
+    engine: 'e621',
+    baseUrl: 'https://e621.net',
+    defaultCapabilities: { favorites: true, tags: true, sourceMatch: true, search: true }
+  },
+  {
+    key: 'E926',
+    name: 'e926',
+    engine: 'e621',
+    baseUrl: 'https://e926.net',
+    defaultCapabilities: { favorites: true, tags: true, sourceMatch: true, search: true }
+  },
+  {
+    key: 'DANBOORU',
+    name: 'Danbooru',
+    engine: 'danbooru',
+    baseUrl: 'https://danbooru.donmai.us',
+    defaultCapabilities: { favorites: true, tags: true, sourceMatch: true, search: true }
+  },
+  {
+    key: 'GELBOORU',
+    name: 'Gelbooru',
+    engine: 'gelbooru',
+    baseUrl: 'https://gelbooru.com',
+    defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true }
+  },
+  {
+    key: 'RULE34',
+    name: 'Rule34',
+    engine: 'gelbooru',
+    baseUrl: 'https://rule34.xxx',
+    defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true }
+  },
+  {
+    key: 'YANDERE',
+    name: 'yande.re',
+    engine: 'moebooru',
+    baseUrl: 'https://yande.re',
+    defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true }
+  },
+  {
+    key: 'KONACHAN',
+    name: 'Konachan',
+    engine: 'moebooru',
+    baseUrl: 'https://konachan.com',
+    defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true }
+  },
+  {
+    key: 'SANKAKU',
+    name: 'Sankaku Channel',
+    engine: 'sankaku',
+    baseUrl: 'https://chan.sankakucomplex.com',
+    defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true }
+  },
+  {
+    key: 'IDOL_COMPLEX',
+    name: 'Idol Complex',
+    engine: 'sankaku',
+    baseUrl: 'https://idol.sankakucomplex.com',
+    defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true }
+  },
+  {
+    key: 'DERPIBOORU',
+    name: 'Derpibooru',
+    engine: 'philomena',
+    baseUrl: 'https://derpibooru.org',
+    defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true }
+  }
+];
+
+export const findPresetByKey = (key: string): BooruPreset | null =>
+  BOORU_PRESETS.find((preset) => preset.key === key) ?? null;

--- a/backend/src/lib/booruEngines/sankaku.ts
+++ b/backend/src/lib/booruEngines/sankaku.ts
@@ -1,7 +1,6 @@
 import { fetch } from 'undici';
 
 import { config } from '../../config';
-import type { BooruSiteRecord } from '../dataStore';
 
 import { normalizeTag, safeJoin } from './helpers';
 import type { BooruEngineModule, TagResult } from './types';

--- a/backend/src/lib/booruEngines/sankaku.ts
+++ b/backend/src/lib/booruEngines/sankaku.ts
@@ -1,0 +1,142 @@
+import { fetch } from 'undici';
+
+import { config } from '../../config';
+import type { BooruSiteRecord } from '../dataStore';
+
+import { normalizeTag, safeJoin } from './helpers';
+import type { BooruEngineModule, TagResult } from './types';
+
+type SankakuTagEntry = {
+  name?: string;
+  type?: string | number;
+};
+
+type SankakuPost = {
+  id?: number | string | null;
+  file_url?: string | null;
+  preview_url?: string | null;
+  sample_url?: string | null;
+  width?: number | null;
+  height?: number | null;
+  rating?: string | null;
+  tags?: SankakuTagEntry[] | string;
+};
+
+type SankakuResponse = SankakuPost[] | SankakuPost;
+
+const userAgent = () => config.e621.userAgent;
+
+const buildHeaders = (): Record<string, string> => ({
+  'User-Agent': userAgent(),
+  Accept: 'application/json'
+});
+
+const escapeRegex = (value: string): string => value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+
+const sankakuRegex = (host: string) =>
+  new RegExp(`^https?://(?:www\\.)?${escapeRegex(host)}/post/show/(\\d+)`, 'i');
+
+const categoryForType = (rawType: unknown): string => {
+  if (typeof rawType === 'string') return rawType.toLowerCase();
+  if (typeof rawType === 'number') {
+    switch (rawType) {
+      case 1:
+        return 'artist';
+      case 3:
+        return 'copyright';
+      case 4:
+        return 'character';
+      case 5:
+        return 'meta';
+      default:
+        return 'general';
+    }
+  }
+  return 'general';
+};
+
+const extractTags = (entry: SankakuPost): TagResult[] => {
+  const bucket: TagResult[] = [];
+  if (Array.isArray(entry.tags)) {
+    for (const item of entry.tags) {
+      const name = typeof item?.name === 'string' ? normalizeTag(item.name) : '';
+      if (!name) continue;
+      bucket.push({ tag: name, category: categoryForType(item?.type) });
+    }
+  } else if (typeof entry.tags === 'string') {
+    entry.tags
+      .split(' ')
+      .map((tag) => normalizeTag(tag))
+      .filter(Boolean)
+      .forEach((tag) => bucket.push({ tag, category: 'general' }));
+  }
+  return bucket;
+};
+
+export const sankakuEngine: BooruEngineModule = {
+  type: 'sankaku',
+  credentialSchema: 'token',
+  defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true },
+  defaultUserAgent: '',
+  probePath: '/posts?limit=1',
+  probeMatches: (body: unknown): boolean => {
+    if (!Array.isArray(body) || body.length === 0) return false;
+    const first = body[0];
+    if (!first || typeof first !== 'object') return false;
+    const tags = (first as SankakuPost).tags;
+    if (!Array.isArray(tags)) return false;
+    const sample = tags[0];
+    return !!sample && typeof sample === 'object' && typeof (sample as { name?: unknown }).name === 'string';
+  },
+  probeSample: (body: unknown) => {
+    const post = Array.isArray(body) ? (body[0] as SankakuPost | undefined) : null;
+    if (!post?.id) return null;
+    const id = String(post.id);
+    return {
+      postId: id,
+      thumbUrl: post.preview_url ?? null,
+      postPath: `/post/show/${id}`
+    };
+  },
+
+  async fetchPostTags(site, postId): Promise<TagResult[]> {
+    // sankaku exposes its JSON API on a dedicated capi-v2 host. Fall back to
+    // the legacy /post/show/{id}.json on the site itself if the api host
+    // refuses (some self-hosted forks do not run capi-v2).
+    const endpoints = [
+      `https://capi-v2.sankakucomplex.com/posts/${postId}`,
+      safeJoin(site.baseUrl, `/post/show/${postId}.json`)
+    ];
+    for (const endpoint of endpoints) {
+      const res = await fetch(endpoint, { headers: buildHeaders() });
+      const text = await res.text();
+      if (!res.ok) {
+        console.warn(`[tags] sankaku fetch failed (${res.status}): ${text.slice(0, 200)}`);
+        continue;
+      }
+      let data: SankakuResponse;
+      try {
+        data = JSON.parse(text) as SankakuResponse;
+      } catch {
+        console.warn(`[tags] sankaku parse failed: ${text.slice(0, 200)}`);
+        continue;
+      }
+      const entry = Array.isArray(data) ? data[0] : data;
+      if (!entry) continue;
+      const tags = extractTags(entry);
+      if (tags.length) return tags;
+    }
+    return [];
+  },
+
+  extractIdFromUrl(url, site) {
+    const host = new URL(site.baseUrl).hostname.replace(/^www\./, '').toLowerCase();
+    const match = url.match(sankakuRegex(host));
+    if (!match?.[1]) return null;
+    return { remoteId: match[1] };
+  },
+
+  buildPostUrl(site, postId) {
+    return safeJoin(site.baseUrl, `/post/show/${postId}`);
+  }
+};

--- a/backend/src/lib/booruEngines/shimmie.ts
+++ b/backend/src/lib/booruEngines/shimmie.ts
@@ -1,7 +1,6 @@
 import { fetch } from 'undici';
 
 import { config } from '../../config';
-import type { BooruSiteRecord } from '../dataStore';
 
 import { normalizeTag, safeJoin } from './helpers';
 import type { BooruEngineModule, TagResult } from './types';

--- a/backend/src/lib/booruEngines/shimmie.ts
+++ b/backend/src/lib/booruEngines/shimmie.ts
@@ -1,0 +1,134 @@
+import { fetch } from 'undici';
+
+import { config } from '../../config';
+import type { BooruSiteRecord } from '../dataStore';
+
+import { normalizeTag, safeJoin } from './helpers';
+import type { BooruEngineModule, TagResult } from './types';
+
+// Shimmie2 (https://code.shishnet.org/shimmie2/) ships a Danbooru-compatible
+// XML API at /api/danbooru/find_posts/index.xml. Some forks also expose
+// /index.php?q=api/danbooru/find_posts/index.xml when clean URLs are off, but
+// the canonical clean form below works on the reference installs we have
+// tested. Response shape:
+//
+//   <posts count="N" offset="0">
+//     <tag name="..." count="X" type="general"/>
+//     <post id="123" md5="..." file_url="..." preview_url="..."
+//           tags="a b c" rating="s" .../>
+//   </posts>
+//
+// We do not pull in an XML parser dependency just for shape detection +
+// single-post extraction. Regex against well-formed shimmie attributes is
+// good enough; if we later need full XML parsing we can swap in fast-xml-
+// parser without changing the public engine interface.
+
+const userAgent = () => config.e621.userAgent;
+
+// Shimmie's "Danbooru compat" auth uses login + password_hash query params
+// (SHA1 of password + site-specific salt), which we can't reproduce from
+// API-key style input. The probe / tag-fetch endpoints are typically public,
+// so we send no auth header — credentialSchema is 'none' accordingly.
+const buildHeaders = (): Record<string, string> => ({
+  'User-Agent': userAgent(),
+  Accept: 'application/xml, text/xml;q=0.9, */*;q=0.5'
+});
+
+const escapeRegex = (value: string): string => value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+
+const shimmieRegex = (host: string) =>
+  // Shimmie post page is /post/view/{id}
+  new RegExp(`^https?://(?:www\\.)?${escapeRegex(host)}/post/view/(\\d+)`, 'i');
+
+const POST_TAG = /<post\b[^>]*?>/i;
+const POSTS_TAG = /<posts\b[^>]*?>/i;
+const ATTR_RE = (name: string) => new RegExp(`\\b${name}="([^"]*)"`, 'i');
+
+const extractAttribute = (xml: string, name: string): string | null => {
+  const match = xml.match(ATTR_RE(name));
+  return match?.[1] ?? null;
+};
+
+const findFirstPost = (xml: string): string | null => {
+  const match = xml.match(POST_TAG);
+  return match?.[0] ?? null;
+};
+
+const looksLikeShimmieResponse = (text: string): boolean => {
+  // Reject things that obviously aren't XML (HTML, JSON, plain text).
+  if (!text || text.length < 10) return false;
+  if (text.trimStart().startsWith('<!DOCTYPE html')) return false;
+  if (text.trimStart().startsWith('{')) return false;
+  return POSTS_TAG.test(text);
+};
+
+export const shimmieEngine: BooruEngineModule = {
+  type: 'shimmie',
+  credentialSchema: 'none',
+  defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true },
+  defaultUserAgent: '',
+  probePath: '/api/danbooru/find_posts/index.xml?limit=1',
+  probeMatches: (body: unknown): boolean => {
+    if (typeof body !== 'string') return false;
+    if (!looksLikeShimmieResponse(body)) return false;
+    // Either zero posts (`<posts count="0" .../>` empty board, still a
+    // valid shimmie) or at least one `<post .../>` with required attrs.
+    const first = findFirstPost(body);
+    if (!first) {
+      // empty board: `<posts ...>...</posts>` with no <post> entries
+      return /<posts\b[^>]*count="\d+"/i.test(body);
+    }
+    const id = extractAttribute(first, 'id');
+    const tags = extractAttribute(first, 'tags');
+    return !!id && typeof tags === 'string';
+  },
+  probeSample: (body: unknown) => {
+    if (typeof body !== 'string') return null;
+    const first = findFirstPost(body);
+    if (!first) return null;
+    const id = extractAttribute(first, 'id');
+    if (!id) return null;
+    return {
+      postId: id,
+      thumbUrl: extractAttribute(first, 'preview_url') ?? null,
+      postPath: `/post/view/${id}`
+    };
+  },
+
+  async fetchPostTags(site, postId) {
+    // Shimmie's per-post XML endpoint mirrors danbooru's query interface.
+    const params = new URLSearchParams({ tags: `id:${postId}`, limit: '1' });
+    const res = await fetch(safeJoin(site.baseUrl, `/api/danbooru/find_posts/index.xml?${params.toString()}`), {
+      headers: buildHeaders()
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      console.warn(`[tags] shimmie fetch failed (${res.status}): ${text.slice(0, 200)}`);
+      return [];
+    }
+    const first = findFirstPost(text);
+    if (!first) return [];
+    const tagsAttr = extractAttribute(first, 'tags');
+    if (!tagsAttr) return [];
+    // Shimmie returns space-separated underscore tags. No per-category info
+    // is available via the danbooru-compat endpoint — everything is
+    // imported as "general"; users can re-categorise via the manual tag
+    // workflow if needed.
+    return tagsAttr
+      .split(/\s+/)
+      .map((tag) => normalizeTag(tag))
+      .filter(Boolean)
+      .map((tag) => ({ tag, category: 'general' } as TagResult));
+  },
+
+  extractIdFromUrl(url, site) {
+    const host = new URL(site.baseUrl).hostname.replace(/^www\./, '').toLowerCase();
+    const match = url.match(shimmieRegex(host));
+    if (!match?.[1]) return null;
+    return { remoteId: match[1] };
+  },
+
+  buildPostUrl(site, postId) {
+    return safeJoin(site.baseUrl, `/post/view/${postId}`);
+  }
+};

--- a/backend/src/lib/booruEngines/szurubooru.ts
+++ b/backend/src/lib/booruEngines/szurubooru.ts
@@ -1,0 +1,163 @@
+import { fetch } from 'undici';
+
+import { config } from '../../config';
+import type { BooruSiteRecord } from '../dataStore';
+
+import { normalizeTag, safeJoin } from './helpers';
+import type { BooruEngineModule, TagResult } from './types';
+
+// Szurubooru API reference: https://github.com/rr-/szurubooru/blob/master/doc/API.md
+// Auth: `Authorization: Token base64(username:token)` where `token` is the
+// API token rendered on the user's account page. There is no separate
+// "favorites" endpoint exposed as a list — favorites are inferred via
+// `query=fav:USERNAME` against /api/posts/. Tags returned per-post are an
+// array of objects with `names: string[]` and `category: string`.
+
+type SzurubooruTag = {
+  names?: string[] | null;
+  category?: string | null;
+};
+
+type SzurubooruPost = {
+  id?: number | string | null;
+  thumbnailUrl?: string | null;
+  contentUrl?: string | null;
+  canvasWidth?: number | null;
+  canvasHeight?: number | null;
+  safety?: string | null;
+  tags?: SzurubooruTag[] | null;
+  checksum?: string | null;
+  checksumMD5?: string | null;
+};
+
+type SzurubooruSearchResponse = {
+  query?: string;
+  offset?: number;
+  limit?: number;
+  total?: number;
+  results?: SzurubooruPost[] | null;
+};
+
+type SzurubooruPostResponse = SzurubooruPost;
+
+const userAgent = () => config.e621.userAgent;
+
+const buildHeaders = (site: BooruSiteRecord): Record<string, string> => {
+  const headers: Record<string, string> = {
+    'User-Agent': userAgent(),
+    Accept: 'application/json'
+  };
+  if (site.username && site.apiKey) {
+    const token = Buffer.from(`${site.username}:${site.apiKey}`).toString('base64');
+    headers.Authorization = `Token ${token}`;
+  }
+  return headers;
+};
+
+const escapeRegex = (value: string): string => value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+
+const szurubooruRegex = (host: string) =>
+  // Szurubooru post page is /post/{id} (no /show/). Some forks add a slug or
+  // hash fragment after the id — capture just the numeric id.
+  new RegExp(`^https?://(?:www\\.)?${escapeRegex(host)}/post/(\\d+)`, 'i');
+
+const collectTagsFromPost = (post: SzurubooruPost | null | undefined): TagResult[] => {
+  if (!post?.tags || !Array.isArray(post.tags)) return [];
+  const bucket: TagResult[] = [];
+  for (const entry of post.tags) {
+    const names = Array.isArray(entry?.names) ? entry.names : [];
+    const category = typeof entry?.category === 'string' ? entry.category : 'general';
+    for (const name of names) {
+      const cleaned = normalizeTag(name);
+      if (cleaned) bucket.push({ tag: cleaned, category });
+    }
+  }
+  return bucket;
+};
+
+export const szurubooruEngine: BooruEngineModule = {
+  type: 'szurubooru',
+  credentialSchema: 'token',
+  defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true },
+  defaultUserAgent: '',
+  probePath: '/api/posts/?offset=0&limit=1',
+  probeMatches: (body: unknown): boolean => {
+    if (!body || typeof body !== 'object') return false;
+    const results = (body as SzurubooruSearchResponse).results;
+    if (!Array.isArray(results)) return false;
+    if (results.length === 0) return true; // empty board is a valid szurubooru
+    const first = results[0];
+    if (!first || typeof first !== 'object') return false;
+    const tags = (first as SzurubooruPost).tags;
+    if (!Array.isArray(tags)) return false;
+    const sample = tags[0];
+    return !!sample && typeof sample === 'object' && Array.isArray((sample as { names?: unknown }).names);
+  },
+  probeSample: (body: unknown) => {
+    const results = (body as SzurubooruSearchResponse | null)?.results;
+    const post = Array.isArray(results) ? results[0] : null;
+    if (!post?.id) return null;
+    const id = String(post.id);
+    return {
+      postId: id,
+      thumbUrl: post.thumbnailUrl ?? null,
+      postPath: `/post/${id}`
+    };
+  },
+
+  async fetchPostTags(site, postId) {
+    const res = await fetch(safeJoin(site.baseUrl, `/api/post/${postId}`), { headers: buildHeaders(site) });
+    const text = await res.text();
+    if (!res.ok) {
+      console.warn(`[tags] szurubooru fetch failed (${res.status}): ${text.slice(0, 200)}`);
+      return [];
+    }
+    let data: SzurubooruPostResponse;
+    try {
+      data = JSON.parse(text) as SzurubooruPostResponse;
+    } catch {
+      console.warn(`[tags] szurubooru parse failed: ${text.slice(0, 200)}`);
+      return [];
+    }
+    return collectTagsFromPost(data);
+  },
+
+  async fetchPostByMd5(site, md5) {
+    // Szurubooru does not expose a generic md5 lookup. The closest match is
+    // /api/posts/?query=md5:HASH but some forks reject it. Best-effort.
+    const params = new URLSearchParams({ query: `checksum:${md5}`, offset: '0', limit: '1' });
+    const res = await fetch(safeJoin(site.baseUrl, `/api/posts/?${params.toString()}`), {
+      headers: buildHeaders(site)
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      console.warn(`[tags] szurubooru md5 fetch failed (${res.status}): ${text.slice(0, 200)}`);
+      return null;
+    }
+    let data: SzurubooruSearchResponse;
+    try {
+      data = JSON.parse(text) as SzurubooruSearchResponse;
+    } catch {
+      console.warn(`[tags] szurubooru md5 parse failed: ${text.slice(0, 200)}`);
+      return null;
+    }
+    const post = Array.isArray(data.results) ? data.results[0] : null;
+    if (!post) return null;
+    const id = post.id ? String(post.id) : null;
+    return {
+      tags: collectTagsFromPost(post),
+      sourceUrl: id ? safeJoin(site.baseUrl, `/post/${id}`) : null
+    };
+  },
+
+  extractIdFromUrl(url, site) {
+    const host = new URL(site.baseUrl).hostname.replace(/^www\./, '').toLowerCase();
+    const match = url.match(szurubooruRegex(host));
+    if (!match?.[1]) return null;
+    return { remoteId: match[1] };
+  },
+
+  buildPostUrl(site, postId) {
+    return safeJoin(site.baseUrl, `/post/${postId}`);
+  }
+};

--- a/backend/src/lib/booruEngines/types.ts
+++ b/backend/src/lib/booruEngines/types.ts
@@ -1,0 +1,81 @@
+import type { BooruEngineType, BooruSiteRecord } from '../dataStore';
+
+export type TagResult = {
+  tag: string;
+  category: string;
+  score?: number | null;
+  sourceUrl?: string | null;
+};
+
+export type BooruRemoteFavorite = {
+  provider: string;
+  remoteId: string;
+  sourceUrl: string;
+  fileUrl: string | null;
+};
+
+export type CredentialSchema =
+  | 'username+apikey'
+  | 'userid+apikey'
+  | 'apikey-only'
+  | 'token'
+  | 'none';
+
+export type EngineCapabilityDefaults = {
+  favorites: boolean;
+  tags: boolean;
+  sourceMatch: boolean;
+  search: boolean;
+};
+
+export type FetchFavoritesContext = {
+  onPage?: (page: number, count: number) => void;
+};
+
+export type ProbeSample = {
+  postId: string;
+  thumbUrl: string | null;
+  /** path joined with the user's `base_url` at call time, NOT an absolute URL. */
+  postPath: string;
+};
+
+export type BooruEngineModule = {
+  type: BooruEngineType;
+  credentialSchema: CredentialSchema;
+  defaultCapabilities: EngineCapabilityDefaults;
+
+  /** Default UA used for outgoing HTTP if site config doesn't override */
+  defaultUserAgent: string;
+
+  /** Returns probe relative path (joined with base_url). */
+  probePath: string;
+  probeMatches(body: unknown): boolean;
+  /**
+   * After `probeMatches(body) === true`, pull a single sample post out of
+   * the body so the UI can render a thumbnail as proof-of-life. Returning
+   * `null` is OK — detection still succeeds, the UI just shows no preview.
+   */
+  probeSample?(body: unknown): ProbeSample | null;
+
+  fetchPostTags(site: BooruSiteRecord, postId: string): Promise<TagResult[]>;
+  fetchPostByMd5?(
+    site: BooruSiteRecord,
+    md5: string
+  ): Promise<{ tags: TagResult[]; sourceUrl: string | null } | null>;
+
+  fetchFavorites?(
+    site: BooruSiteRecord,
+    ctx?: FetchFavoritesContext
+  ): Promise<{ items: BooruRemoteFavorite[]; downloadHeaders: Record<string, string> }>;
+
+  favorite?(site: BooruSiteRecord, postId: string): Promise<void>;
+  unfavorite?(site: BooruSiteRecord, postId: string): Promise<void>;
+
+  /** Extracts remote post id from a sauce URL if it belongs to this engine. */
+  extractIdFromUrl(url: string, site: BooruSiteRecord): { remoteId: string } | null;
+
+  /** Canonical URL for a post id on this site. */
+  buildPostUrl(site: BooruSiteRecord, postId: string): string;
+};
+
+export type EngineRegistry = Record<BooruEngineType, BooruEngineModule>;

--- a/backend/src/lib/booruSitesSeed.test.ts
+++ b/backend/src/lib/booruSitesSeed.test.ts
@@ -1,0 +1,71 @@
+// Seeds existing provider_credentials E621/DANBOORU rows into user_booru_sites
+// preset rows on boot. Pin the idempotency contract: running twice must not
+// duplicate, and existing preset rows must be left alone.
+import '../../test/helpers/setupEnv';
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { seedUser } from '../../test/helpers/testApp';
+
+import { seedBooruSitesFromLegacyCredentials } from './booruSitesSeed';
+import { dataStore } from './dataStore';
+
+test('seedBooruSitesFromLegacyCredentials creates preset rows from existing E621/DANBOORU credentials', async () => {
+  const seeded = await seedUser({ username: 'seed-from-creds' });
+  await dataStore.upsertCredential('E621', { username: 'e621-user', apiKey: 'e621-key' }, seeded.user.id);
+  await dataStore.upsertCredential('DANBOORU', { username: 'db-user', apiKey: 'db-key' }, seeded.user.id);
+
+  const result = await seedBooruSitesFromLegacyCredentials();
+  assert.ok(result.scannedUsers >= 1);
+  assert.ok(result.insertedRows >= 2);
+
+  const e621 = await dataStore.findBooruSiteByPresetKey('E621', seeded.user.id);
+  assert.ok(e621);
+  assert.equal(e621!.engine, 'e621');
+  assert.equal(e621!.baseUrl, 'https://e621.net');
+  assert.equal(e621!.username, 'e621-user');
+  assert.equal(e621!.apiKey, 'e621-key');
+  assert.equal(e621!.isPreset, true);
+  assert.equal(e621!.capFavorites, true);
+  assert.equal(e621!.capTags, true);
+
+  const danbooru = await dataStore.findBooruSiteByPresetKey('DANBOORU', seeded.user.id);
+  assert.ok(danbooru);
+  assert.equal(danbooru!.username, 'db-user');
+  assert.equal(danbooru!.apiKey, 'db-key');
+});
+
+test('seedBooruSitesFromLegacyCredentials is idempotent — second run inserts zero rows for already-seeded user', async () => {
+  const seeded = await seedUser({ username: 'seed-idempotent' });
+  await dataStore.upsertCredential('E621', { username: 'u', apiKey: 'k' }, seeded.user.id);
+
+  const first = await seedBooruSitesFromLegacyCredentials();
+  const firstInserted = first.insertedRows;
+  const second = await seedBooruSitesFromLegacyCredentials();
+  // The second call must not touch rows for users already seeded.
+  assert.ok(second.insertedRows < firstInserted, `expected second-pass inserts to drop, got ${second.insertedRows} vs ${firstInserted}`);
+
+  const sites = await dataStore.listBooruSites(seeded.user.id);
+  const e621Sites = sites.filter((site) => site.presetKey === 'E621');
+  assert.equal(e621Sites.length, 1, 'should never produce duplicate preset rows for one user');
+});
+
+test('seedBooruSitesFromLegacyCredentials skips SAUCENAO credentials (not a booru)', async () => {
+  const seeded = await seedUser({ username: 'seed-saucenao-only' });
+  await dataStore.upsertCredential('SAUCENAO', { apiKey: 'sn-key' }, seeded.user.id);
+
+  await seedBooruSitesFromLegacyCredentials();
+  const sites = await dataStore.listBooruSites(seeded.user.id);
+  // SAUCENAO is reverse image search, not a booru — must never end up as a
+  // user_booru_sites row.
+  assert.equal(sites.length, 0);
+});
+
+test('seedBooruSitesFromLegacyCredentials does nothing for users with no booru credentials', async () => {
+  const seeded = await seedUser({ username: 'seed-no-creds' });
+
+  await seedBooruSitesFromLegacyCredentials();
+  const sites = await dataStore.listBooruSites(seeded.user.id);
+  assert.equal(sites.length, 0);
+});

--- a/backend/src/lib/booruSitesSeed.ts
+++ b/backend/src/lib/booruSitesSeed.ts
@@ -1,5 +1,5 @@
-import { dataStore } from './dataStore';
 import { BOORU_PRESETS } from './booruEngines/presets';
+import { dataStore } from './dataStore';
 
 const PRESETS_WITH_LEGACY_CREDS = new Set(['E621', 'DANBOORU']);
 

--- a/backend/src/lib/booruSitesSeed.ts
+++ b/backend/src/lib/booruSitesSeed.ts
@@ -1,0 +1,50 @@
+import { dataStore } from './dataStore';
+import { BOORU_PRESETS } from './booruEngines/presets';
+
+const PRESETS_WITH_LEGACY_CREDS = new Set(['E621', 'DANBOORU']);
+
+/**
+ * One-shot, idempotent migration. For each user that has stored credentials in
+ * provider_credentials for E621 / DANBOORU, ensure a matching preset row in
+ * user_booru_sites exists with the credentials copied over. Users without
+ * credentials are left empty: they'll add sites via the UI on demand.
+ *
+ * Safe to call on every boot — does nothing if a preset row already exists for
+ * the user.
+ */
+export const seedBooruSitesFromLegacyCredentials = async (): Promise<{
+  scannedUsers: number;
+  insertedRows: number;
+}> => {
+  const users = await dataStore.listUsers();
+  let inserted = 0;
+  for (const user of users) {
+    const credentials = await dataStore.listCredentials(user.id);
+    for (const credential of credentials) {
+      if (!PRESETS_WITH_LEGACY_CREDS.has(credential.provider)) continue;
+      const preset = BOORU_PRESETS.find((p) => p.key === credential.provider);
+      if (!preset) continue;
+      const existing = await dataStore.findBooruSiteByPresetKey(preset.key, user.id);
+      if (existing) continue;
+      await dataStore.insertBooruSite(
+        {
+          name: preset.name,
+          engine: preset.engine,
+          baseUrl: preset.baseUrl,
+          username: credential.username,
+          apiKey: credential.apiKey,
+          isPreset: true,
+          presetKey: preset.key,
+          enabled: true,
+          capFavorites: preset.defaultCapabilities.favorites,
+          capTags: preset.defaultCapabilities.tags,
+          capSourceMatch: preset.defaultCapabilities.sourceMatch,
+          capSearch: preset.defaultCapabilities.search
+        },
+        user.id
+      );
+      inserted += 1;
+    }
+  }
+  return { scannedUsers: users.length, insertedRows: inserted };
+};

--- a/backend/src/lib/booruSitesStore.test.ts
+++ b/backend/src/lib/booruSitesStore.test.ts
@@ -1,0 +1,90 @@
+// CRUD + data-integrity contract for user_booru_sites. The headline case:
+// deleting a custom site must purge its favorite_items rows (they're keyed by
+// the site UUID with no FK), otherwise those rows orphan and reverse-sync
+// silently no-ops.
+import '../../test/helpers/setupEnv';
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { seedUser } from '../../test/helpers/testApp';
+
+import { dataStore } from './dataStore';
+
+test('deleteBooruSite purges favorite_items rows owned by the deleted custom site', async () => {
+  const seeded = await seedUser({ username: 'delete-cascade' });
+
+  const site = await dataStore.insertBooruSite(
+    {
+      name: 'My booru',
+      engine: 'szurubooru',
+      baseUrl: 'https://my.example.com',
+      isPreset: false,
+      presetKey: null,
+      enabled: true,
+      capFavorites: true,
+      capTags: true,
+      capSourceMatch: true,
+      capSearch: false
+    },
+    seeded.user.id
+  );
+
+  // Favorites for a custom site are keyed by the site UUID.
+  await dataStore.upsertFavoriteItem(
+    {
+      provider: site.id,
+      remoteId: '1',
+      filePath: '/tmp/a.jpg',
+      sourceUrl: 'https://my.example.com/post/1',
+      fileUrl: null
+    },
+    seeded.user.id
+  );
+  assert.equal((await dataStore.listFavoriteItems(site.id, seeded.user.id)).length, 1);
+
+  const removed = await dataStore.deleteBooruSite(site.id, seeded.user.id);
+  assert.equal(removed, true);
+
+  // Site gone AND its favorites gone — no orphans.
+  assert.equal(await dataStore.getBooruSite(site.id, seeded.user.id), null);
+  assert.equal((await dataStore.listFavoriteItems(site.id, seeded.user.id)).length, 0);
+});
+
+test('deleteBooruSite refuses to delete preset rows and leaves them intact', async () => {
+  const seeded = await seedUser({ username: 'delete-preset' });
+  const preset = await dataStore.insertBooruSite(
+    {
+      name: 'e621',
+      engine: 'e621',
+      baseUrl: 'https://e621.net',
+      isPreset: true,
+      presetKey: 'E621',
+      enabled: true,
+      capFavorites: true,
+      capTags: true,
+      capSourceMatch: true,
+      capSearch: false
+    },
+    seeded.user.id
+  );
+  const removed = await dataStore.deleteBooruSite(preset.id, seeded.user.id);
+  assert.equal(removed, false);
+  assert.ok(await dataStore.getBooruSite(preset.id, seeded.user.id));
+});
+
+test('deleteBooruSite does not touch another user\'s favorites that share a remote id', async () => {
+  const a = await seedUser({ username: 'cascade-user-a' });
+  const b = await seedUser({ username: 'cascade-user-b' });
+  const siteA = await dataStore.insertBooruSite(
+    { name: 'A', engine: 'szurubooru', baseUrl: 'https://a.example.com', isPreset: false, presetKey: null, enabled: true, capFavorites: true, capTags: true, capSourceMatch: true, capSearch: false },
+    a.user.id
+  );
+  // user B has a favorite under a legacy preset key, unrelated to siteA.id
+  await dataStore.upsertFavoriteItem(
+    { provider: 'E621', remoteId: '99', filePath: '/tmp/b.jpg', sourceUrl: null, fileUrl: null },
+    b.user.id
+  );
+  await dataStore.deleteBooruSite(siteA.id, a.user.id);
+  assert.equal((await dataStore.listFavoriteItems('E621', b.user.id)).length, 1);
+});

--- a/backend/src/lib/dataStore.ts
+++ b/backend/src/lib/dataStore.ts
@@ -1906,38 +1906,46 @@ export const dataStore = {
   async insertBooruSite(input: BooruSiteInput, userId: string): Promise<BooruSiteRecord> {
     const id = randomUUID();
     const now = new Date().toISOString();
-    const nextSortOrder = input.sortOrder ?? (() => {
-      const row = db
-        .prepare('SELECT COALESCE(MAX(sort_order), -1) + 1 AS next FROM user_booru_sites WHERE user_id = ?')
-        .get(userId) as { next: number };
-      return row.next;
-    })();
-    db.prepare(
-      `INSERT INTO user_booru_sites
-         (id, user_id, name, engine, base_url, username, api_key,
-          is_preset, preset_key, enabled,
-          cap_favorites, cap_tags, cap_source_match, cap_search,
-          sort_order, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      id,
-      userId,
-      input.name,
-      input.engine,
-      input.baseUrl,
-      input.username ?? null,
-      input.apiKey ?? null,
-      input.isPreset ? 1 : 0,
-      input.presetKey ?? null,
-      input.enabled === false ? 0 : 1,
-      input.capFavorites ? 1 : 0,
-      input.capTags ? 1 : 0,
-      input.capSourceMatch ? 1 : 0,
-      input.capSearch ? 1 : 0,
-      nextSortOrder,
-      now,
-      now
-    );
+    // MAX(sort_order)+1 read and the INSERT run in one transaction so two
+    // concurrent inserts for the same user can't read the same max and collide
+    // on sort_order. better-sqlite3 transactions are synchronous, so nothing
+    // interleaves between the SELECT and the INSERT.
+    const insertTx = db.transaction(() => {
+      const nextSortOrder =
+        input.sortOrder ??
+        (
+          db
+            .prepare('SELECT COALESCE(MAX(sort_order), -1) + 1 AS next FROM user_booru_sites WHERE user_id = ?')
+            .get(userId) as { next: number }
+        ).next;
+      db.prepare(
+        `INSERT INTO user_booru_sites
+           (id, user_id, name, engine, base_url, username, api_key,
+            is_preset, preset_key, enabled,
+            cap_favorites, cap_tags, cap_source_match, cap_search,
+            sort_order, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        id,
+        userId,
+        input.name,
+        input.engine,
+        input.baseUrl,
+        input.username ?? null,
+        input.apiKey ?? null,
+        input.isPreset ? 1 : 0,
+        input.presetKey ?? null,
+        input.enabled === false ? 0 : 1,
+        input.capFavorites ? 1 : 0,
+        input.capTags ? 1 : 0,
+        input.capSourceMatch ? 1 : 0,
+        input.capSearch ? 1 : 0,
+        nextSortOrder,
+        now,
+        now
+      );
+    });
+    insertTx();
     const row = db.prepare('SELECT * FROM user_booru_sites WHERE id = ?').get(id) as BooruSiteRow;
     return mapBooruSiteRow(row);
   },

--- a/backend/src/lib/dataStore.ts
+++ b/backend/src/lib/dataStore.ts
@@ -75,7 +75,11 @@ export type ProviderRunRecord = {
   error: string | null;
 };
 
-export type FavoriteProvider = 'E621' | 'DANBOORU';
+// Opaque identifier. Holds either a legacy preset key ('E621', 'DANBOORU', ...)
+// or a `user_booru_sites.id` UUID for custom sites added by the user.
+export type FavoriteProvider = string;
+
+export type LegacyFavoriteProvider = 'E621' | 'DANBOORU';
 
 export type FavoriteItemRecord = {
   provider: FavoriteProvider;
@@ -88,6 +92,52 @@ export type FavoriteItemRecord = {
 };
 
 export type CredentialProvider = 'E621' | 'DANBOORU' | 'SAUCENAO';
+
+export type BooruEngineType =
+  | 'danbooru'
+  | 'e621'
+  | 'moebooru'
+  | 'gelbooru'
+  | 'sankaku'
+  | 'philomena'
+  | 'shimmie'
+  | 'szurubooru';
+
+export type BooruSiteRecord = {
+  id: string;
+  userId: string;
+  name: string;
+  engine: BooruEngineType;
+  baseUrl: string;
+  username: string | null;
+  apiKey: string | null;
+  isPreset: boolean;
+  presetKey: string | null;
+  enabled: boolean;
+  capFavorites: boolean;
+  capTags: boolean;
+  capSourceMatch: boolean;
+  capSearch: boolean;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type BooruSiteInput = {
+  name: string;
+  engine: BooruEngineType;
+  baseUrl: string;
+  username?: string | null;
+  apiKey?: string | null;
+  isPreset?: boolean;
+  presetKey?: string | null;
+  enabled?: boolean;
+  capFavorites?: boolean;
+  capTags?: boolean;
+  capSourceMatch?: boolean;
+  capSearch?: boolean;
+  sortOrder?: number;
+};
 
 export type CredentialRecord = {
   provider: CredentialProvider;
@@ -125,16 +175,21 @@ export type SessionRecord = {
   expiresAt: string;
 };
 
-export type TagSource =
-  | 'E621'
-  | 'DANBOORU'
-  | 'GELBOORU'
-  | 'YANDERE'
-  | 'KONACHAN'
-  | 'SANKAKU'
-  | 'IDOL_COMPLEX'
-  | 'WD14'
-  | 'MANUAL';
+// Opaque tag source identifier. Holds legacy preset keys ('E621', 'DANBOORU',
+// 'GELBOORU', 'YANDERE', 'KONACHAN', 'SANKAKU', 'IDOL_COMPLEX'), the special
+// values 'WD14' / 'MANUAL', or a `user_booru_sites.id` UUID for custom sites.
+export type TagSource = string;
+
+export const SPECIAL_TAG_SOURCES = ['WD14', 'MANUAL'] as const;
+export const LEGACY_BOORU_TAG_SOURCES = [
+  'E621',
+  'DANBOORU',
+  'GELBOORU',
+  'YANDERE',
+  'KONACHAN',
+  'SANKAKU',
+  'IDOL_COMPLEX'
+] as const;
 
 export type FileTagRecord = {
   fileId: string;
@@ -247,6 +302,26 @@ type FavoriteItemRow = {
   file_path: string;
   source_url?: string | null;
   file_url?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type BooruSiteRow = {
+  id: string;
+  user_id: string;
+  name: string;
+  engine: string;
+  base_url: string;
+  username?: string | null;
+  api_key?: string | null;
+  is_preset: number;
+  preset_key?: string | null;
+  enabled: number;
+  cap_favorites: number;
+  cap_tags: number;
+  cap_source_match: number;
+  cap_search: number;
+  sort_order: number;
   created_at: string;
   updated_at: string;
 };
@@ -420,6 +495,28 @@ db.exec(`
     PRIMARY KEY (user_id, provider)
   );
 
+  CREATE TABLE IF NOT EXISTS user_booru_sites (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    engine TEXT NOT NULL,
+    base_url TEXT NOT NULL,
+    username TEXT,
+    api_key TEXT,
+    is_preset INTEGER NOT NULL,
+    preset_key TEXT,
+    enabled INTEGER NOT NULL,
+    cap_favorites INTEGER NOT NULL,
+    cap_tags INTEGER NOT NULL,
+    cap_source_match INTEGER NOT NULL,
+    cap_search INTEGER NOT NULL,
+    sort_order INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (user_id, preset_key),
+    UNIQUE (user_id, base_url)
+  );
+
   CREATE TABLE IF NOT EXISTS file_manual_order (
     file_id TEXT PRIMARY KEY REFERENCES files(id) ON DELETE CASCADE,
     position REAL NOT NULL,
@@ -454,6 +551,10 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_favorite_items_provider ON favorite_items(provider);
   CREATE INDEX IF NOT EXISTS idx_favorite_items_file_path ON favorite_items(file_path);
   CREATE INDEX IF NOT EXISTS idx_provider_credentials_provider ON provider_credentials(provider);
+  CREATE INDEX IF NOT EXISTS idx_user_booru_sites_user_sort ON user_booru_sites(user_id, sort_order);
+  CREATE INDEX IF NOT EXISTS idx_user_booru_sites_user_fav ON user_booru_sites(user_id, enabled, cap_favorites);
+  CREATE INDEX IF NOT EXISTS idx_user_booru_sites_user_tags ON user_booru_sites(user_id, enabled, cap_tags);
+  CREATE INDEX IF NOT EXISTS idx_user_booru_sites_user_match ON user_booru_sites(user_id, enabled, cap_source_match);
   CREATE INDEX IF NOT EXISTS idx_file_manual_order_position ON file_manual_order(position);
   CREATE INDEX IF NOT EXISTS idx_file_signatures_sample_size_file_id ON file_signatures(sample_size, file_id);
   CREATE INDEX IF NOT EXISTS idx_files_media_type ON files(media_type);
@@ -692,6 +793,26 @@ const mapFavoriteRow = (row: FavoriteItemRow): FavoriteItemRecord => ({
   filePath: row.file_path,
   sourceUrl: row.source_url ?? null,
   fileUrl: row.file_url ?? null,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at
+});
+
+const mapBooruSiteRow = (row: BooruSiteRow): BooruSiteRecord => ({
+  id: row.id,
+  userId: row.user_id,
+  name: row.name,
+  engine: row.engine as BooruEngineType,
+  baseUrl: row.base_url,
+  username: row.username ?? null,
+  apiKey: row.api_key ?? null,
+  isPreset: row.is_preset === 1,
+  presetKey: row.preset_key ?? null,
+  enabled: row.enabled === 1,
+  capFavorites: row.cap_favorites === 1,
+  capTags: row.cap_tags === 1,
+  capSourceMatch: row.cap_source_match === 1,
+  capSearch: row.cap_search === 1,
+  sortOrder: row.sort_order,
   createdAt: row.created_at,
   updatedAt: row.updated_at
 });
@@ -1757,6 +1878,146 @@ export const dataStore = {
   },
   async deleteFavoriteItem(provider: FavoriteProvider, remoteId: string, userId: string) {
     db.prepare('DELETE FROM favorite_items WHERE provider = ? AND remote_id = ? AND user_id = ?').run(provider, remoteId, userId);
+  },
+  async listBooruSites(userId: string): Promise<BooruSiteRecord[]> {
+    const rows = db
+      .prepare('SELECT * FROM user_booru_sites WHERE user_id = ? ORDER BY sort_order ASC, created_at ASC')
+      .all(userId) as BooruSiteRow[];
+    return rows.map(mapBooruSiteRow);
+  },
+  async getBooruSite(id: string, userId: string): Promise<BooruSiteRecord | null> {
+    const row = db
+      .prepare('SELECT * FROM user_booru_sites WHERE id = ? AND user_id = ?')
+      .get(id, userId) as BooruSiteRow | undefined;
+    return row ? mapBooruSiteRow(row) : null;
+  },
+  async findBooruSiteByPresetKey(presetKey: string, userId: string): Promise<BooruSiteRecord | null> {
+    const row = db
+      .prepare('SELECT * FROM user_booru_sites WHERE preset_key = ? AND user_id = ?')
+      .get(presetKey, userId) as BooruSiteRow | undefined;
+    return row ? mapBooruSiteRow(row) : null;
+  },
+  async findBooruSiteByBaseUrl(baseUrl: string, userId: string): Promise<BooruSiteRecord | null> {
+    const row = db
+      .prepare('SELECT * FROM user_booru_sites WHERE base_url = ? AND user_id = ?')
+      .get(baseUrl, userId) as BooruSiteRow | undefined;
+    return row ? mapBooruSiteRow(row) : null;
+  },
+  async insertBooruSite(input: BooruSiteInput, userId: string): Promise<BooruSiteRecord> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    const nextSortOrder = input.sortOrder ?? (() => {
+      const row = db
+        .prepare('SELECT COALESCE(MAX(sort_order), -1) + 1 AS next FROM user_booru_sites WHERE user_id = ?')
+        .get(userId) as { next: number };
+      return row.next;
+    })();
+    db.prepare(
+      `INSERT INTO user_booru_sites
+         (id, user_id, name, engine, base_url, username, api_key,
+          is_preset, preset_key, enabled,
+          cap_favorites, cap_tags, cap_source_match, cap_search,
+          sort_order, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      id,
+      userId,
+      input.name,
+      input.engine,
+      input.baseUrl,
+      input.username ?? null,
+      input.apiKey ?? null,
+      input.isPreset ? 1 : 0,
+      input.presetKey ?? null,
+      input.enabled === false ? 0 : 1,
+      input.capFavorites ? 1 : 0,
+      input.capTags ? 1 : 0,
+      input.capSourceMatch ? 1 : 0,
+      input.capSearch ? 1 : 0,
+      nextSortOrder,
+      now,
+      now
+    );
+    const row = db.prepare('SELECT * FROM user_booru_sites WHERE id = ?').get(id) as BooruSiteRow;
+    return mapBooruSiteRow(row);
+  },
+  async updateBooruSite(
+    id: string,
+    updates: Partial<BooruSiteInput>,
+    userId: string
+  ): Promise<BooruSiteRecord | null> {
+    const existing = db
+      .prepare('SELECT * FROM user_booru_sites WHERE id = ? AND user_id = ?')
+      .get(id, userId) as BooruSiteRow | undefined;
+    if (!existing) return null;
+    const merged: BooruSiteRow = {
+      ...existing,
+      name: updates.name ?? existing.name,
+      engine: updates.engine ?? existing.engine,
+      base_url: updates.baseUrl ?? existing.base_url,
+      username: updates.username !== undefined ? updates.username : existing.username,
+      api_key: updates.apiKey !== undefined ? updates.apiKey : existing.api_key,
+      enabled: updates.enabled !== undefined ? (updates.enabled ? 1 : 0) : existing.enabled,
+      cap_favorites:
+        updates.capFavorites !== undefined ? (updates.capFavorites ? 1 : 0) : existing.cap_favorites,
+      cap_tags: updates.capTags !== undefined ? (updates.capTags ? 1 : 0) : existing.cap_tags,
+      cap_source_match:
+        updates.capSourceMatch !== undefined ? (updates.capSourceMatch ? 1 : 0) : existing.cap_source_match,
+      cap_search: updates.capSearch !== undefined ? (updates.capSearch ? 1 : 0) : existing.cap_search,
+      sort_order: updates.sortOrder ?? existing.sort_order,
+      updated_at: new Date().toISOString()
+    };
+    db.prepare(
+      `UPDATE user_booru_sites
+       SET name = ?, engine = ?, base_url = ?, username = ?, api_key = ?,
+           enabled = ?, cap_favorites = ?, cap_tags = ?, cap_source_match = ?, cap_search = ?,
+           sort_order = ?, updated_at = ?
+       WHERE id = ? AND user_id = ?`
+    ).run(
+      merged.name,
+      merged.engine,
+      merged.base_url,
+      merged.username ?? null,
+      merged.api_key ?? null,
+      merged.enabled,
+      merged.cap_favorites,
+      merged.cap_tags,
+      merged.cap_source_match,
+      merged.cap_search,
+      merged.sort_order,
+      merged.updated_at,
+      id,
+      userId
+    );
+    return mapBooruSiteRow(merged);
+  },
+  async deleteBooruSite(id: string, userId: string): Promise<boolean> {
+    // favorite_items.provider has no FK to user_booru_sites (it stores either a
+    // legacy preset key or a custom-site UUID), so deleting a site must also
+    // purge its favorites rows in the same transaction. Otherwise custom-site
+    // favorites become orphaned: their provider UUID can never resolve back to
+    // a site, so reverse-sync/unfavorite silently no-op and the rows are dead.
+    const tx = db.transaction(() => {
+      const result = db
+        .prepare('DELETE FROM user_booru_sites WHERE id = ? AND user_id = ? AND is_preset = 0')
+        .run(id, userId);
+      if ((result.changes ?? 0) === 0) return false;
+      db.prepare('DELETE FROM favorite_items WHERE provider = ? AND user_id = ?').run(id, userId);
+      return true;
+    });
+    return tx() as boolean;
+  },
+  async reorderBooruSites(orderedIds: string[], userId: string): Promise<void> {
+    const stmt = db.prepare(
+      'UPDATE user_booru_sites SET sort_order = ?, updated_at = ? WHERE id = ? AND user_id = ?'
+    );
+    const now = new Date().toISOString();
+    const tx = db.transaction(() => {
+      orderedIds.forEach((id, idx) => {
+        stmt.run(idx, now, id, userId);
+      });
+    });
+    tx();
   },
   async getFavoritesSettings(userId: string): Promise<FavoritesSettings> {
     const autoSyncDefault = config.favorites.syncIntervalMs > 0;

--- a/backend/src/lib/favoriteSourceMatch.test.ts
+++ b/backend/src/lib/favoriteSourceMatch.test.ts
@@ -1,0 +1,112 @@
+// URL-matcher built dynamically from a user's user_booru_sites rows. Pins
+// the contract for `extractFavoriteRemoteFromSiteList` so that adding /
+// removing engines or sites keeps producing the expected `(provider,
+// remoteId)` pair for routing favorites + auto-fav decisions.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { BooruEngineType, BooruSiteRecord } from './dataStore';
+import { extractFavoriteRemoteFromSiteList, extractFavoriteRemoteFromSourceUrl } from './favoriteSourceMatch';
+
+const siteFixture = (overrides: Partial<BooruSiteRecord>): BooruSiteRecord => ({
+  id: 'site-' + (overrides.name ?? 'x'),
+  userId: 'user-1',
+  name: 'fixture',
+  engine: 'e621' as BooruEngineType,
+  baseUrl: 'https://e621.net',
+  username: null,
+  apiKey: null,
+  isPreset: false,
+  presetKey: null,
+  enabled: true,
+  capFavorites: false,
+  capTags: false,
+  capSourceMatch: true,
+  capSearch: false,
+  sortOrder: 0,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  ...overrides
+});
+
+test('extractFavoriteRemoteFromSiteList resolves canonical e621 URL to its preset site', () => {
+  const e621 = siteFixture({ engine: 'e621', baseUrl: 'https://e621.net', isPreset: true, presetKey: 'E621' });
+  const result = extractFavoriteRemoteFromSiteList('https://e621.net/posts/42', [e621]);
+  assert.ok(result);
+  assert.equal(result!.provider, e621.id);
+  assert.equal(result!.remoteId, '42');
+  assert.equal(result!.site.engine, 'e621');
+});
+
+test('extractFavoriteRemoteFromSiteList resolves danbooru URL to danbooru site', () => {
+  const danbooru = siteFixture({
+    engine: 'danbooru',
+    baseUrl: 'https://danbooru.donmai.us',
+    isPreset: true,
+    presetKey: 'DANBOORU'
+  });
+  const result = extractFavoriteRemoteFromSiteList('https://danbooru.donmai.us/posts/777', [danbooru]);
+  assert.ok(result);
+  assert.equal(result!.remoteId, '777');
+  assert.equal(result!.site.engine, 'danbooru');
+});
+
+test('extractFavoriteRemoteFromSiteList skips sites with capSourceMatch=false', () => {
+  const e621 = siteFixture({
+    engine: 'e621',
+    baseUrl: 'https://e621.net',
+    capSourceMatch: false
+  });
+  // Even though the URL belongs to e621, the user has disabled URL matching
+  // for this site, so it must not produce a hit.
+  assert.equal(extractFavoriteRemoteFromSiteList('https://e621.net/posts/1', [e621]), null);
+});
+
+test('extractFavoriteRemoteFromSiteList skips disabled sites', () => {
+  const e621 = siteFixture({
+    engine: 'e621',
+    baseUrl: 'https://e621.net',
+    enabled: false
+  });
+  assert.equal(extractFavoriteRemoteFromSiteList('https://e621.net/posts/1', [e621]), null);
+});
+
+test('extractFavoriteRemoteFromSiteList returns null for URLs no configured site claims', () => {
+  const e621 = siteFixture({ engine: 'e621', baseUrl: 'https://e621.net' });
+  assert.equal(extractFavoriteRemoteFromSiteList('https://example.com/post/1', [e621]), null);
+});
+
+test('extractFavoriteRemoteFromSiteList prefers earlier sortOrder when two sites could match', () => {
+  // Two e621 sites for the same user with different base_url; only one
+  // matches a given URL. Sort order should make the chosen site
+  // deterministic across reads.
+  const first = siteFixture({
+    id: 'first',
+    engine: 'e621',
+    baseUrl: 'https://e621.net',
+    sortOrder: 0
+  });
+  const second = siteFixture({
+    id: 'second',
+    engine: 'e621',
+    baseUrl: 'https://e926.net',
+    sortOrder: 1
+  });
+  const result = extractFavoriteRemoteFromSiteList('https://e621.net/posts/9', [second, first]);
+  assert.ok(result);
+  assert.equal(result!.site.id, 'first');
+});
+
+test('extractFavoriteRemoteFromSourceUrl legacy fallback still matches the two original hardcoded providers', () => {
+  // This function is kept as a fallback for workers that have no user
+  // context; it must continue to recognise the canonical e621 + danbooru
+  // post URLs.
+  assert.deepEqual(extractFavoriteRemoteFromSourceUrl('https://e621.net/posts/1'), {
+    provider: 'E621',
+    remoteId: '1'
+  });
+  assert.deepEqual(extractFavoriteRemoteFromSourceUrl('https://danbooru.donmai.us/posts/2'), {
+    provider: 'DANBOORU',
+    remoteId: '2'
+  });
+});

--- a/backend/src/lib/favoriteSourceMatch.test.ts
+++ b/backend/src/lib/favoriteSourceMatch.test.ts
@@ -6,7 +6,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import type { BooruEngineType, BooruSiteRecord } from './dataStore';
-import { extractFavoriteRemoteFromSiteList, extractFavoriteRemoteFromSourceUrl } from './favoriteSourceMatch';
+import { extractFavoriteRemoteFromSiteList } from './favoriteSourceMatch';
 
 const siteFixture = (overrides: Partial<BooruSiteRecord>): BooruSiteRecord => ({
   id: 'site-' + (overrides.name ?? 'x'),
@@ -95,18 +95,4 @@ test('extractFavoriteRemoteFromSiteList prefers earlier sortOrder when two sites
   const result = extractFavoriteRemoteFromSiteList('https://e621.net/posts/9', [second, first]);
   assert.ok(result);
   assert.equal(result!.site.id, 'first');
-});
-
-test('extractFavoriteRemoteFromSourceUrl legacy fallback still matches the two original hardcoded providers', () => {
-  // This function is kept as a fallback for workers that have no user
-  // context; it must continue to recognise the canonical e621 + danbooru
-  // post URLs.
-  assert.deepEqual(extractFavoriteRemoteFromSourceUrl('https://e621.net/posts/1'), {
-    provider: 'E621',
-    remoteId: '1'
-  });
-  assert.deepEqual(extractFavoriteRemoteFromSourceUrl('https://danbooru.donmai.us/posts/2'), {
-    provider: 'DANBOORU',
-    remoteId: '2'
-  });
 });

--- a/backend/src/lib/favoriteSourceMatch.ts
+++ b/backend/src/lib/favoriteSourceMatch.ts
@@ -1,16 +1,42 @@
-import type { FavoriteProvider } from './dataStore';
+import { getEngine } from './booruEngines';
+import type { BooruSiteRecord, FavoriteProvider } from './dataStore';
 
-// Registry of supported favorite providers. To add a new site:
-//   1. Extend the `FavoriteProvider` union in dataStore.ts.
-//   2. Add a `{provider, pattern}` entry here matching post URLs (capture
-//      group 1 must be the remote post id).
-//   3. Wire the network calls in services/favorites.ts FAVORITE_API_REGISTRY
-//      (favorite + unfavorite). No other code needs to change.
+// Legacy hardcoded patterns. Kept as a fallback so that callers without
+// per-user site context (e.g. workers operating before login) can still match
+// the canonical e621.net / danbooru.donmai.us URLs. New code should prefer
+// `extractFavoriteRemoteFromSiteList(url, sites)`.
 export const FAVORITE_URL_PATTERNS: { provider: FavoriteProvider; pattern: RegExp }[] = [
   { provider: 'E621', pattern: /^https?:\/\/(?:www\.)?e621\.net\/posts\/(\d+)/i },
   { provider: 'DANBOORU', pattern: /^https?:\/\/(?:www\.)?danbooru\.donmai\.us\/posts\/(\d+)/i }
 ];
 
+// Per-user URL matcher built from the caller's `user_booru_sites` rows. Only
+// considers sites with `capSourceMatch = true` and `enabled = true`, in
+// ascending `sortOrder`. Returns the site id as the `provider` value so the
+// caller can persist a `favorite_items.provider = site.id` row that uniquely
+// identifies which configured site originated the match.
+export const extractFavoriteRemoteFromSiteList = (
+  sourceUrl: string | null | undefined,
+  sites: BooruSiteRecord[]
+): { provider: FavoriteProvider; remoteId: string; site: BooruSiteRecord } | null => {
+  if (!sourceUrl) return null;
+  const ordered = [...sites]
+    .filter((site) => site.enabled && site.capSourceMatch)
+    .sort((a, b) => a.sortOrder - b.sortOrder);
+  for (const site of ordered) {
+    const engine = getEngine(site.engine);
+    if (!engine) continue;
+    const result = engine.extractIdFromUrl(sourceUrl, site);
+    if (result) {
+      return { provider: site.id, remoteId: result.remoteId, site };
+    }
+  }
+  return null;
+};
+
+// Legacy fallback that does NOT consult user sites. Use only for code paths
+// that have no userId available. New code should call
+// `extractFavoriteRemoteFromSiteList`.
 export const extractFavoriteRemoteFromSourceUrl = (
   sourceUrl: string | null | undefined
 ): { provider: FavoriteProvider; remoteId: string } | null => {

--- a/backend/src/lib/favoriteSourceMatch.ts
+++ b/backend/src/lib/favoriteSourceMatch.ts
@@ -1,15 +1,6 @@
 import { getEngine } from './booruEngines';
 import type { BooruSiteRecord, FavoriteProvider } from './dataStore';
 
-// Legacy hardcoded patterns. Kept as a fallback so that callers without
-// per-user site context (e.g. workers operating before login) can still match
-// the canonical e621.net / danbooru.donmai.us URLs. New code should prefer
-// `extractFavoriteRemoteFromSiteList(url, sites)`.
-export const FAVORITE_URL_PATTERNS: { provider: FavoriteProvider; pattern: RegExp }[] = [
-  { provider: 'E621', pattern: /^https?:\/\/(?:www\.)?e621\.net\/posts\/(\d+)/i },
-  { provider: 'DANBOORU', pattern: /^https?:\/\/(?:www\.)?danbooru\.donmai\.us\/posts\/(\d+)/i }
-];
-
 // Per-user URL matcher built from the caller's `user_booru_sites` rows. Only
 // considers sites with `capSourceMatch = true` and `enabled = true`, in
 // ascending `sortOrder`. Returns the site id as the `provider` value so the
@@ -30,20 +21,6 @@ export const extractFavoriteRemoteFromSiteList = (
     if (result) {
       return { provider: site.id, remoteId: result.remoteId, site };
     }
-  }
-  return null;
-};
-
-// Legacy fallback that does NOT consult user sites. Use only for code paths
-// that have no userId available. New code should call
-// `extractFavoriteRemoteFromSiteList`.
-export const extractFavoriteRemoteFromSourceUrl = (
-  sourceUrl: string | null | undefined
-): { provider: FavoriteProvider; remoteId: string } | null => {
-  if (!sourceUrl) return null;
-  for (const { provider, pattern } of FAVORITE_URL_PATTERNS) {
-    const m = sourceUrl.match(pattern);
-    if (m) return { provider, remoteId: m[1] };
   }
   return null;
 };

--- a/backend/src/routes/booruSites.ts
+++ b/backend/src/routes/booruSites.ts
@@ -3,8 +3,8 @@ import { fetch } from 'undici';
 import { z } from 'zod';
 
 import { config } from '../config';
-import { detectEngine } from '../lib/booruEngines/detect';
 import { getEngine, listEngines } from '../lib/booruEngines';
+import { detectEngine } from '../lib/booruEngines/detect';
 import { BOORU_PRESETS } from '../lib/booruEngines/presets';
 import { BooruEngineType, BooruSiteRecord, dataStore } from '../lib/dataStore';
 

--- a/backend/src/routes/booruSites.ts
+++ b/backend/src/routes/booruSites.ts
@@ -1,0 +1,291 @@
+import { FastifyInstance } from 'fastify';
+import { fetch } from 'undici';
+import { z } from 'zod';
+
+import { config } from '../config';
+import { detectEngine } from '../lib/booruEngines/detect';
+import { getEngine, listEngines } from '../lib/booruEngines';
+import { BOORU_PRESETS } from '../lib/booruEngines/presets';
+import { BooruEngineType, BooruSiteRecord, dataStore } from '../lib/dataStore';
+
+const engineEnum = z.enum([
+  'danbooru',
+  'e621',
+  'moebooru',
+  'gelbooru',
+  'sankaku',
+  'philomena',
+  'shimmie',
+  'szurubooru'
+]);
+
+const createSchema = z.object({
+  name: z.string().min(1).max(100),
+  engine: engineEnum,
+  baseUrl: z.string().url(),
+  username: z.string().optional().nullable(),
+  apiKey: z.string().optional().nullable(),
+  capFavorites: z.boolean().optional(),
+  capTags: z.boolean().optional(),
+  capSourceMatch: z.boolean().optional(),
+  capSearch: z.boolean().optional(),
+  enabled: z.boolean().optional()
+});
+
+const updateSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  username: z.string().nullable().optional(),
+  apiKey: z.string().nullable().optional(),
+  enabled: z.boolean().optional(),
+  capFavorites: z.boolean().optional(),
+  capTags: z.boolean().optional(),
+  capSourceMatch: z.boolean().optional(),
+  capSearch: z.boolean().optional(),
+  // Only honoured for non-preset rows; presets ignore engine/baseUrl edits to
+  // keep historical favorite_items rows pointing at the right canonical site.
+  engine: engineEnum.optional(),
+  baseUrl: z.string().url().optional()
+});
+
+const detectSchema = z.object({
+  baseUrl: z.string().url()
+});
+
+const reorderSchema = z.object({
+  orderedIds: z.array(z.string()).min(1)
+});
+
+const toPublic = (site: BooruSiteRecord) => ({
+  id: site.id,
+  name: site.name,
+  engine: site.engine,
+  baseUrl: site.baseUrl,
+  username: site.username,
+  hasApiKey: Boolean(site.apiKey),
+  isPreset: site.isPreset,
+  presetKey: site.presetKey,
+  enabled: site.enabled,
+  capFavorites: site.capFavorites,
+  capTags: site.capTags,
+  capSourceMatch: site.capSourceMatch,
+  capSearch: site.capSearch,
+  sortOrder: site.sortOrder,
+  createdAt: site.createdAt,
+  updatedAt: site.updatedAt,
+  engineCredentialSchema: getEngine(site.engine)?.credentialSchema ?? 'none'
+});
+
+const trimOrUndefined = (value: string | null | undefined): string | null | undefined => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+};
+
+const probeTestConnection = async (
+  site: BooruSiteRecord
+): Promise<{ ok: boolean; status?: number; error?: string }> => {
+  const engine = getEngine(site.engine);
+  if (!engine) return { ok: false, error: 'unknown engine' };
+  const url = site.baseUrl.replace(/\/+$/, '') + engine.probePath;
+  try {
+    const headers: Record<string, string> = { 'User-Agent': config.e621.userAgent };
+    if (site.username && site.apiKey && engine.credentialSchema === 'username+apikey') {
+      const token = Buffer.from(`${site.username}:${site.apiKey}`).toString('base64');
+      headers.Authorization = `Basic ${token}`;
+    }
+    const res = await fetch(url, { headers });
+    if (!res.ok) {
+      return { ok: false, status: res.status, error: `HTTP ${res.status}` };
+    }
+    // Mirror detect.ts: try JSON, fall back to the raw text so XML-based
+    // engines (shimmie) can still shape-match instead of always failing here.
+    const text = await res.text();
+    let body: unknown = text;
+    try {
+      body = JSON.parse(text);
+    } catch {
+      // not JSON — keep raw text for XML engines
+    }
+    if (!engine.probeMatches(body)) {
+      return { ok: false, status: res.status, error: 'response does not match engine shape' };
+    }
+    return { ok: true, status: res.status };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+};
+
+export const registerBooruSiteRoutes = (app: FastifyInstance) => {
+  app.get('/booru-sites', async (request) => {
+    const sites = await dataStore.listBooruSites(request.currentUser!.id);
+    return { sites: sites.map(toPublic) };
+  });
+
+  app.get('/booru-sites/engines', async () => ({
+    engines: listEngines().map((engine) => ({
+      type: engine.type,
+      credentialSchema: engine.credentialSchema,
+      defaultCapabilities: engine.defaultCapabilities
+    })),
+    presets: BOORU_PRESETS.map((preset) => ({
+      key: preset.key,
+      name: preset.name,
+      engine: preset.engine,
+      baseUrl: preset.baseUrl,
+      defaultCapabilities: preset.defaultCapabilities
+    }))
+  }));
+
+  app.post('/booru-sites/detect', async (request, reply) => {
+    const parsed = detectSchema.safeParse(request.body ?? {});
+    if (!parsed.success) {
+      reply.code(400);
+      return { error: 'Invalid payload', issues: parsed.error.issues };
+    }
+    const baseUrl = parsed.data.baseUrl.replace(/\/+$/, '');
+    const result = await detectEngine(baseUrl);
+    if ('engine' in result) {
+      const engine = getEngine(result.engine);
+      // Materialise the sample's path into an absolute URL the browser can
+      // use without knowing the engine's path conventions. Done here (not in
+      // detect.ts) so the engine modules stay free of route-rendering logic.
+      const sample = result.sample
+        ? {
+            postId: result.sample.postId,
+            thumbUrl: result.sample.thumbUrl,
+            postUrl: `${baseUrl}${result.sample.postPath}`
+          }
+        : null;
+      return {
+        engine: result.engine,
+        confidence: result.confidence,
+        credentialSchema: engine?.credentialSchema ?? 'none',
+        defaultCapabilities: engine?.defaultCapabilities ?? null,
+        sample,
+        attempts: result.attempts
+      };
+    }
+    if (result.error === 'unreachable') {
+      reply.code(502);
+    } else {
+      reply.code(422);
+    }
+    return result;
+  });
+
+  app.post('/booru-sites', async (request, reply) => {
+    const userId = request.currentUser!.id;
+    const parsed = createSchema.safeParse(request.body ?? {});
+    if (!parsed.success) {
+      reply.code(400);
+      return { error: 'Invalid payload', issues: parsed.error.issues };
+    }
+    const engine = getEngine(parsed.data.engine);
+    if (!engine) {
+      reply.code(400);
+      return { error: `Unknown engine: ${parsed.data.engine}` };
+    }
+    const baseUrl = parsed.data.baseUrl.replace(/\/+$/, '');
+    const existing = await dataStore.findBooruSiteByBaseUrl(baseUrl, userId);
+    if (existing) {
+      reply.code(409);
+      return { error: 'A site with this base URL already exists for this account' };
+    }
+    const capDefaults = engine.defaultCapabilities;
+    const site = await dataStore.insertBooruSite(
+      {
+        name: parsed.data.name,
+        engine: parsed.data.engine,
+        baseUrl,
+        username: trimOrUndefined(parsed.data.username ?? undefined) ?? null,
+        apiKey: trimOrUndefined(parsed.data.apiKey ?? undefined) ?? null,
+        isPreset: false,
+        presetKey: null,
+        enabled: parsed.data.enabled ?? true,
+        capFavorites: parsed.data.capFavorites ?? capDefaults.favorites,
+        capTags: parsed.data.capTags ?? capDefaults.tags,
+        capSourceMatch: parsed.data.capSourceMatch ?? capDefaults.sourceMatch,
+        capSearch: parsed.data.capSearch ?? capDefaults.search
+      },
+      userId
+    );
+    return { site: toPublic(site) };
+  });
+
+  app.put<{ Params: { id: string } }>('/booru-sites/:id', async (request, reply) => {
+    const userId = request.currentUser!.id;
+    const parsed = updateSchema.safeParse(request.body ?? {});
+    if (!parsed.success) {
+      reply.code(400);
+      return { error: 'Invalid payload', issues: parsed.error.issues };
+    }
+    const existing = await dataStore.getBooruSite(request.params.id, userId);
+    if (!existing) {
+      reply.code(404);
+      return { error: 'Site not found' };
+    }
+    const updates = { ...parsed.data };
+    if (existing.isPreset) {
+      // Lock engine + base_url for preset rows so that historical favorite_items
+      // rows keep referring to the same canonical site (see AGENTS.md §11).
+      delete (updates as { engine?: BooruEngineType }).engine;
+      delete (updates as { baseUrl?: string }).baseUrl;
+    } else if (updates.baseUrl) {
+      updates.baseUrl = updates.baseUrl.replace(/\/+$/, '');
+    }
+    if (updates.username !== undefined) {
+      updates.username = trimOrUndefined(updates.username);
+    }
+    if (updates.apiKey !== undefined) {
+      updates.apiKey = trimOrUndefined(updates.apiKey);
+    }
+    const site = await dataStore.updateBooruSite(request.params.id, updates, userId);
+    if (!site) {
+      reply.code(404);
+      return { error: 'Site not found' };
+    }
+    return { site: toPublic(site) };
+  });
+
+  app.delete<{ Params: { id: string } }>('/booru-sites/:id', async (request, reply) => {
+    const userId = request.currentUser!.id;
+    const existing = await dataStore.getBooruSite(request.params.id, userId);
+    if (!existing) {
+      reply.code(404);
+      return { error: 'Site not found' };
+    }
+    if (existing.isPreset) {
+      reply.code(400);
+      return { error: 'Preset sites cannot be deleted. Disable the site instead.' };
+    }
+    const removed = await dataStore.deleteBooruSite(request.params.id, userId);
+    if (!removed) {
+      reply.code(409);
+      return { error: 'Site could not be deleted' };
+    }
+    return { ok: true };
+  });
+
+  app.post<{ Params: { id: string } }>('/booru-sites/:id/test', async (request, reply) => {
+    const userId = request.currentUser!.id;
+    const site = await dataStore.getBooruSite(request.params.id, userId);
+    if (!site) {
+      reply.code(404);
+      return { error: 'Site not found' };
+    }
+    const result = await probeTestConnection(site);
+    return result;
+  });
+
+  app.post('/booru-sites/reorder', async (request, reply) => {
+    const parsed = reorderSchema.safeParse(request.body ?? {});
+    if (!parsed.success) {
+      reply.code(400);
+      return { error: 'Invalid payload', issues: parsed.error.issues };
+    }
+    await dataStore.reorderBooruSites(parsed.data.orderedIds, request.currentUser!.id);
+    const sites = await dataStore.listBooruSites(request.currentUser!.id);
+    return { sites: sites.map(toPublic) };
+  });
+};

--- a/backend/src/routes/credentials.ts
+++ b/backend/src/routes/credentials.ts
@@ -1,8 +1,8 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 
-import { CredentialProvider, dataStore } from '../lib/dataStore';
-import { resolveCredential, resolveCredentials } from '../services/credentials';
+import { CredentialProvider } from '../lib/dataStore';
+import { resolveCredential, resolveCredentials, upsertCredentialCompat } from '../services/credentials';
 
 const updateSchema = z.object({
   provider: z.enum(['E621', 'DANBOORU', 'SAUCENAO']),
@@ -39,7 +39,7 @@ export const registerCredentialRoutes = (app: FastifyInstance) => {
     }
     const { provider, username, apiKey } = parsed.data;
     const userId = request.currentUser!.id;
-    await dataStore.upsertCredential(provider, { username, apiKey }, userId);
+    await upsertCredentialCompat(provider, { username, apiKey }, userId);
     const resolved = await resolveCredential(provider, userId);
     return { credential: toPublicCredential(resolved) };
   });

--- a/backend/src/routes/favorites.ts
+++ b/backend/src/routes/favorites.ts
@@ -16,8 +16,6 @@ const settingsSchema = z.object({
   favoritesRootId: z.string().nullable().optional()
 });
 
-const toProvider = (value: string) => value.trim().toUpperCase();
-
 export const registerFavoritesRoutes = (app: FastifyInstance) => {
   app.get('/favorites/settings', async (request) => {
     return dataStore.getFavoritesSettings(request.currentUser!.id);
@@ -56,12 +54,13 @@ export const registerFavoritesRoutes = (app: FastifyInstance) => {
       reply.code(400);
       return { error: 'Invalid payload', issues: parsed.error.issues };
     }
-    const providers = parsed.data.providers
-      ? parsed.data.providers.map(toProvider).filter((provider) => provider === 'E621' || provider === 'DANBOORU')
-      : undefined;
+    // providers can be either a legacy preset key ('E621', 'DANBOORU', ...) or a
+    // user_booru_sites.id UUID. The sync service resolves either form back to a
+    // BooruSiteRecord, so we just pass strings through here without filtering.
+    const providers = parsed.data.providers?.map((value) => value.trim()).filter(Boolean);
     if (parsed.data.providers && (!providers || providers.length === 0)) {
       reply.code(400);
-      return { error: 'No valid providers provided (use E621 or DANBOORU).' };
+      return { error: 'No valid providers provided.' };
     }
     const { assertFavoritesSyncReady, startFavoritesSync } = await import('../services/favorites.js');
     try {

--- a/backend/src/services/credentials.ts
+++ b/backend/src/services/credentials.ts
@@ -1,3 +1,4 @@
+import { BOORU_PRESETS } from '../lib/booruEngines/presets';
 import { CredentialProvider, dataStore } from '../lib/dataStore';
 
 export type CredentialSource = 'db' | 'none';
@@ -10,15 +11,26 @@ export type ResolvedCredential = {
   updatedAt: string | null;
 };
 
+const BOORU_PRESET_PROVIDERS = new Set<CredentialProvider>(['E621', 'DANBOORU']);
+
 export const resolveCredential = async (provider: CredentialProvider, userId?: string): Promise<ResolvedCredential> => {
   if (!userId) {
-    return {
-      provider,
-      username: null,
-      apiKey: null,
-      source: 'none',
-      updatedAt: null
-    };
+    return { provider, username: null, apiKey: null, source: 'none', updatedAt: null };
+  }
+  // E621/DANBOORU credentials now live on user_booru_sites preset rows. Read
+  // from there first; fall back to provider_credentials for legacy installs
+  // where the seed migration hasn't been run yet.
+  if (BOORU_PRESET_PROVIDERS.has(provider)) {
+    const site = await dataStore.findBooruSiteByPresetKey(provider, userId);
+    if (site) {
+      return {
+        provider,
+        username: site.username,
+        apiKey: site.apiKey,
+        source: 'db',
+        updatedAt: site.updatedAt
+      };
+    }
   }
   const stored = await dataStore.getCredential(provider, userId);
   if (stored) {
@@ -30,16 +42,53 @@ export const resolveCredential = async (provider: CredentialProvider, userId?: s
       updatedAt: stored.updatedAt
     };
   }
-  return {
-    provider,
-    username: null,
-    apiKey: null,
-    source: 'none',
-    updatedAt: null
-  };
+  return { provider, username: null, apiKey: null, source: 'none', updatedAt: null };
 };
 
 export const resolveCredentials = async (providers: CredentialProvider[], userId?: string) => {
   const resolved = await Promise.all(providers.map((provider) => resolveCredential(provider, userId)));
   return resolved;
+};
+
+// Backward-compatible writer for `/credentials` PUT. For SAUCENAO this still
+// hits provider_credentials; for E621/DANBOORU it updates the matching preset
+// row in user_booru_sites (creating one if none exists yet).
+export const upsertCredentialCompat = async (
+  provider: CredentialProvider,
+  updates: { username?: string; apiKey?: string },
+  userId: string
+): Promise<void> => {
+  if (!BOORU_PRESET_PROVIDERS.has(provider)) {
+    await dataStore.upsertCredential(provider, updates, userId);
+    return;
+  }
+  const preset = BOORU_PRESETS.find((entry) => entry.key === provider);
+  if (!preset) {
+    await dataStore.upsertCredential(provider, updates, userId);
+    return;
+  }
+  const existing = await dataStore.findBooruSiteByPresetKey(provider, userId);
+  const username = updates.username !== undefined ? updates.username.trim() || null : existing?.username ?? null;
+  const apiKey = updates.apiKey !== undefined ? updates.apiKey.trim() || null : existing?.apiKey ?? null;
+  if (existing) {
+    await dataStore.updateBooruSite(existing.id, { username, apiKey }, userId);
+  } else {
+    await dataStore.insertBooruSite(
+      {
+        name: preset.name,
+        engine: preset.engine,
+        baseUrl: preset.baseUrl,
+        username,
+        apiKey,
+        isPreset: true,
+        presetKey: preset.key,
+        enabled: true,
+        capFavorites: preset.defaultCapabilities.favorites,
+        capTags: preset.defaultCapabilities.tags,
+        capSourceMatch: preset.defaultCapabilities.sourceMatch,
+        capSearch: preset.defaultCapabilities.search
+      },
+      userId
+    );
+  }
 };

--- a/backend/src/services/favorites.test.ts
+++ b/backend/src/services/favorites.test.ts
@@ -12,39 +12,12 @@ import {
   registerFixtureFile
 } from '../../test/helpers/testApp';
 import { dataStore } from '../lib/dataStore';
-import { extractFavoriteRemoteFromSourceUrl } from '../lib/favoriteSourceMatch';
 
 import { autoFavoriteFromSauce } from './favorites';
 
-/**
- * URL → (provider, remoteId) parsing — these stay pure and cheap, and
- * adding a new site means adding one regex + one test row here.
- */
-test('extractFavoriteRemoteFromSourceUrl returns E621 + remoteId for e621 post URL', () => {
-  const result = extractFavoriteRemoteFromSourceUrl('https://e621.net/posts/12345');
-  assert.deepEqual(result, { provider: 'E621', remoteId: '12345' });
-});
-
-test('extractFavoriteRemoteFromSourceUrl handles trailing path/query', () => {
-  const result = extractFavoriteRemoteFromSourceUrl('https://e621.net/posts/98765?q=foo#bar');
-  assert.deepEqual(result, { provider: 'E621', remoteId: '98765' });
-});
-
-test('extractFavoriteRemoteFromSourceUrl returns DANBOORU for danbooru post URL', () => {
-  const result = extractFavoriteRemoteFromSourceUrl('https://danbooru.donmai.us/posts/42');
-  assert.deepEqual(result, { provider: 'DANBOORU', remoteId: '42' });
-});
-
-test('extractFavoriteRemoteFromSourceUrl rejects non-post URLs', () => {
-  assert.equal(extractFavoriteRemoteFromSourceUrl('https://e621.net/users/me'), null);
-  assert.equal(extractFavoriteRemoteFromSourceUrl('https://example.com/posts/1'), null);
-});
-
-test('extractFavoriteRemoteFromSourceUrl handles null/empty input', () => {
-  assert.equal(extractFavoriteRemoteFromSourceUrl(null), null);
-  assert.equal(extractFavoriteRemoteFromSourceUrl(''), null);
-  assert.equal(extractFavoriteRemoteFromSourceUrl(undefined), null);
-});
+// URL → site resolution is covered in lib/favoriteSourceMatch.test.ts via
+// extractFavoriteRemoteFromSiteList. The autoFavoriteFromSauce tests below
+// exercise the end-to-end favorite decision against seeded user_booru_sites.
 
 /**
  * #66 option C guardrails — replaces the old source-text grep test with a

--- a/backend/src/services/favorites.test.ts
+++ b/backend/src/services/favorites.test.ts
@@ -126,6 +126,27 @@ test('autoFavoriteFromSauce skips and does NOT touch network when already marked
   try {
     const seeded = await seedUser({ username: 'autofav_already' });
     await dataStore.saveFavoritesSettings({ autoFavEnabled: true }, seeded.user.id);
+
+    // The URL matcher consults user_booru_sites rows now — seed the E621
+    // preset so the e621.net source URL resolves to a known site. No
+    // credentials needed: this test exercises the already-marked
+    // short-circuit which fires before any network call.
+    await dataStore.insertBooruSite(
+      {
+        name: 'e621',
+        engine: 'e621',
+        baseUrl: 'https://e621.net',
+        isPreset: true,
+        presetKey: 'E621',
+        enabled: true,
+        capFavorites: true,
+        capTags: true,
+        capSourceMatch: true,
+        capSearch: false
+      },
+      seeded.user.id
+    );
+
     const filePath = writeFixtureFile(seeded.libraryRoot, 'already.png', Buffer.from('x'));
     const folders = await dataStore.listFolders(seeded.user.id);
     const file = await registerFixtureFile(folders[0].id, filePath);
@@ -140,7 +161,9 @@ test('autoFavoriteFromSauce skips and does NOT touch network when already marked
       completedAt: new Date().toISOString()
     });
 
-    // Pre-mark as already-favorited locally.
+    // Pre-mark as already-favorited locally. Provider key is 'E621' (the
+    // preset key), which is what the matcher returns for preset sites so
+    // legacy favorite_items rows keep matching.
     await dataStore.upsertFavoriteItem(
       {
         provider: 'E621',

--- a/backend/src/services/favorites.ts
+++ b/backend/src/services/favorites.ts
@@ -112,7 +112,6 @@ const debugLog = (...args: string[]) => {
   console.log('[favorites]', ...args);
 };
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const ensureFavoritesRoot = async (userId: string) => {
   const settings = await dataStore.getFavoritesSettings(userId);

--- a/backend/src/services/favorites.ts
+++ b/backend/src/services/favorites.ts
@@ -6,13 +6,42 @@ import { pipeline } from 'stream/promises';
 import { fetch } from 'undici';
 
 import { config } from '../config';
-import { dataStore, FavoriteProvider, FavoriteItemRecord, FileRecord } from '../lib/dataStore';
-import { extractFavoriteRemoteFromSourceUrl } from '../lib/favoriteSourceMatch';
+import { getEngine } from '../lib/booruEngines';
+import {
+  BooruSiteRecord,
+  dataStore,
+  FavoriteProvider,
+  FavoriteItemRecord,
+  FileRecord
+} from '../lib/dataStore';
+import { extractFavoriteRemoteFromSiteList } from '../lib/favoriteSourceMatch';
 import { ensureDirectoryWritable } from '../lib/fsAccess';
 import { scanLocalFile } from '../lib/scanner';
 
-import { resolveCredential } from './credentials';
 import { applyRemotePostTags } from './tagging';
+
+// favorite_items.provider for a given site is the preset key when the site is
+// one of the seeded presets (so legacy 'E621'/'DANBOORU' rows continue to
+// match) and the site UUID for fully-custom sites.
+const favoriteKeyForSite = (site: BooruSiteRecord): string => site.presetKey ?? site.id;
+
+const resolveSiteFromProvider = async (
+  userId: string,
+  provider: FavoriteProvider
+): Promise<BooruSiteRecord | null> => {
+  // direct id lookup
+  const byId = await dataStore.getBooruSite(provider, userId);
+  if (byId) return byId;
+  // legacy preset key lookup ('E621', 'DANBOORU', ...)
+  return dataStore.findBooruSiteByPresetKey(provider, userId);
+};
+
+const loadFavoriteSyncableSites = async (userId: string): Promise<BooruSiteRecord[]> => {
+  const sites = await dataStore.listBooruSites(userId);
+  return sites.filter(
+    (site) => site.enabled && site.capFavorites && site.username && site.apiKey
+  );
+};
 
 type FavoriteRemote = {
   provider: FavoriteProvider;
@@ -20,25 +49,6 @@ type FavoriteRemote = {
   sourceUrl: string;
   fileUrl: string | null;
 };
-
-type E621FavoritePost = {
-  id?: number | string | null;
-  file?: {
-    url?: string | null;
-  } | null;
-};
-
-type E621FavoritesResponse = {
-  posts?: E621FavoritePost[] | null;
-};
-
-type DanbooruFavoritePost = {
-  id?: number | string | null;
-  file_url?: string | null;
-  large_file_url?: string | null;
-};
-
-type DanbooruFavoritesResponse = DanbooruFavoritePost[] | { posts?: DanbooruFavoritePost[] | null };
 
 type SyncResult = {
   provider: FavoriteProvider;
@@ -149,7 +159,11 @@ const findOrScanFavoriteRecord = async (folderId: string, filePath: string, user
   return scanAndUpsertFavorite(folderId, filePath);
 };
 
-const favoriteSourceName = (provider: FavoriteProvider) => (provider === 'E621' ? 'e621' : 'danbooru');
+const favoriteSourceName = (provider: FavoriteProvider): string => {
+  if (provider === 'E621') return 'e621';
+  if (provider === 'DANBOORU') return 'danbooru';
+  return provider;
+};
 
 const providerThreshold = (provider: 'SAUCENAO' | 'FLUFFLE') => (provider === 'FLUFFLE' ? 95 : 90);
 
@@ -205,18 +219,6 @@ const ensureFavoriteSourceMetadata = async (file: FileRecord, item: FavoriteRemo
   await ensureFavoriteSourceRun(file, item);
   if (await hasProviderSourceTags(file.id, item.provider)) return;
   await applyRemotePostTags(file, item.provider, item.remoteId, item.sourceUrl);
-};
-
-const resolveE621Auth = async (userId: string) => {
-  const credential = await resolveCredential('E621', userId);
-  if (!credential.username || !credential.apiKey) return null;
-  return { username: credential.username, apiKey: credential.apiKey, userAgent: config.e621.userAgent };
-};
-
-const resolveDanbooruAuth = async (userId: string) => {
-  const credential = await resolveCredential('DANBOORU', userId);
-  if (!credential.username || !credential.apiKey) return null;
-  return { username: credential.username, apiKey: credential.apiKey, userAgent: config.e621.userAgent };
 };
 
 const toSafeId = (value: string) => value.replace(/[^a-zA-Z0-9_-]+/g, '');
@@ -303,95 +305,28 @@ const deleteFavoriteFile = async (userId: string, item: FavoriteItemRecord) => {
   await dataStore.deleteFavoriteItem(item.provider, item.remoteId, userId);
 };
 
-const unfavoriteE621 = async (userId: string, postId: string) => {
-  const auth = await resolveE621Auth(userId);
-  if (!auth) {
-    throw new Error('E621 credentials missing');
+// Engine-dispatched favorite / unfavorite. Resolves the site row by site id or
+// legacy preset key, then calls the engine module's network adapter.
+export const removeFavorite = async (
+  userId: string,
+  provider: FavoriteProvider,
+  remoteId: string
+) => {
+  const site = await resolveSiteFromProvider(userId, provider);
+  if (!site) throw new Error(`Unknown booru provider: ${provider}`);
+  const engine = getEngine(site.engine);
+  if (!engine?.unfavorite) {
+    throw new Error(`Engine ${site.engine} does not support unfavorite`);
   }
-  const token = Buffer.from(`${auth.username}:${auth.apiKey}`).toString('base64');
-  const res = await fetch(`https://e621.net/favorites/${postId}.json`, {
-    method: 'DELETE',
-    headers: {
-      Authorization: `Basic ${token}`,
-      'User-Agent': auth.userAgent
-    }
-  });
-  if (res.ok || res.status === 404) return;
-  const text = await res.text();
-  throw new Error(`e621 unfavorite failed (${res.status}): ${text.slice(0, 200)}`);
+  await engine.unfavorite(site, remoteId);
 };
 
-const unfavoriteDanbooru = async (userId: string, postId: string) => {
-  const auth = await resolveDanbooruAuth(userId);
-  if (!auth) {
-    throw new Error('Danbooru credentials missing');
+const favoriteOnSite = async (site: BooruSiteRecord, postId: string) => {
+  const engine = getEngine(site.engine);
+  if (!engine?.favorite) {
+    throw new Error(`Engine ${site.engine} does not support favorite`);
   }
-  const token = Buffer.from(`${auth.username}:${auth.apiKey}`).toString('base64');
-  const res = await fetch(`https://danbooru.donmai.us/favorites/${postId}.json`, {
-    method: 'DELETE',
-    headers: {
-      Authorization: `Basic ${token}`,
-      'User-Agent': auth.userAgent
-    }
-  });
-  if (res.ok || res.status === 404) return;
-  const text = await res.text();
-  throw new Error(`danbooru unfavorite failed (${res.status}): ${text.slice(0, 200)}`);
-};
-
-type FavoriteApi = {
-  favorite: (userId: string, postId: string) => Promise<void>;
-  unfavorite: (userId: string, postId: string) => Promise<void>;
-};
-
-// Registry of network adapters per provider. Add new providers by appending
-// here; the rest of the auto-fav / sync / remove pipeline is provider-agnostic
-// and looks providers up by key. See favoriteSourceMatch.ts for URL patterns.
-const FAVORITE_API_REGISTRY: Record<FavoriteProvider, FavoriteApi> = {
-  E621: { favorite: (uid, id) => favoriteE621(uid, id), unfavorite: (uid, id) => unfavoriteE621(uid, id) },
-  DANBOORU: { favorite: (uid, id) => favoriteDanbooru(uid, id), unfavorite: (uid, id) => unfavoriteDanbooru(uid, id) }
-};
-
-export const removeFavorite = async (userId: string, provider: FavoriteProvider, remoteId: string) => {
-  await FAVORITE_API_REGISTRY[provider].unfavorite(userId, remoteId);
-};
-
-const favoriteE621 = async (userId: string, postId: string) => {
-  const auth = await resolveE621Auth(userId);
-  if (!auth) throw new Error('E621 credentials missing');
-  const token = Buffer.from(`${auth.username}:${auth.apiKey}`).toString('base64');
-  const body = new URLSearchParams({ post_id: postId });
-  const res = await fetch('https://e621.net/favorites.json', {
-    method: 'POST',
-    headers: {
-      Authorization: `Basic ${token}`,
-      'User-Agent': auth.userAgent,
-      'Content-Type': 'application/x-www-form-urlencoded'
-    },
-    body
-  });
-  if (res.ok || res.status === 422) return;
-  const text = await res.text();
-  throw new Error(`e621 favorite failed (${res.status}): ${text.slice(0, 200)}`);
-};
-
-const favoriteDanbooru = async (userId: string, postId: string) => {
-  const auth = await resolveDanbooruAuth(userId);
-  if (!auth) throw new Error('Danbooru credentials missing');
-  const token = Buffer.from(`${auth.username}:${auth.apiKey}`).toString('base64');
-  const body = new URLSearchParams({ post_id: postId });
-  const res = await fetch('https://danbooru.donmai.us/favorites.json', {
-    method: 'POST',
-    headers: {
-      Authorization: `Basic ${token}`,
-      'User-Agent': auth.userAgent,
-      'Content-Type': 'application/x-www-form-urlencoded'
-    },
-    body
-  });
-  if (res.ok || res.status === 422) return;
-  const text = await res.text();
-  throw new Error(`danbooru favorite failed (${res.status}): ${text.slice(0, 200)}`);
+  await engine.favorite(site, postId);
 };
 
 export type AutoFavoriteOutcome =
@@ -421,7 +356,10 @@ type ScoredFavoritableMatch = {
 // ranked result points at a provider we can auto-favorite on; we still want
 // to favorite that one. Supported providers come from FAVORITE_URL_PATTERNS,
 // so adding a new site automatically extends this lookup.
-const findBestFavoritableMatch = async (fileId: string): Promise<ScoredFavoritableMatch | null> => {
+const findBestFavoritableMatch = async (
+  fileId: string,
+  sites: BooruSiteRecord[]
+): Promise<ScoredFavoritableMatch | null> => {
   const runs = await dataStore.listProviderRuns(fileId);
   let best: { match: ScoredFavoritableMatch; score: number } | null = null;
   for (const run of runs) {
@@ -435,10 +373,17 @@ const findBestFavoritableMatch = async (fileId: string): Promise<ScoredFavoritab
     for (const candidate of candidates) {
       const score = candidate.score;
       if (typeof score !== 'number' || !Number.isFinite(score) || score < threshold) continue;
-      const remote = extractFavoriteRemoteFromSourceUrl(candidate.sourceUrl);
+      const remote = extractFavoriteRemoteFromSiteList(candidate.sourceUrl, sites);
       if (!remote) continue;
       if (!best || score > best.score) {
-        best = { match: { ...remote, sourceUrl: candidate.sourceUrl ?? '' }, score };
+        best = {
+          match: {
+            provider: favoriteKeyForSite(remote.site),
+            remoteId: remote.remoteId,
+            sourceUrl: candidate.sourceUrl ?? ''
+          },
+          score
+        };
       }
     }
   }
@@ -457,7 +402,14 @@ export const autoFavoriteFromSauce = async (file: FileRecord): Promise<AutoFavor
   const settings = await dataStore.getFavoritesSettings(userId);
   if (!settings.autoFavEnabled) return { status: 'skipped', reason: 'disabled' };
 
-  const remote = await findBestFavoritableMatch(file.id);
+  // Match URL against every site that opted into source-match (cap_source_match).
+  // Don't pre-filter by favorites capability or credentials here: the
+  // already-marked short-circuit below must fire even when the site is
+  // disabled / missing creds, otherwise reverse-sync / repeated scans would
+  // get the wrong outcome.
+  const allSites = await dataStore.listBooruSites(userId);
+  const matchSites = allSites.filter((site) => site.capSourceMatch);
+  const remote = await findBestFavoritableMatch(file.id, matchSites);
   if (!remote) return { status: 'skipped', reason: 'no-supported-match' };
 
   const existing = await dataStore.findFavoriteItemByPath(file.path, userId);
@@ -465,8 +417,17 @@ export const autoFavoriteFromSauce = async (file: FileRecord): Promise<AutoFavor
     return { status: 'skipped', reason: 'already-marked' };
   }
 
+  const targetSite = await resolveSiteFromProvider(userId, remote.provider);
+  if (!targetSite) return { status: 'error', reason: `unknown provider: ${remote.provider}` };
+  if (!targetSite.capFavorites) {
+    return { status: 'skipped', reason: 'favorites-capability-disabled' };
+  }
+  if (!targetSite.username || !targetSite.apiKey) {
+    return { status: 'skipped', reason: 'credentials-missing' };
+  }
+
   try {
-    await FAVORITE_API_REGISTRY[remote.provider].favorite(userId, remote.remoteId);
+    await favoriteOnSite(targetSite, remote.remoteId);
   } catch (err) {
     return { status: 'error', reason: (err as Error).message };
   }
@@ -485,106 +446,25 @@ export const autoFavoriteFromSauce = async (file: FileRecord): Promise<AutoFavor
   return { status: 'favorited', provider: remote.provider, remoteId: remote.remoteId };
 };
 
-const fetchE621Favorites = async (userId: string, onPage?: (page: number, count: number) => void) => {
-  const auth = await resolveE621Auth(userId);
-  if (!auth) {
-    throw new Error('E621 credentials missing');
+const fetchSiteFavorites = async (
+  site: BooruSiteRecord,
+  onPage?: (page: number, count: number) => void
+): Promise<{ items: FavoriteRemote[]; headers: Record<string, string> }> => {
+  const engine = getEngine(site.engine);
+  if (!engine?.fetchFavorites) {
+    throw new Error(`Engine ${site.engine} does not support favorites sync`);
   }
-  const token = Buffer.from(`${auth.username}:${auth.apiKey}`).toString('base64');
-  const headers = {
-    Authorization: `Basic ${token}`,
-    'User-Agent': auth.userAgent
-  };
-  const items: FavoriteRemote[] = [];
-  const limit = 320;
-  let page = 1;
-  for (;;) {
-    const params = new URLSearchParams({
-      tags: `fav:${auth.username}`,
-      limit: String(limit),
-      page: String(page)
-    });
-    const res = await fetch(`https://e621.net/posts.json?${params.toString()}`, { headers });
-    const text = await res.text();
-    if (!res.ok) {
-      throw new Error(`e621 favorites failed (${res.status}): ${text.slice(0, 200)}`);
-    }
-    let data: E621FavoritesResponse;
-    try {
-      data = JSON.parse(text) as E621FavoritesResponse;
-    } catch {
-      throw new Error(`e621 favorites parse failed: ${text.slice(0, 200)}`);
-    }
-    const posts = Array.isArray(data.posts) ? data.posts : [];
-    if (!posts.length) break;
-    onPage?.(page, posts.length);
-    for (const post of posts) {
-      const id = post?.id ? String(post.id) : null;
-      const fileUrl = post?.file?.url ?? null;
-      if (!id) continue;
-      items.push({
-        provider: 'E621',
-        remoteId: id,
-        sourceUrl: `https://e621.net/posts/${id}`,
-        fileUrl
-      });
-    }
-    if (posts.length < limit) break;
-    page += 1;
-    await sleep(200);
-  }
-  return { items, headers };
-};
-
-const fetchDanbooruFavorites = async (userId: string, onPage?: (page: number, count: number) => void) => {
-  const auth = await resolveDanbooruAuth(userId);
-  if (!auth) {
-    throw new Error('Danbooru credentials missing');
-  }
-  const token = Buffer.from(`${auth.username}:${auth.apiKey}`).toString('base64');
-  const headers = {
-    Authorization: `Basic ${token}`,
-    'User-Agent': auth.userAgent
-  };
-  const items: FavoriteRemote[] = [];
-  const limit = 200;
-  let page = 1;
-  for (;;) {
-    const params = new URLSearchParams({
-      tags: `fav:${auth.username}`,
-      limit: String(limit),
-      page: String(page)
-    });
-    const res = await fetch(`https://danbooru.donmai.us/posts.json?${params.toString()}`, { headers });
-    const text = await res.text();
-    if (!res.ok) {
-      throw new Error(`danbooru favorites failed (${res.status}): ${text.slice(0, 200)}`);
-    }
-    let data: DanbooruFavoritesResponse;
-    try {
-      data = JSON.parse(text) as DanbooruFavoritesResponse;
-    } catch {
-      throw new Error(`danbooru favorites parse failed: ${text.slice(0, 200)}`);
-    }
-    const posts = Array.isArray(data) ? data : Array.isArray(data.posts) ? data.posts : [];
-    if (!posts.length) break;
-    onPage?.(page, posts.length);
-    for (const post of posts) {
-      const id = post?.id ? String(post.id) : null;
-      const fileUrl = post?.file_url ?? post?.large_file_url ?? null;
-      if (!id) continue;
-      items.push({
-        provider: 'DANBOORU',
-        remoteId: id,
-        sourceUrl: `https://danbooru.donmai.us/posts/${id}`,
-        fileUrl
-      });
-    }
-    if (posts.length < limit) break;
-    page += 1;
-    await sleep(200);
-  }
-  return { items, headers };
+  const provider = favoriteKeyForSite(site);
+  const result = await engine.fetchFavorites(site, { onPage });
+  // Engine emits provider = site.id; remap to legacy preset key when present
+  // so that existing favorite_items rows keep matching across the migration.
+  const items: FavoriteRemote[] = result.items.map((item) => ({
+    provider,
+    remoteId: item.remoteId,
+    sourceUrl: item.sourceUrl,
+    fileUrl: item.fileUrl
+  }));
+  return { items, headers: result.downloadHeaders };
 };
 
 const initProviderProgress = (provider: FavoriteProvider): FavoriteSyncProgress => ({
@@ -599,43 +479,32 @@ const initProviderProgress = (provider: FavoriteProvider): FavoriteSyncProgress 
   errors: []
 });
 
-// Sync engine MUST NOT call `removeFavorite` / `unfavoriteE621` / `unfavoriteDanbooru`.
-// Those are reverse-sync (delete-locally → unfav-remotely), gated by the user
-// setting and triggered ONLY from the HTTP DELETE /files route handler. If a
-// future change wires reverse-sync into sync itself, the auto-fav marker
-// (#66 option C) becomes a self-cancelling loop: scanner auto-favs → sync
-// re-scans local file → sync ends up unfavoriting → next scan auto-favs again.
-// Internal cleanup uses `deleteFavoriteFile`, which is filesystem+DB only.
-const syncProvider = async (
+// Sync engine MUST NOT call `removeFavorite`. Those are reverse-sync
+// (delete-locally → unfav-remotely), gated by the user setting and triggered
+// ONLY from the HTTP DELETE /files route handler. If a future change wires
+// reverse-sync into sync itself, the auto-fav marker (#66 option C) becomes a
+// self-cancelling loop: scanner auto-favs → sync re-scans local file → sync
+// ends up unfavoriting → next scan auto-favs again. Internal cleanup uses
+// `deleteFavoriteFile`, which is filesystem+DB only.
+const syncSite = async (
   userId: string,
-  provider: FavoriteProvider,
+  site: BooruSiteRecord,
   deleteMissing: boolean,
   root: string,
   onProgress: (provider: FavoriteProvider, patch: Partial<FavoriteSyncProgress>, message?: string) => void
 ): Promise<SyncResult> => {
+  const provider = favoriteKeyForSite(site);
+  const label = site.name;
   const result: SyncResult = { provider, fetched: 0, added: 0, removed: 0, skipped: 0, errors: [] };
-  let remote: FavoriteRemote[] = [];
-  let headers: Record<string, string> = {};
-  debugLog(`${provider}: start`);
-  if (provider === 'E621') {
-    onProgress(provider, { stage: 'fetching' }, 'Fetching e621 favorites…');
-    const fetched = await fetchE621Favorites(userId, (page, count) => {
-      const message = `Fetching e621 favorites (page ${page}, ${count} items)…`;
-      onProgress(provider, { stage: 'fetching' }, message);
-      debugLog(message);
-    });
-    remote = fetched.items;
-    headers = fetched.headers;
-  } else {
-    onProgress(provider, { stage: 'fetching' }, 'Fetching danbooru favorites…');
-    const fetched = await fetchDanbooruFavorites(userId, (page, count) => {
-      const message = `Fetching danbooru favorites (page ${page}, ${count} items)…`;
-      onProgress(provider, { stage: 'fetching' }, message);
-      debugLog(message);
-    });
-    remote = fetched.items;
-    headers = fetched.headers;
-  }
+  debugLog(`${label}: start`);
+  onProgress(provider, { stage: 'fetching' }, `Fetching ${label} favorites…`);
+  const fetched = await fetchSiteFavorites(site, (page, count) => {
+    const message = `Fetching ${label} favorites (page ${page}, ${count} items)…`;
+    onProgress(provider, { stage: 'fetching' }, message);
+    debugLog(message);
+  });
+  const remote: FavoriteRemote[] = fetched.items;
+  const headers: Record<string, string> = fetched.headers;
 
   result.fetched = remote.length;
   onProgress(
@@ -806,10 +675,25 @@ const createProgressUpdater = (userId: string, providers: FavoriteProvider[]) =>
 const runFavoritesSync = async (userId: string, options: SyncOptions) => {
   try {
     const root = await ensureFavoritesRoot(userId);
-    const providers = options.providers?.length ? options.providers : (['E621', 'DANBOORU'] as FavoriteProvider[]);
+    const syncableSites = await loadFavoriteSyncableSites(userId);
+    const filterIds = options.providers?.length ? new Set(options.providers) : null;
+    const sites = filterIds
+      ? syncableSites.filter((site) => filterIds.has(site.id) || (site.presetKey && filterIds.has(site.presetKey)))
+      : syncableSites;
+    if (!sites.length) {
+      updateSyncState(userId, {
+        status: 'done',
+        message: 'No booru sites configured for favorites sync.',
+        results: [],
+        progress: { providers: [] }
+      });
+      debugLog('sync skipped: no syncable sites');
+      return;
+    }
+    const providerKeys = sites.map((site) => favoriteKeyForSite(site));
     const deleteMissing = options.deleteMissing ?? config.favorites.deleteMissing;
     const results: SyncResult[] = [];
-    const progress = createProgressUpdater(userId, providers);
+    const progress = createProgressUpdater(userId, providerKeys);
     updateSyncState(userId, {
       status: 'running',
       message: 'Starting favorites sync…',
@@ -817,9 +701,10 @@ const runFavoritesSync = async (userId: string, options: SyncOptions) => {
       results: []
     });
     debugLog('sync started');
-    for (const provider of providers) {
+    for (const site of sites) {
+      const provider = favoriteKeyForSite(site);
       try {
-        results.push(await syncProvider(userId, provider, deleteMissing, root, progress.update));
+        results.push(await syncSite(userId, site, deleteMissing, root, progress.update));
       } catch (err) {
         results.push({
           provider,
@@ -830,7 +715,7 @@ const runFavoritesSync = async (userId: string, options: SyncOptions) => {
           errors: [(err as Error).message]
         });
         progress.update(provider, { stage: 'error', errors: [(err as Error).message] });
-        debugLog(`${provider}: error ${(err as Error).message}`);
+        debugLog(`${site.name}: error ${(err as Error).message}`);
       }
     }
     updateSyncState(userId, {

--- a/backend/src/services/favorites.ts
+++ b/backend/src/services/favorites.ts
@@ -354,8 +354,8 @@ type ScoredFavoritableMatch = {
 // best supported-provider hit above the per-provider threshold. The top
 // result is often an unsupported site (e.g. furaffinity) even when a lower
 // ranked result points at a provider we can auto-favorite on; we still want
-// to favorite that one. Supported providers come from FAVORITE_URL_PATTERNS,
-// so adding a new site automatically extends this lookup.
+// to favorite that one. Candidate sites come from the caller's
+// user_booru_sites list, so adding a site automatically extends this lookup.
 const findBestFavoritableMatch = async (
   fileId: string,
   sites: BooruSiteRecord[]

--- a/backend/src/services/tagging.ts
+++ b/backend/src/services/tagging.ts
@@ -8,20 +8,25 @@ import sharp from 'sharp';
 import { FormData, fetch } from 'undici';
 
 import { config } from '../config';
-import { dataStore, FileRecord, ProviderRunRecord, TagSource } from '../lib/dataStore';
-
-import { resolveCredential } from './credentials';
-
-type TagCandidateSource = 'E621' | 'DANBOORU' | 'GELBOORU' | 'YANDERE' | 'KONACHAN' | 'SANKAKU' | 'IDOL_COMPLEX';
+import { getEngine } from '../lib/booruEngines';
+import {
+  BooruSiteRecord,
+  dataStore,
+  FileRecord,
+  ProviderRunRecord,
+  TagSource,
+  SPECIAL_TAG_SOURCES
+} from '../lib/dataStore';
 
 type TagCandidate = {
-  source: TagCandidateSource;
+  site: BooruSiteRecord;
   id: string;
   idKind?: 'POST' | 'MD5';
   url: string;
   score: number;
-  baseUrl?: string;
 };
+
+const tagSourceForSite = (site: BooruSiteRecord): TagSource => site.presetKey ?? site.id;
 
 type TagResult = {
   tag: string;
@@ -29,69 +34,6 @@ type TagResult = {
   score?: number | null;
   sourceUrl?: string | null;
 };
-
-type E621TagBuckets = {
-  general?: string[];
-  artist?: string[];
-  character?: string[];
-  species?: string[];
-  meta?: string[];
-  lore?: string[];
-  invalid?: string[];
-};
-
-type E621Post = {
-  id?: number | string | null;
-  tags?: E621TagBuckets | null;
-};
-
-type E621Response = {
-  post?: E621Post | null;
-  posts?: E621Post[] | null;
-};
-
-type DanbooruPost = {
-  id?: number | string | null;
-  tag_string_general?: string;
-  tag_string_artist?: string;
-  tag_string_character?: string;
-  tag_string_copyright?: string;
-  tag_string_meta?: string;
-};
-
-type DanbooruResponse = DanbooruPost[] | { post?: DanbooruPost | null; posts?: DanbooruPost[] | null };
-
-type GelbooruPost = {
-  tags?: string | null;
-};
-
-type GelbooruEnvelope = {
-  post?: GelbooruPost | null;
-};
-
-type GelbooruResponse = GelbooruPost[] | GelbooruEnvelope | GelbooruPost;
-
-type MoebooruPost = {
-  tags_general?: string;
-  tags?: string;
-  tags_artist?: string;
-  tags_character?: string;
-  tags_copyright?: string;
-  tags_meta?: string;
-};
-
-type MoebooruResponse = MoebooruPost[] | MoebooruPost;
-
-type SankakuTagEntry = {
-  name?: string;
-  type?: string | number;
-};
-
-type SankakuPost = {
-  tags?: SankakuTagEntry[] | string;
-};
-
-type SankakuResponse = SankakuPost[] | SankakuPost;
 
 type Wd14Tag = {
   tag: string;
@@ -103,10 +45,6 @@ type Wd14Response = {
   tags?: Wd14Tag[] | null;
 };
 
-const isGelbooruEnvelope = (value: GelbooruResponse): value is GelbooruEnvelope => {
-  return !Array.isArray(value) && Object.prototype.hasOwnProperty.call(value, 'post');
-};
-
 const providerScoreThresholds: Record<ProviderRunRecord['provider'], number> = {
   SAUCENAO: 90,
   FLUFFLE: 95
@@ -116,26 +54,6 @@ const resolveFileUserId = async (fileId: string) => {
   const user = await dataStore.findUserByFileId(fileId);
   return user?.id;
 };
-
-const resolveE621Auth = async (userId?: string) => {
-  const credential = await resolveCredential('E621', userId);
-  if (!credential.username || !credential.apiKey) return null;
-  return { username: credential.username, apiKey: credential.apiKey, userAgent: config.e621.userAgent };
-};
-
-const resolveDanbooruAuth = async (userId?: string) => {
-  const credential = await resolveCredential('DANBOORU', userId);
-  if (!credential.username || !credential.apiKey) return null;
-  return { username: credential.username, apiKey: credential.apiKey, userAgent: config.e621.userAgent };
-};
-
-const e621Regex = /https?:\/\/(?:www\.)?e621\.net\/(?:posts|post\/show)\/(\d+)/i;
-const danbooruRegex = /https?:\/\/(?:www\.)?danbooru\.donmai\.us\/(?:posts|post\/show)\/(\d+)/i;
-const gelbooruRegex = /https?:\/\/(?:www\.)?gelbooru\.com\/index\.php/i;
-const yandereRegex = /https?:\/\/(?:www\.)?yande\.re\/post\/show\/(\d+)/i;
-const konachanRegex = /https?:\/\/(?:www\.)?konachan\.(?:com|net)\/post\/show\/(\d+)/i;
-const sankakuRegex = /https?:\/\/(?:www\.)?chan\.sankakucomplex\.com\/post\/show\/(\d+)/i;
-const idolComplexRegex = /https?:\/\/(?:www\.)?idol\.sankakucomplex\.com\/post\/show\/(\d+)/i;
 
 const normalizeTag = (value: string) =>
   value
@@ -160,12 +78,6 @@ const resolveCandidateScore = (
   return 0;
 };
 
-const resolveNumericId = (value: string | null | undefined) => {
-  if (!value) return null;
-  const trimmed = value.trim();
-  return /^\d+$/.test(trimmed) ? trimmed : null;
-};
-
 const md5Regex = /\b[a-f0-9]{32}\b/i;
 
 const resolveMd5 = (value: string | null | undefined) => {
@@ -174,153 +86,65 @@ const resolveMd5 = (value: string | null | undefined) => {
   return match ? match[0].toLowerCase() : null;
 };
 
-const resolveSourceFromName = (value: string): TagCandidateSource | null => {
+const resolveSiteFromName = (
+  value: string,
+  sites: BooruSiteRecord[]
+): BooruSiteRecord | null => {
   const lower = value.toLowerCase();
-  if (lower.includes('danbooru')) return 'DANBOORU' as const;
-  if (lower.includes('e621')) return 'E621' as const;
+  for (const site of sites) {
+    const presetKey = site.presetKey?.toLowerCase();
+    if (presetKey && lower.includes(presetKey)) return site;
+    if (site.name && lower.includes(site.name.toLowerCase())) return site;
+  }
   return null;
 };
 
-const resolveIdFromUrl = (url: URL) => {
-  const idParam = resolveNumericId(url.searchParams.get('id'));
-  if (idParam) return idParam;
-  const match = url.pathname.match(/\/(\d+)(?:\.\w+)?$/);
-  return match ? match[1] : null;
-};
-
-const resolveSourceFromUrl = (url: URL): TagCandidateSource | null => {
-  const host = url.hostname.replace(/^www\./, '').toLowerCase();
-  if (host.endsWith('e621.net')) return 'E621' as const;
-  if (host.endsWith('donmai.us')) return 'DANBOORU' as const;
-  return null;
-};
-
+// Per-user, engine-driven URL → site resolver. Replaces the static
+// e621Regex/danbooruRegex/... cascade. Iterates user's `cap_tags=true` sites
+// in sort order and asks each engine if the URL belongs to it.
 const resolveTagCandidate = (
   url: string | null | undefined,
   score: number,
-  sourceName?: string | null
+  sourceName: string | null | undefined,
+  sites: BooruSiteRecord[]
 ): TagCandidate | null => {
+  const eligible = sites
+    .filter((site) => site.enabled && site.capTags)
+    .sort((a, b) => a.sortOrder - b.sortOrder);
+
   if (url) {
-    if (e621Regex.test(url)) {
-      const match = url.match(e621Regex);
-      const id = match?.[1];
-      if (id) return { source: 'E621', id, idKind: 'POST', url, score };
-    }
-    if (danbooruRegex.test(url)) {
-      const match = url.match(danbooruRegex);
-      const id = match?.[1];
-      if (id) return { source: 'DANBOORU', id, idKind: 'POST', url, score };
-    }
-    if (yandereRegex.test(url)) {
-      const match = url.match(yandereRegex);
-      const id = match?.[1];
-      if (id) return { source: 'YANDERE', id, idKind: 'POST', url, score, baseUrl: 'https://yande.re' };
-    }
-    if (konachanRegex.test(url)) {
-      const match = url.match(konachanRegex);
-      const id = match?.[1];
-      if (id) {
-        const host = url.includes('konachan.net') ? 'https://konachan.net' : 'https://konachan.com';
-        return { source: 'KONACHAN', id, idKind: 'POST', url, score, baseUrl: host };
+    for (const site of eligible) {
+      const engine = getEngine(site.engine);
+      if (!engine) continue;
+      const match = engine.extractIdFromUrl(url, site);
+      if (match) {
+        return { site, id: match.remoteId, idKind: 'POST', url, score };
       }
     }
-    if (sankakuRegex.test(url)) {
-      const match = url.match(sankakuRegex);
-      const id = match?.[1];
-      if (id) {
-        return { source: 'SANKAKU', id, idKind: 'POST', url, score, baseUrl: 'https://chan.sankakucomplex.com' };
+    // md5-based fallback: try to identify site from name (e.g. SauceNAO
+    // "Index #29: e621") then look up the post by md5 on that site.
+    const md5 = resolveMd5(url) ?? resolveMd5(sourceName ?? null);
+    if (md5) {
+      const site = sourceName ? resolveSiteFromName(sourceName, eligible) : null;
+      if (site) {
+        return { site, id: md5, idKind: 'MD5', url, score };
       }
-    }
-    if (idolComplexRegex.test(url)) {
-      const match = url.match(idolComplexRegex);
-      const id = match?.[1];
-      if (id) {
-        return { source: 'IDOL_COMPLEX', id, idKind: 'POST', url, score, baseUrl: 'https://idol.sankakucomplex.com' };
-      }
-    }
-    if (gelbooruRegex.test(url)) {
-      try {
-        const parsed = new URL(url);
-        const id = resolveIdFromUrl(parsed);
-        if (id) return { source: 'GELBOORU', id, idKind: 'POST', url, score, baseUrl: 'https://gelbooru.com' };
-      } catch {
-        // ignore
-      }
-    }
-    try {
-      const parsed = new URL(url);
-      const host = parsed.hostname.replace(/^www\./, '').toLowerCase();
-      const id = resolveIdFromUrl(parsed);
-      if (id) {
-        if (host === 'yande.re') return { source: 'YANDERE', id, idKind: 'POST', url, score, baseUrl: 'https://yande.re' };
-        if (host === 'konachan.com' || host === 'konachan.net') {
-          return { source: 'KONACHAN', id, idKind: 'POST', url, score, baseUrl: `https://${host}` };
-        }
-        if (host === 'gelbooru.com') {
-          return { source: 'GELBOORU', id, idKind: 'POST', url, score, baseUrl: 'https://gelbooru.com' };
-        }
-        if (host === 'chan.sankakucomplex.com') {
-          return { source: 'SANKAKU', id, idKind: 'POST', url, score, baseUrl: 'https://chan.sankakucomplex.com' };
-        }
-        if (host === 'idol.sankakucomplex.com') {
-          return { source: 'IDOL_COMPLEX', id, idKind: 'POST', url, score, baseUrl: 'https://idol.sankakucomplex.com' };
-        }
-      }
-      const md5 = resolveMd5(url) ?? resolveMd5(sourceName ?? null);
-      const inferred = resolveSourceFromUrl(parsed) ?? (sourceName ? resolveSourceFromName(sourceName) : null);
-      if (md5 && inferred) {
-        return { source: inferred, id: md5, idKind: 'MD5', url, score };
-      }
-    } catch {
-      // ignore
     }
   }
   const md5 = resolveMd5(url ?? null) ?? resolveMd5(sourceName ?? null);
-  const inferred = sourceName ? resolveSourceFromName(sourceName) : null;
-  if (md5 && inferred) {
-    return { source: inferred, id: md5, idKind: 'MD5', url: url ?? '', score };
+  if (md5) {
+    const site = sourceName ? resolveSiteFromName(sourceName, eligible) : null;
+    if (site) {
+      return { site, id: md5, idKind: 'MD5', url: url ?? '', score };
+    }
   }
   return null;
 };
 
-const buildE621Tags = (tags: E621TagBuckets | null | undefined) => {
-  if (!tags) return [];
-  const bucket: TagResult[] = [];
-  const pushTags = (category: string, values: string[]) => {
-    for (const tag of values ?? []) {
-      const cleaned = normalizeTag(tag);
-      if (cleaned) bucket.push({ tag: cleaned, category });
-    }
-  };
-  pushTags('general', tags.general ?? []);
-  pushTags('artist', tags.artist ?? []);
-  pushTags('character', tags.character ?? []);
-  pushTags('species', tags.species ?? []);
-  pushTags('meta', tags.meta ?? []);
-  pushTags('lore', tags.lore ?? []);
-  pushTags('invalid', tags.invalid ?? []);
-  return bucket;
-};
+// Tag parsing moved into engine modules. Kept the `normalizeTag` helper above
+// for the WD14 path which still computes tag categories locally.
 
-const buildDanbooruTags = (data: DanbooruPost | null | undefined) => {
-  const bucket: TagResult[] = [];
-  const pushTags = (category: string, value?: string) => {
-    if (!value) return;
-    value
-      .split(' ')
-      .map((tag) => normalizeTag(tag))
-      .filter(Boolean)
-      .forEach((tag) => bucket.push({ tag, category }));
-  };
-  pushTags('general', data?.tag_string_general);
-  pushTags('artist', data?.tag_string_artist);
-  pushTags('character', data?.tag_string_character);
-  pushTags('copyright', data?.tag_string_copyright);
-  pushTags('meta', data?.tag_string_meta);
-  return bucket;
-};
-
-const extractCandidates = (run: ProviderRunRecord): TagCandidate[] => {
+const extractCandidates = (run: ProviderRunRecord, sites: BooruSiteRecord[]): TagCandidate[] => {
   const minScore = providerScoreThresholds[run.provider] ?? 0;
   const results =
     run.results && run.results.length
@@ -328,294 +152,59 @@ const extractCandidates = (run: ProviderRunRecord): TagCandidate[] => {
       : run.sourceUrl
         ? [{ sourceUrl: run.sourceUrl, score: run.score }]
         : [];
-  const picks = new Map<TagCandidateSource, TagCandidate>();
+  const picks = new Map<string, TagCandidate>();
 
   for (const result of results) {
     const score = resolveCandidateScore(run, result);
     if (score < minScore) continue;
     const url = result.sourceUrl ?? null;
     const sourceName = (result as { sourceName?: string | null }).sourceName ?? null;
-    const candidate = resolveTagCandidate(url, score, sourceName);
+    const candidate = resolveTagCandidate(url, score, sourceName, sites);
     if (!candidate) continue;
-    const existing = picks.get(candidate.source);
+    const key = tagSourceForSite(candidate.site);
+    const existing = picks.get(key);
     if (!existing || score > existing.score) {
-      picks.set(candidate.source, candidate);
+      picks.set(key, candidate);
     }
   }
 
   return Array.from(picks.values());
 };
 
-const collectCandidatesFromRuns = (runs: ProviderRunRecord[]) => {
-  const picks = new Map<TagCandidateSource, TagCandidate>();
+const collectCandidatesFromRuns = (runs: ProviderRunRecord[], sites: BooruSiteRecord[]) => {
+  const picks = new Map<string, TagCandidate>();
   for (const run of runs) {
     if (run.status !== 'COMPLETED') continue;
-    const candidates = extractCandidates(run);
+    const candidates = extractCandidates(run, sites);
     for (const candidate of candidates) {
-      const existing = picks.get(candidate.source);
+      const key = tagSourceForSite(candidate.site);
+      const existing = picks.get(key);
       if (!existing || candidate.score > existing.score) {
-        picks.set(candidate.source, candidate);
+        picks.set(key, candidate);
       }
     }
   }
   return Array.from(picks.values());
 };
 
-const fetchE621Tags = async (postId: string, userId?: string) => {
-  const auth = await resolveE621Auth(userId);
-  if (!auth) return [];
-  const token = Buffer.from(`${auth.username}:${auth.apiKey}`).toString('base64');
-  const res = await fetch(`https://e621.net/posts/${postId}.json`, {
-    headers: {
-      Authorization: `Basic ${token}`,
-      'User-Agent': auth.userAgent
-    }
-  });
-  const text = await res.text();
-  if (!res.ok) {
-    console.warn(`[tags] e621 fetch failed (${res.status}): ${text.slice(0, 200)}`);
-    return [];
-  }
-  let data: E621Response;
-  try {
-    data = JSON.parse(text) as E621Response;
-  } catch {
-    console.warn(`[tags] e621 parse failed: ${text.slice(0, 200)}`);
-    return [];
-  }
-  const tags = data?.post?.tags;
-  return buildE621Tags(tags);
-};
+// Tag fetching is now handled by engine modules in lib/booruEngines. The
+// legacy fetchE621Tags / fetchDanbooruTags / fetchGelbooruTags /
+// fetchMoebooruTags / fetchSankakuTags wrappers were removed in favor of
+// `engine.fetchPostTags(site, postId)` / `engine.fetchPostByMd5(site, md5)`.
 
-const fetchE621TagsByMd5 = async (md5: string, userId?: string) => {
-  const auth = await resolveE621Auth(userId);
-  if (!auth) return { tags: [], sourceUrl: null };
-  const token = Buffer.from(`${auth.username}:${auth.apiKey}`).toString('base64');
-  const res = await fetch(`https://e621.net/posts.json?md5=${md5}`, {
-    headers: {
-      Authorization: `Basic ${token}`,
-      'User-Agent': auth.userAgent
-    }
-  });
-  const text = await res.text();
-  if (!res.ok) {
-    console.warn(`[tags] e621 md5 fetch failed (${res.status}): ${text.slice(0, 200)}`);
-    return { tags: [], sourceUrl: null };
+const fetchTagsBySite = async (
+  site: BooruSiteRecord,
+  candidate: TagCandidate
+): Promise<{ tags: TagResult[]; sourceUrl: string | null }> => {
+  const engine = getEngine(site.engine);
+  if (!engine) return { tags: [], sourceUrl: null };
+  if (candidate.idKind === 'MD5') {
+    if (!engine.fetchPostByMd5) return { tags: [], sourceUrl: null };
+    const result = await engine.fetchPostByMd5(site, candidate.id);
+    return result ?? { tags: [], sourceUrl: null };
   }
-  let data: E621Response;
-  try {
-    data = JSON.parse(text) as E621Response;
-  } catch {
-    console.warn(`[tags] e621 md5 parse failed: ${text.slice(0, 200)}`);
-    return { tags: [], sourceUrl: null };
-  }
-  const post = data?.post ?? (Array.isArray(data?.posts) ? data.posts[0] : null);
-  const tags = buildE621Tags(post?.tags ?? null);
-  const postId = post?.id ? String(post.id) : null;
-  return { tags, sourceUrl: postId ? `https://e621.net/posts/${postId}` : null };
-};
-
-const fetchDanbooruTags = async (postId: string, userId?: string) => {
-  const auth = await resolveDanbooruAuth(userId);
-  if (!auth) return [];
-  const token = Buffer.from(`${auth.username}:${auth.apiKey}`).toString('base64');
-  const res = await fetch(`https://danbooru.donmai.us/posts/${postId}.json`, {
-    headers: {
-      Authorization: `Basic ${token}`,
-      'User-Agent': auth.userAgent
-    }
-  });
-  const text = await res.text();
-  if (!res.ok) {
-    console.warn(`[tags] danbooru fetch failed (${res.status}): ${text.slice(0, 200)}`);
-    return [];
-  }
-  let data: DanbooruPost;
-  try {
-    data = JSON.parse(text) as DanbooruPost;
-  } catch {
-    console.warn(`[tags] danbooru parse failed: ${text.slice(0, 200)}`);
-    return [];
-  }
-  return buildDanbooruTags(data);
-};
-
-const fetchDanbooruTagsByMd5 = async (md5: string, userId?: string) => {
-  const auth = await resolveDanbooruAuth(userId);
-  if (!auth) return { tags: [], sourceUrl: null };
-  const token = Buffer.from(`${auth.username}:${auth.apiKey}`).toString('base64');
-  const res = await fetch(`https://danbooru.donmai.us/posts.json?md5=${md5}`, {
-    headers: {
-      Authorization: `Basic ${token}`,
-      'User-Agent': auth.userAgent
-    }
-  });
-  const text = await res.text();
-  if (!res.ok) {
-    console.warn(`[tags] danbooru md5 fetch failed (${res.status}): ${text.slice(0, 200)}`);
-    return { tags: [], sourceUrl: null };
-  }
-  let data: DanbooruResponse;
-  try {
-    data = JSON.parse(text) as DanbooruResponse;
-  } catch {
-    console.warn(`[tags] danbooru md5 parse failed: ${text.slice(0, 200)}`);
-    return { tags: [], sourceUrl: null };
-  }
-  const post = Array.isArray(data) ? data[0] : data?.post ?? (Array.isArray(data?.posts) ? data.posts[0] : null);
-  if (!post) return { tags: [], sourceUrl: null };
-  const tags = buildDanbooruTags(post);
-  const postId = post?.id ? String(post.id) : null;
-  return { tags, sourceUrl: postId ? `https://danbooru.donmai.us/posts/${postId}` : null };
-};
-
-const fetchGelbooruTags = async (postId: string) => {
-  const params = new URLSearchParams({
-    page: 'dapi',
-    s: 'post',
-    q: 'index',
-    id: postId,
-    json: '1'
-  });
-  if (config.gelbooru.userId && config.gelbooru.apiKey) {
-    params.set('user_id', config.gelbooru.userId);
-    params.set('api_key', config.gelbooru.apiKey);
-  }
-  const res = await fetch(`https://gelbooru.com/index.php?${params.toString()}`, {
-    headers: {
-      'User-Agent': config.e621.userAgent
-    }
-  });
-  const text = await res.text();
-  if (!res.ok) {
-    console.warn(`[tags] gelbooru fetch failed (${res.status}): ${text.slice(0, 200)}`);
-    return [];
-  }
-  let data: GelbooruResponse;
-  try {
-    data = JSON.parse(text) as GelbooruResponse;
-  } catch {
-    console.warn(`[tags] gelbooru parse failed: ${text.slice(0, 200)}`);
-    return [];
-  }
-  const entry: GelbooruPost | null = Array.isArray(data) ? (data[0] ?? null) : isGelbooruEnvelope(data) ? (data.post ?? null) : data;
-  const rawTags = typeof entry?.tags === 'string' ? entry.tags : '';
-  if (!rawTags) return [];
-  return rawTags
-    .split(' ')
-    .map((tag: string) => normalizeTag(tag))
-    .filter(Boolean)
-    .map((tag: string) => ({ tag, category: 'general' }));
-};
-
-const fetchMoebooruTags = async (baseUrl: string, postId: string) => {
-  const endpoints = [`${baseUrl}/post/show/${postId}.json`, `${baseUrl}/post.json?tags=id:${postId}`];
-  for (const endpoint of endpoints) {
-    const res = await fetch(endpoint, {
-      headers: {
-        'User-Agent': config.e621.userAgent
-      }
-    });
-    const text = await res.text();
-    if (!res.ok) {
-      console.warn(`[tags] moebooru fetch failed (${res.status}): ${text.slice(0, 200)}`);
-      continue;
-    }
-    let data: MoebooruResponse;
-    try {
-      data = JSON.parse(text) as MoebooruResponse;
-    } catch {
-      console.warn(`[tags] moebooru parse failed: ${text.slice(0, 200)}`);
-      continue;
-    }
-    const entry = Array.isArray(data) ? data[0] : data;
-    if (!entry) continue;
-    const bucket: TagResult[] = [];
-    const pushTags = (category: string, value?: string) => {
-      if (!value) return;
-      value
-        .split(' ')
-        .map((tag) => normalizeTag(tag))
-        .filter(Boolean)
-        .forEach((tag) => bucket.push({ tag, category }));
-    };
-    pushTags('general', entry.tags_general ?? entry.tags ?? '');
-    pushTags('artist', entry.tags_artist ?? '');
-    pushTags('character', entry.tags_character ?? '');
-    pushTags('copyright', entry.tags_copyright ?? '');
-    pushTags('meta', entry.tags_meta ?? '');
-    if (bucket.length) return bucket;
-    return [];
-  }
-  return [];
-};
-
-const fetchSankakuTags = async (postId: string, baseUrl: string) => {
-  const endpoints = [
-    `https://capi-v2.sankakucomplex.com/posts/${postId}`,
-    `${baseUrl}/post/show/${postId}.json`
-  ];
-  for (const endpoint of endpoints) {
-    const res = await fetch(endpoint, {
-      headers: {
-        'User-Agent': config.e621.userAgent,
-        Accept: 'application/json'
-      }
-    });
-    const text = await res.text();
-    if (!res.ok) {
-      console.warn(`[tags] sankaku fetch failed (${res.status}): ${text.slice(0, 200)}`);
-      continue;
-    }
-    let data: SankakuResponse;
-    try {
-      data = JSON.parse(text) as SankakuResponse;
-    } catch {
-      console.warn(`[tags] sankaku parse failed: ${text.slice(0, 200)}`);
-      continue;
-    }
-    const entry = Array.isArray(data) ? data[0] : data;
-    if (!entry) continue;
-    const bucket: TagResult[] = [];
-    if (Array.isArray(entry.tags)) {
-      for (const item of entry.tags) {
-        const name = typeof item?.name === 'string' ? normalizeTag(item.name) : '';
-        if (!name) continue;
-        const rawType = item?.type;
-        let category = 'general';
-        if (typeof rawType === 'string') {
-          category = rawType.toLowerCase();
-        } else if (typeof rawType === 'number') {
-          switch (rawType) {
-            case 1:
-              category = 'artist';
-              break;
-            case 3:
-              category = 'copyright';
-              break;
-            case 4:
-              category = 'character';
-              break;
-            case 5:
-              category = 'meta';
-              break;
-            default:
-              category = 'general';
-          }
-        }
-        bucket.push({ tag: name, category });
-      }
-    } else if (typeof entry.tags === 'string') {
-      entry.tags
-        .split(' ')
-        .map((tag: string) => normalizeTag(tag))
-        .filter(Boolean)
-        .forEach((tag: string) => bucket.push({ tag, category: 'general' }));
-    }
-    if (bucket.length) return bucket;
-    return [];
-  }
-  return [];
+  const tags = await engine.fetchPostTags(site, candidate.id);
+  return { tags, sourceUrl: candidate.url || engine.buildPostUrl(site, candidate.id) };
 };
 
 const resolveLocalPath = async (file: FileRecord) => {
@@ -737,86 +326,35 @@ const replaceTags = async (fileId: string, source: TagSource, tags: TagResult[],
   );
 };
 
+// Legacy entry point kept for favorites.ts. `provider` is either a legacy
+// preset key ('E621'/'DANBOORU') or a user_booru_sites.id UUID. Resolves the
+// site from the caller's perspective (via file owner) and dispatches to the
+// engine module.
 export const applyRemotePostTags = async (
   file: FileRecord,
-  provider: 'E621' | 'DANBOORU',
+  provider: string,
   postId: string,
   sourceUrl?: string | null
 ) => {
   const userId = await resolveFileUserId(file.id);
-  if (provider === 'E621') {
-    const tags = await fetchE621Tags(postId, userId);
-    if (!tags.length) return { applied: false, count: 0 };
-    await replaceTags(file.id, 'E621', tags, sourceUrl ?? `https://e621.net/posts/${postId}`);
-    return { applied: true, count: tags.length };
-  }
-  const tags = await fetchDanbooruTags(postId, userId);
+  if (!userId) return { applied: false, count: 0 };
+  const byId = await dataStore.getBooruSite(provider, userId);
+  const site = byId ?? (await dataStore.findBooruSiteByPresetKey(provider, userId));
+  if (!site) return { applied: false, count: 0 };
+  const engine = getEngine(site.engine);
+  if (!engine) return { applied: false, count: 0 };
+  const tags = await engine.fetchPostTags(site, postId);
   if (!tags.length) return { applied: false, count: 0 };
-  await replaceTags(file.id, 'DANBOORU', tags, sourceUrl ?? `https://danbooru.donmai.us/posts/${postId}`);
+  const resolvedUrl = sourceUrl ?? engine.buildPostUrl(site, postId);
+  await replaceTags(file.id, tagSourceForSite(site), tags, resolvedUrl);
   return { applied: true, count: tags.length };
 };
 
 const applyCandidateTags = async (fileId: string, candidate: TagCandidate) => {
-  const userId = await resolveFileUserId(fileId);
-  if (candidate.source === 'E621') {
-    if (candidate.idKind === 'MD5') {
-      const result = await fetchE621TagsByMd5(candidate.id, userId);
-      if (result.tags.length === 0) return false;
-      await replaceTags(fileId, 'E621', result.tags, result.sourceUrl ?? candidate.url);
-      return true;
-    }
-    const tags = await fetchE621Tags(candidate.id, userId);
-    if (tags.length === 0) return false;
-    await replaceTags(fileId, 'E621', tags, candidate.url);
-    return true;
-  }
-  if (candidate.source === 'DANBOORU') {
-    if (candidate.idKind === 'MD5') {
-      const result = await fetchDanbooruTagsByMd5(candidate.id, userId);
-      if (result.tags.length === 0) return false;
-      await replaceTags(fileId, 'DANBOORU', result.tags, result.sourceUrl ?? candidate.url);
-      return true;
-    }
-    const tags = await fetchDanbooruTags(candidate.id, userId);
-    if (tags.length === 0) return false;
-    await replaceTags(fileId, 'DANBOORU', tags, candidate.url);
-    return true;
-  }
-  if (candidate.source === 'GELBOORU') {
-    const tags = await fetchGelbooruTags(candidate.id);
-    if (tags.length === 0) return false;
-    await replaceTags(fileId, 'GELBOORU', tags, candidate.url);
-    return true;
-  }
-  if (candidate.source === 'YANDERE') {
-    const baseUrl = candidate.baseUrl ?? 'https://yande.re';
-    const tags = await fetchMoebooruTags(baseUrl, candidate.id);
-    if (tags.length === 0) return false;
-    await replaceTags(fileId, 'YANDERE', tags, candidate.url);
-    return true;
-  }
-  if (candidate.source === 'KONACHAN') {
-    const baseUrl = candidate.baseUrl ?? 'https://konachan.com';
-    const tags = await fetchMoebooruTags(baseUrl, candidate.id);
-    if (tags.length === 0) return false;
-    await replaceTags(fileId, 'KONACHAN', tags, candidate.url);
-    return true;
-  }
-  if (candidate.source === 'SANKAKU') {
-    const baseUrl = candidate.baseUrl ?? 'https://chan.sankakucomplex.com';
-    const tags = await fetchSankakuTags(candidate.id, baseUrl);
-    if (tags.length === 0) return false;
-    await replaceTags(fileId, 'SANKAKU', tags, candidate.url);
-    return true;
-  }
-  if (candidate.source === 'IDOL_COMPLEX') {
-    const baseUrl = candidate.baseUrl ?? 'https://idol.sankakucomplex.com';
-    const tags = await fetchSankakuTags(candidate.id, baseUrl);
-    if (tags.length === 0) return false;
-    await replaceTags(fileId, 'IDOL_COMPLEX', tags, candidate.url);
-    return true;
-  }
-  return false;
+  const { tags, sourceUrl } = await fetchTagsBySite(candidate.site, candidate);
+  if (!tags.length) return false;
+  await replaceTags(fileId, tagSourceForSite(candidate.site), tags, sourceUrl ?? candidate.url);
+  return true;
 };
 
 const applyCombinedTags = async (file: FileRecord, candidates: TagCandidate[]) => {
@@ -826,11 +364,18 @@ const applyCombinedTags = async (file: FileRecord, candidates: TagCandidate[]) =
   await ensureWd14Tags(file, file.mediaType === 'VIDEO', { force: true });
 };
 
+const loadTagSitesForFile = async (file: FileRecord): Promise<BooruSiteRecord[]> => {
+  const userId = await resolveFileUserId(file.id);
+  if (!userId) return [];
+  return dataStore.listBooruSites(userId);
+};
+
 export const refreshTagsFromProviderRun = async (file: FileRecord, _run: ProviderRunRecord) => {
   void _run;
   try {
+    const sites = await loadTagSitesForFile(file);
     const runs = await dataStore.listProviderRuns(file.id);
-    const candidates = collectCandidatesFromRuns(runs);
+    const candidates = collectCandidatesFromRuns(runs, sites);
     await applyCombinedTags(file, candidates);
   } catch (err) {
     console.warn(`[tags] refresh failed for ${file.id}: ${(err as Error).message}`);
@@ -845,9 +390,8 @@ export const ensureWd14Tags = async (
   if (!config.tagger.url) return;
   if (file.mediaType === 'IMAGE' && (!file.width || !file.height)) return;
   const tags = await dataStore.listTagsForFile(file.id);
-  const hasSourceTags = tags.some((tag) =>
-    ['E621', 'DANBOORU', 'GELBOORU', 'YANDERE', 'KONACHAN', 'SANKAKU', 'IDOL_COMPLEX'].includes(tag.source)
-  );
+  const specialSources = new Set<string>(SPECIAL_TAG_SOURCES);
+  const hasSourceTags = tags.some((tag) => !specialSources.has(tag.source));
   const hasWd14 = tags.some((tag) => tag.source === 'WD14');
   if (hasWd14 && !options?.force) return;
   if (!forceForVideo && hasSourceTags && !options?.force && !options?.ignoreSourceTags) return;
@@ -876,7 +420,8 @@ export const ensureWd14Tags = async (
 };
 
 export const refreshTagsForFile = async (file: FileRecord) => {
+  const sites = await loadTagSitesForFile(file);
   const runs = await dataStore.listProviderRuns(file.id);
-  const candidates = collectCandidatesFromRuns(runs);
+  const candidates = collectCandidatesFromRuns(runs, sites);
   await applyCombinedTags(file, candidates);
 };

--- a/backend/src/services/tagging.ts
+++ b/backend/src/services/tagging.ts
@@ -55,13 +55,6 @@ const resolveFileUserId = async (fileId: string) => {
   return user?.id;
 };
 
-const normalizeTag = (value: string) =>
-  value
-    .trim()
-    .replace(/\s+/g, '_')
-    .replace(/[^\w:()-]+/g, '')
-    .toLowerCase();
-
 const resolveCandidateScore = (
   run: ProviderRunRecord,
   result: { score?: number | null; distance?: number | null }
@@ -141,8 +134,7 @@ const resolveTagCandidate = (
   return null;
 };
 
-// Tag parsing moved into engine modules. Kept the `normalizeTag` helper above
-// for the WD14 path which still computes tag categories locally.
+// Tag parsing moved into engine modules (lib/booruEngines).
 
 const extractCandidates = (run: ProviderRunRecord, sites: BooruSiteRecord[]): TagCandidate[] => {
   const minScore = providerScoreThresholds[run.provider] ?? 0;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import {
   SauceSource
 } from './api';
 import type { CredentialProvider, CredentialSummary, DuplicateScanStatus, FavoriteSyncStatus, ProviderRun } from './api';
+import { BooruSitesPanel } from './BooruSitesPanel';
 
 type FetchState = {
   loading: boolean;
@@ -452,6 +453,20 @@ function App() {
   });
   const [sauceProgress, setSauceProgress] = useState<SauceProgress>(emptySauceProgress);
   const [sauceState, setSauceState] = useState<FetchState>({ loading: false, error: null });
+  // Booru-sites "developer options" toggle. Hidden by default; when on it
+  // reveals the probe attempts table + manual engine override inside
+  // <BooruSitesPanel>. Persisted in localStorage so power users don't
+  // re-enable it every session.
+  const [booruDevOptions, setBooruDevOptions] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem('booru:devOptions') === '1';
+  });
+  const setBooruDevOptionsPersistent = (next: boolean) => {
+    setBooruDevOptions(next);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('booru:devOptions', next ? '1' : '0');
+    }
+  };
   const [favoritesSyncState, setFavoritesSyncState] = useState<FetchState>({ loading: false, error: null });
   const [favoritesSyncStatus, setFavoritesSyncStatus] = useState<FavoriteSyncStatus | null>(null);
   const favoritesPollRef = useRef<number | null>(null);
@@ -2833,6 +2848,60 @@ function App() {
                     <p className="text-secondary small mb-3">
                       Connect your e621 and Danbooru accounts to double-sync favorites.
                     </p>
+
+                    <BooruSitesPanel className="mb-4" devOptions={booruDevOptions} />
+
+                    <div className="d-flex flex-wrap gap-2 mb-2">
+                      <button
+                        className="btn btn-outline-light btn-sm"
+                        onClick={() => void runFavoritesSync(true)}
+                        disabled={favoritesSyncState.loading}
+                      >
+                        Sync favorites
+                      </button>
+                    </div>
+                    <div className="form-check form-switch mb-2">
+                      <input
+                        className="form-check-input"
+                        type="checkbox"
+                        id="auto-sync-toggle-top"
+                        checked={favoritesSettings.autoSyncMidnight}
+                        onChange={(event) => void updateFavoritesSettings({ autoSyncMidnight: event.target.checked })}
+                        disabled={favoritesSettingsState.loading}
+                      />
+                      <label className="form-check-label text-secondary small" htmlFor="auto-sync-toggle-top">
+                        Run a daily sync at midnight to keep favorites current
+                      </label>
+                    </div>
+                    <div className="form-check form-switch mb-2">
+                      <input
+                        className="form-check-input"
+                        type="checkbox"
+                        id="reverse-sync-toggle-top"
+                        checked={favoritesSettings.reverseSyncEnabled}
+                        onChange={(event) => void updateFavoritesSettings({ reverseSyncEnabled: event.target.checked })}
+                        disabled={favoritesSettingsState.loading}
+                      />
+                      <label className="form-check-label text-secondary small" htmlFor="reverse-sync-toggle-top">
+                        When you delete a file here, also remove it from favorites
+                      </label>
+                    </div>
+                    <div className="form-check form-switch mb-3">
+                      <input
+                        className="form-check-input"
+                        type="checkbox"
+                        id="auto-fav-toggle-top"
+                        checked={favoritesSettings.autoFavEnabled}
+                        onChange={(event) => void updateFavoritesSettings({ autoFavEnabled: event.target.checked })}
+                        disabled={favoritesSettingsState.loading}
+                      />
+                      <label className="form-check-label text-secondary small" htmlFor="auto-fav-toggle-top">
+                        When the sources scanner finds a match on a logged-in source, auto-favorite it there
+                      </label>
+                    </div>
+
+                    <details className="mb-3">
+                      <summary className="text-secondary small">Legacy credential cards (E621 / Danbooru)</summary>
                     <div className="credential-grid mb-3">
                       <div className="credential-col">
                         <div className="border border-secondary rounded p-2 credential-card">
@@ -2967,60 +3036,13 @@ function App() {
                         </div>
                       </div>
                     </div>
+                    </details>
                     {credentialsState.error &&
                     (credentialLastProvider === null ||
                       credentialLastProvider === 'E621' ||
                       credentialLastProvider === 'DANBOORU') ? (
                       <div className="text-danger small mb-2">Credentials error: {credentialsState.error}</div>
                     ) : null}
-                    <div className="d-flex flex-wrap gap-2 mb-2">
-                      <button
-                        className="btn btn-outline-light btn-sm"
-                        onClick={() => void runFavoritesSync(true)}
-                        disabled={favoritesSyncState.loading}
-                      >
-                        Sync favorites
-                      </button>
-                    </div>
-                    <div className="form-check form-switch mb-2">
-                      <input
-                        className="form-check-input"
-                        type="checkbox"
-                        id="auto-sync-toggle"
-                        checked={favoritesSettings.autoSyncMidnight}
-                        onChange={(event) => void updateFavoritesSettings({ autoSyncMidnight: event.target.checked })}
-                        disabled={favoritesSettingsState.loading}
-                      />
-                      <label className="form-check-label text-secondary small" htmlFor="auto-sync-toggle">
-                        Run a daily sync at midnight to keep favorites current
-                      </label>
-                    </div>
-                    <div className="form-check form-switch mb-2">
-                      <input
-                        className="form-check-input"
-                        type="checkbox"
-                        id="reverse-sync-toggle"
-                        checked={favoritesSettings.reverseSyncEnabled}
-                        onChange={(event) => void updateFavoritesSettings({ reverseSyncEnabled: event.target.checked })}
-                        disabled={favoritesSettingsState.loading}
-                      />
-                      <label className="form-check-label text-secondary small" htmlFor="reverse-sync-toggle">
-                        When you delete a file here, also remove it from favorites
-                      </label>
-                    </div>
-                    <div className="form-check form-switch mb-2">
-                      <input
-                        className="form-check-input"
-                        type="checkbox"
-                        id="auto-fav-toggle"
-                        checked={favoritesSettings.autoFavEnabled}
-                        onChange={(event) => void updateFavoritesSettings({ autoFavEnabled: event.target.checked })}
-                        disabled={favoritesSettingsState.loading}
-                      />
-                      <label className="form-check-label text-secondary small" htmlFor="auto-fav-toggle">
-                        When the sources scanner finds a match on a logged-in source, auto-favorite it there
-                      </label>
-                    </div>
                     {favoritesSettingsState.error ? (
                       <div className="text-danger small">Settings error: {favoritesSettingsState.error}</div>
                     ) : null}
@@ -3266,6 +3288,28 @@ function App() {
                         </div>
                       </>
                     )}
+                  </div>
+                </div>
+              </div>
+              <div className="col-12 settings-section">
+                <div className="card bg-transparent text-light border-0 h-100 settings-section-card">
+                  <div className="card-body">
+                    <hr className="border-secondary mt-0 mb-3" />
+                    <div className="form-check form-switch">
+                      <input
+                        className="form-check-input"
+                        type="checkbox"
+                        id="booru-dev-options-toggle"
+                        checked={booruDevOptions}
+                        onChange={(e) => setBooruDevOptionsPersistent(e.target.checked)}
+                      />
+                      <label
+                        className="form-check-label text-secondary small"
+                        htmlFor="booru-dev-options-toggle"
+                      >
+                        Developer options
+                      </label>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/frontend/src/BooruSitesPanel.tsx
+++ b/frontend/src/BooruSitesPanel.tsx
@@ -1,0 +1,660 @@
+import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from 'react';
+
+import {
+  api,
+  type BooruCredentialSchema,
+  type BooruDetectionResult,
+  type BooruEngineCatalog,
+  type BooruEngineType,
+  type BooruSite
+} from './api';
+
+const ENGINE_LABELS: Record<BooruEngineType, string> = {
+  danbooru: 'Danbooru',
+  e621: 'e621',
+  moebooru: 'Moebooru (yande.re / konachan)',
+  gelbooru: 'Gelbooru',
+  sankaku: 'Sankaku',
+  philomena: 'Philomena (Derpibooru)',
+  shimmie: 'Shimmie2',
+  szurubooru: 'Szurubooru'
+};
+
+type CapabilityKey = 'capFavorites' | 'capTags' | 'capSourceMatch';
+
+const CAPABILITY_LABELS: Record<CapabilityKey, string> = {
+  capFavorites: 'Sync favorites',
+  capTags: 'Tag fetch',
+  capSourceMatch: 'Source URL match'
+};
+
+type CredentialsState = {
+  username: string;
+  apiKey: string;
+};
+
+type AddFormState = {
+  name: string;
+  baseUrl: string;
+  detection: BooruDetectionResult | null;
+  detecting: boolean;
+  detectError: string | null;
+  username: string;
+  apiKey: string;
+  capabilities: Record<CapabilityKey, boolean>;
+};
+
+const defaultCaps: Record<CapabilityKey, boolean> = {
+  capFavorites: false,
+  capTags: true,
+  capSourceMatch: true
+};
+
+const initialAddForm = (): AddFormState => ({
+  name: '',
+  baseUrl: '',
+  detection: null,
+  detecting: false,
+  detectError: null,
+  username: '',
+  apiKey: '',
+  capabilities: { ...defaultCaps }
+});
+
+const credentialFieldsForSchema = (schema: BooruCredentialSchema) => {
+  switch (schema) {
+    case 'username+apikey':
+      return { username: true, usernameLabel: 'Username', apiKey: true, apiKeyLabel: 'API key' };
+    case 'userid+apikey':
+      return { username: true, usernameLabel: 'User ID', apiKey: true, apiKeyLabel: 'API key' };
+    case 'apikey-only':
+      return { username: false, usernameLabel: '', apiKey: true, apiKeyLabel: 'API key' };
+    case 'token':
+      return { username: false, usernameLabel: '', apiKey: true, apiKeyLabel: 'Token' };
+    case 'none':
+    default:
+      return { username: false, usernameLabel: '', apiKey: false, apiKeyLabel: '' };
+  }
+};
+
+const debounce = <T extends (...args: never[]) => void>(fn: T, delay: number) => {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  return (...args: Parameters<T>) => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delay);
+  };
+};
+
+type Props = {
+  className?: string;
+  /**
+   * Hoisted from the parent so the toggle UI can live at the bottom of the
+   * favorites settings card rather than inside this panel. Off by default
+   * — the happy-path detection badge is enough for normal users.
+   */
+  devOptions: boolean;
+};
+
+export const BooruSitesPanel = ({ className, devOptions }: Props) => {
+  const [sites, setSites] = useState<BooruSite[]>([]);
+  const [catalog, setCatalog] = useState<BooruEngineCatalog | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [addForm, setAddForm] = useState<AddFormState>(initialAddForm());
+  const [addingBusy, setAddingBusy] = useState(false);
+  const [testingId, setTestingId] = useState<string | null>(null);
+  const [testResults, setTestResults] = useState<Record<string, { ok: boolean; message: string }>>({});
+  const [editCredentials, setEditCredentials] = useState<Record<string, CredentialsState>>({});
+
+  const reload = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [list, engineCatalog] = await Promise.all([
+        api.getBooruSites(),
+        api.getBooruEngineCatalog()
+      ]);
+      setSites(list);
+      setCatalog(engineCatalog);
+      const inputs: Record<string, CredentialsState> = {};
+      list.forEach((site) => {
+        inputs[site.id] = {
+          username: site.username ?? '',
+          apiKey: ''
+        };
+      });
+      setEditCredentials(inputs);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void reload();
+  }, []);
+
+  const detectedEngine: BooruEngineType | null = useMemo(() => {
+    if (addForm.detection && 'engine' in addForm.detection) return addForm.detection.engine;
+    return null;
+  }, [addForm.detection]);
+
+  const detectedSchema: BooruCredentialSchema = useMemo(() => {
+    if (addForm.detection && 'engine' in addForm.detection) {
+      return addForm.detection.credentialSchema;
+    }
+    return 'none';
+  }, [addForm.detection]);
+
+  const runDetect = useMemo(
+    () =>
+      debounce(async (url: string) => {
+        if (!url) {
+          setAddForm((prev) => ({ ...prev, detection: null, detecting: false, detectError: null }));
+          return;
+        }
+        setAddForm((prev) => ({ ...prev, detecting: true, detectError: null }));
+        try {
+          const result = await api.detectBooruEngine(url);
+          setAddForm((prev) => ({
+            ...prev,
+            detection: result,
+            detecting: false,
+            detectError: 'error' in result ? null : null,
+            capabilities:
+              'engine' in result && result.defaultCapabilities
+                ? {
+                    capFavorites: result.defaultCapabilities.favorites,
+                    capTags: result.defaultCapabilities.tags,
+                    capSourceMatch: result.defaultCapabilities.sourceMatch
+                  }
+                : prev.capabilities
+          }));
+        } catch (err) {
+          setAddForm((prev) => ({ ...prev, detecting: false, detectError: (err as Error).message }));
+        }
+      }, 600),
+    []
+  );
+
+  const onUrlChange = (value: string) => {
+    setAddForm((prev) => ({ ...prev, baseUrl: value, detection: null }));
+    runDetect(value);
+  };
+
+  const submitNewSite = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!detectedEngine) {
+      setAddForm((prev) => ({ ...prev, detectError: 'No engine selected. Wait for detection or choose manually.' }));
+      return;
+    }
+    setAddingBusy(true);
+    try {
+      await api.createBooruSite({
+        name: addForm.name.trim(),
+        engine: detectedEngine,
+        baseUrl: addForm.baseUrl.trim(),
+        username: addForm.username.trim() || null,
+        apiKey: addForm.apiKey.trim() || null,
+        capFavorites: addForm.capabilities.capFavorites,
+        capTags: addForm.capabilities.capTags,
+        capSourceMatch: addForm.capabilities.capSourceMatch,
+        enabled: true
+      });
+      setAddForm(initialAddForm());
+      await reload();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setAddingBusy(false);
+    }
+  };
+
+  const toggleCapability = async (site: BooruSite, capability: CapabilityKey) => {
+    try {
+      const updated = await api.updateBooruSite(site.id, { [capability]: !site[capability] });
+      setSites((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const toggleEnabled = async (site: BooruSite) => {
+    try {
+      const updated = await api.updateBooruSite(site.id, { enabled: !site.enabled });
+      setSites((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const saveCredentials = async (site: BooruSite) => {
+    const input = editCredentials[site.id];
+    if (!input) return;
+    try {
+      const updated = await api.updateBooruSite(site.id, {
+        username: input.username.trim() || null,
+        apiKey: input.apiKey.trim() || null
+      });
+      setSites((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
+      setEditCredentials((prev) => ({ ...prev, [site.id]: { username: updated.username ?? '', apiKey: '' } }));
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const deleteSite = async (site: BooruSite) => {
+    if (!confirm(`Delete ${site.name}?`)) return;
+    try {
+      await api.deleteBooruSite(site.id);
+      await reload();
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const testSite = async (site: BooruSite) => {
+    setTestingId(site.id);
+    try {
+      const res = await api.testBooruSite(site.id);
+      setTestResults((prev) => ({
+        ...prev,
+        [site.id]: {
+          ok: res.ok,
+          message: res.ok ? `OK (HTTP ${res.status ?? '200'})` : res.error ?? `HTTP ${res.status ?? '?'}`
+        }
+      }));
+    } catch (err) {
+      setTestResults((prev) => ({
+        ...prev,
+        [site.id]: { ok: false, message: (err as Error).message }
+      }));
+    } finally {
+      setTestingId(null);
+    }
+  };
+
+  const moveSite = async (site: BooruSite, direction: -1 | 1) => {
+    const sorted = [...sites].sort((a, b) => a.sortOrder - b.sortOrder);
+    const idx = sorted.findIndex((s) => s.id === site.id);
+    const targetIdx = idx + direction;
+    if (targetIdx < 0 || targetIdx >= sorted.length) return;
+    const reordered = [...sorted];
+    [reordered[idx], reordered[targetIdx]] = [reordered[targetIdx], reordered[idx]];
+    try {
+      const updated = await api.reorderBooruSites(reordered.map((s) => s.id));
+      setSites(updated);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const credentialSchemaFor = (site: BooruSite) =>
+    catalog?.engines.find((entry) => entry.type === site.engine)?.credentialSchema ?? 'none';
+
+  if (loading) return <div className={className}>Loading booru sites…</div>;
+
+  return (
+    <div className={className}>
+      {error ? (
+        <div className="alert alert-danger" role="alert">
+          {error}
+          <button type="button" className="btn btn-sm btn-link" onClick={() => setError(null)}>
+            dismiss
+          </button>
+        </div>
+      ) : null}
+
+      <h5 className="mt-3 text-light">Configured booru sources</h5>
+      {sites.length === 0 ? (
+        <p className="text-secondary small">No sites configured. Add one below to enable favorites sync and tag fetch.</p>
+      ) : (
+        <div className="mb-4 d-flex flex-column gap-2">
+          {[...sites]
+            .sort((a, b) => a.sortOrder - b.sortOrder)
+            .map((site) => {
+              const schema = credentialSchemaFor(site);
+              const fields = credentialFieldsForSchema(schema);
+              const test = testResults[site.id];
+              const edit = editCredentials[site.id] ?? { username: '', apiKey: '' };
+              return (
+                <div key={site.id} className="border border-secondary rounded p-2 text-light">
+                  <div className="d-flex align-items-center gap-2">
+                    <div className="flex-grow-1">
+                      <strong>{site.name}</strong>{' '}
+                      <small className="text-secondary">
+                        {ENGINE_LABELS[site.engine]} · {site.baseUrl}
+                        {site.isPreset ? ' · preset' : ''}
+                      </small>
+                    </div>
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-light"
+                      onClick={() => moveSite(site, -1)}
+                      title="Move up"
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-light"
+                      onClick={() => moveSite(site, 1)}
+                      title="Move down"
+                    >
+                      ↓
+                    </button>
+                    <div className="form-check form-switch m-0">
+                      <input
+                        className="form-check-input"
+                        type="checkbox"
+                        id={`enabled-${site.id}`}
+                        checked={site.enabled}
+                        onChange={() => toggleEnabled(site)}
+                      />
+                      <label className="form-check-label text-secondary small" htmlFor={`enabled-${site.id}`}>
+                        enabled
+                      </label>
+                    </div>
+                  </div>
+
+                  <div className="row g-2 mt-2">
+                    {(Object.keys(CAPABILITY_LABELS) as CapabilityKey[]).map((cap) => (
+                      <div key={cap} className="col-6 col-md-3">
+                        <div className="form-check">
+                          <input
+                            className="form-check-input"
+                            type="checkbox"
+                            id={`${site.id}-${cap}`}
+                            checked={site[cap]}
+                            onChange={() => toggleCapability(site, cap)}
+                          />
+                          <label className="form-check-label text-secondary small" htmlFor={`${site.id}-${cap}`}>
+                            {CAPABILITY_LABELS[cap]}
+                          </label>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+
+                  {(fields.username || fields.apiKey) ? (
+                    <div className="row g-2 mt-2">
+                      {fields.username ? (
+                        <div className="col-md-4">
+                          <label className="form-label small mb-1 text-secondary">{fields.usernameLabel}</label>
+                          <input
+                            type="text"
+                            className="form-control form-control-sm bg-dark text-light border-secondary"
+                            value={edit.username}
+                            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                              setEditCredentials((prev) => ({
+                                ...prev,
+                                [site.id]: { ...edit, username: e.target.value }
+                              }))
+                            }
+                          />
+                        </div>
+                      ) : null}
+                      {fields.apiKey ? (
+                        <div className="col-md-4">
+                          <label className="form-label small mb-1 text-secondary">
+                            {fields.apiKeyLabel}
+                            {site.hasApiKey ? <span className="text-secondary"> · saved</span> : null}
+                          </label>
+                          <input
+                            type="password"
+                            className="form-control form-control-sm bg-dark text-light border-secondary"
+                            placeholder={site.hasApiKey ? '••••••••' : ''}
+                            value={edit.apiKey}
+                            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                              setEditCredentials((prev) => ({
+                                ...prev,
+                                [site.id]: { ...edit, apiKey: e.target.value }
+                              }))
+                            }
+                          />
+                        </div>
+                      ) : null}
+                      <div className="col-md-4 d-flex align-items-end gap-2">
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-outline-light"
+                          onClick={() => saveCredentials(site)}
+                        >
+                          Save credentials
+                        </button>
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-outline-light"
+                          onClick={() => testSite(site)}
+                          disabled={testingId === site.id}
+                        >
+                          {testingId === site.id ? 'Testing…' : 'Test'}
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="mt-2">
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-light"
+                        onClick={() => testSite(site)}
+                        disabled={testingId === site.id}
+                      >
+                        {testingId === site.id ? 'Testing…' : 'Test connection'}
+                      </button>
+                    </div>
+                  )}
+
+                  {test ? (
+                    <div className={`small mt-2 ${test.ok ? 'text-success' : 'text-danger'}`}>
+                      {test.ok ? '✓ ' : '✗ '} {test.message}
+                    </div>
+                  ) : null}
+
+                  {!site.isPreset ? (
+                    <div className="mt-2">
+                      <button type="button" className="btn btn-sm btn-link text-danger" onClick={() => deleteSite(site)}>
+                        Delete site
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+              );
+            })}
+        </div>
+      )}
+
+      <h5 className="mt-4 text-light">Add custom booru site</h5>
+      <form onSubmit={submitNewSite} className="row g-2">
+        <div className="col-md-6">
+          <label htmlFor="booru-name" className="form-label small mb-1 text-secondary">
+            Name
+          </label>
+          <input
+            id="booru-name"
+            type="text"
+            className="form-control form-control-sm bg-dark text-light border-secondary"
+            value={addForm.name}
+            onChange={(e) => setAddForm((prev) => ({ ...prev, name: e.target.value }))}
+            placeholder="My booru"
+            required
+          />
+        </div>
+        <div className="col-md-6">
+          <label htmlFor="booru-url" className="form-label small mb-1 text-secondary">
+            Base URL
+          </label>
+          <input
+            id="booru-url"
+            type="url"
+            className="form-control form-control-sm bg-dark text-light border-secondary"
+            value={addForm.baseUrl}
+            onChange={(e) => onUrlChange(e.target.value)}
+            placeholder="https://example.com"
+            required
+          />
+        </div>
+
+        {addForm.detecting ? (
+          <div className="col-12 text-secondary small">Detecting engine…</div>
+        ) : null}
+
+        {addForm.detection && 'engine' in addForm.detection ? (
+          <div className="col-12">
+            <div className="d-flex align-items-center gap-2 flex-wrap">
+              <span className="badge text-bg-success">
+                Detected: {ENGINE_LABELS[addForm.detection.engine]}
+              </span>
+              {devOptions ? (
+                <small className="text-secondary">
+                  via {addForm.detection.confidence === 'hostname' ? 'known hostname' : 'API probe'}
+                </small>
+              ) : null}
+            </div>
+            {addForm.detection.sample?.thumbUrl ? (
+              <div className="mt-2 d-flex align-items-start gap-2">
+                <a
+                  href={addForm.detection.sample.postUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  title={`Sample post #${addForm.detection.sample.postId}`}
+                >
+                  <img
+                    src={addForm.detection.sample.thumbUrl}
+                    alt={`Sample post #${addForm.detection.sample.postId}`}
+                    style={{ maxWidth: 96, maxHeight: 96 }}
+                    className="border border-secondary rounded"
+                    loading="lazy"
+                  />
+                </a>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {addForm.detection && 'error' in addForm.detection ? (
+          <div className="col-12">
+            <div className="alert alert-warning py-2 small mb-2">
+              {addForm.detection.error === 'unreachable'
+                ? `Site unreachable. ${addForm.detection.message}`
+                : 'Could not identify the engine for this site. It may run an unsupported booru engine, require login, or sit behind a CAPTCHA/anti-bot wall. Only recognized engines can be added.'}
+            </div>
+            {devOptions && addForm.detection.attempts?.length ? (
+              <details className="mb-2" open>
+                <summary className="text-secondary small">
+                  Probe attempts ({addForm.detection.attempts.length})
+                </summary>
+                <table className="table table-sm table-dark table-borderless mt-2 mb-0 small">
+                  <thead>
+                    <tr className="text-secondary">
+                      <th scope="col">Engine</th>
+                      <th scope="col">Status</th>
+                      <th scope="col">HTTP</th>
+                      <th scope="col">Detail</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {addForm.detection.attempts.map((attempt) => (
+                      <tr key={attempt.engine}>
+                        <td>{ENGINE_LABELS[attempt.engine]}</td>
+                        <td>
+                          <span
+                            className={
+                              attempt.status === 'matched'
+                                ? 'text-success'
+                                : attempt.status === 'no-match'
+                                  ? 'text-secondary'
+                                  : 'text-warning'
+                            }
+                          >
+                            {attempt.status}
+                          </span>
+                        </td>
+                        <td>{attempt.httpStatus ?? '—'}</td>
+                        <td className="text-secondary">{attempt.error ?? ''}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </details>
+            ) : null}
+          </div>
+        ) : null}
+
+        {detectedEngine ? (
+          <>
+            {credentialFieldsForSchema(detectedSchema).username ? (
+              <div className="col-md-6">
+                <label className="form-label small mb-1">
+                  {credentialFieldsForSchema(detectedSchema).usernameLabel}
+                </label>
+                <input
+                  type="text"
+                  className="form-control form-control-sm bg-dark text-light border-secondary"
+                  value={addForm.username}
+                  onChange={(e) => setAddForm((prev) => ({ ...prev, username: e.target.value }))}
+                />
+              </div>
+            ) : null}
+            {credentialFieldsForSchema(detectedSchema).apiKey ? (
+              <div className="col-md-6">
+                <label className="form-label small mb-1">
+                  {credentialFieldsForSchema(detectedSchema).apiKeyLabel}
+                </label>
+                <input
+                  type="password"
+                  className="form-control form-control-sm bg-dark text-light border-secondary"
+                  value={addForm.apiKey}
+                  onChange={(e) => setAddForm((prev) => ({ ...prev, apiKey: e.target.value }))}
+                />
+              </div>
+            ) : null}
+
+            <div className="col-12 mt-2">
+              <small className="text-muted d-block mb-1">Capabilities</small>
+              <div className="row g-2">
+                {(Object.keys(CAPABILITY_LABELS) as CapabilityKey[]).map((cap) => (
+                  <div key={cap} className="col-6 col-md-3">
+                    <div className="form-check">
+                      <input
+                        className="form-check-input"
+                        type="checkbox"
+                        id={`new-${cap}`}
+                        checked={addForm.capabilities[cap]}
+                        onChange={() =>
+                          setAddForm((prev) => ({
+                            ...prev,
+                            capabilities: { ...prev.capabilities, [cap]: !prev.capabilities[cap] }
+                          }))
+                        }
+                      />
+                      <label className="form-check-label text-secondary small" htmlFor={`new-${cap}`}>
+                        {CAPABILITY_LABELS[cap]}
+                      </label>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </>
+        ) : null}
+
+        {addForm.detectError ? <div className="col-12 text-danger small">{addForm.detectError}</div> : null}
+
+        <div className="col-12 d-flex gap-2 mt-2">
+          <button type="submit" className="btn btn-sm btn-outline-light" disabled={addingBusy || !detectedEngine}>
+            {addingBusy ? 'Adding…' : 'Add site'}
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm btn-outline-light"
+            onClick={() => setAddForm(initialAddForm())}
+          >
+            Reset
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -155,21 +155,100 @@ export type CredentialSummary = {
   updatedAt: string | null;
 };
 
+// Tag source is an opaque string: it can be a legacy preset key ('E621',
+// 'DANBOORU', 'GELBOORU', 'YANDERE', 'KONACHAN', 'SANKAKU', 'IDOL_COMPLEX'),
+// the special values 'WD14' or 'MANUAL', or a user_booru_sites.id UUID for a
+// fully custom user-added site.
 export type FileTag = {
   tag: string;
   category: string;
-  source:
-    | 'E621'
-    | 'DANBOORU'
-    | 'GELBOORU'
-    | 'YANDERE'
-    | 'KONACHAN'
-    | 'SANKAKU'
-    | 'IDOL_COMPLEX'
-    | 'WD14'
-    | 'MANUAL';
+  source: string;
   score: number | null;
   sourceUrl: string | null;
+};
+
+export type BooruEngineType =
+  | 'danbooru'
+  | 'e621'
+  | 'moebooru'
+  | 'gelbooru'
+  | 'sankaku'
+  | 'philomena'
+  | 'shimmie'
+  | 'szurubooru';
+
+export type BooruCredentialSchema =
+  | 'username+apikey'
+  | 'userid+apikey'
+  | 'apikey-only'
+  | 'token'
+  | 'none';
+
+export type BooruSite = {
+  id: string;
+  name: string;
+  engine: BooruEngineType;
+  baseUrl: string;
+  username: string | null;
+  hasApiKey: boolean;
+  isPreset: boolean;
+  presetKey: string | null;
+  enabled: boolean;
+  capFavorites: boolean;
+  capTags: boolean;
+  capSourceMatch: boolean;
+  capSearch: boolean;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+  engineCredentialSchema: BooruCredentialSchema;
+};
+
+export type BooruDetectionAttemptStatus =
+  | 'matched'
+  | 'no-match'
+  | 'http-error'
+  | 'network-error'
+  | 'timeout';
+
+export type BooruDetectionAttempt = {
+  engine: BooruEngineType;
+  status: BooruDetectionAttemptStatus;
+  httpStatus?: number;
+  error?: string;
+};
+
+export type BooruDetectionSample = {
+  postId: string;
+  thumbUrl: string | null;
+  postUrl: string;
+};
+
+export type BooruDetectionResult =
+  | {
+      engine: BooruEngineType;
+      confidence: 'hostname' | 'probe';
+      credentialSchema: BooruCredentialSchema;
+      defaultCapabilities: { favorites: boolean; tags: boolean; sourceMatch: boolean; search: boolean } | null;
+      sample: BooruDetectionSample | null;
+      attempts: BooruDetectionAttempt[];
+    }
+  | { error: 'unknown'; tried: BooruEngineType[]; attempts: BooruDetectionAttempt[] }
+  | { error: 'unreachable'; message: string; attempts: BooruDetectionAttempt[] };
+
+export type BooruEngineCatalog = {
+  engines: Array<{
+    type: BooruEngineType;
+    credentialSchema: BooruCredentialSchema;
+    defaultCapabilities: { favorites: boolean; tags: boolean; sourceMatch: boolean; search: boolean };
+  }>;
+  presets: Array<{
+    key: string;
+    name: string;
+    engine: BooruEngineType;
+    baseUrl: string;
+    defaultCapabilities: { favorites: boolean; tags: boolean; sourceMatch: boolean; search: boolean };
+  }>;
 };
 
 type FoldersResponse = { folders: Folder[] };
@@ -570,5 +649,82 @@ export const api = {
       body: JSON.stringify(settings)
     });
     return handle<DuplicateSettingsResponse>(res);
+  },
+  getBooruSites: async () => {
+    const res = await apiFetch(`${API_BASE}/booru-sites`);
+    const data = await handle<{ sites: BooruSite[] }>(res);
+    return data.sites;
+  },
+  getBooruEngineCatalog: async () => {
+    const res = await apiFetch(`${API_BASE}/booru-sites/engines`);
+    return handle<BooruEngineCatalog>(res);
+  },
+  detectBooruEngine: async (baseUrl: string) => {
+    const res = await apiFetch(`${API_BASE}/booru-sites/detect`, {
+      method: 'POST',
+      headers: jsonHeaders,
+      body: JSON.stringify({ baseUrl })
+    });
+    if (res.status === 422 || res.status === 502) {
+      return (await res.json()) as BooruDetectionResult;
+    }
+    return handle<BooruDetectionResult>(res);
+  },
+  createBooruSite: async (payload: {
+    name: string;
+    engine: BooruEngineType;
+    baseUrl: string;
+    username?: string | null;
+    apiKey?: string | null;
+    capFavorites?: boolean;
+    capTags?: boolean;
+    capSourceMatch?: boolean;
+    capSearch?: boolean;
+    enabled?: boolean;
+  }) => {
+    const res = await apiFetch(`${API_BASE}/booru-sites`, {
+      method: 'POST',
+      headers: jsonHeaders,
+      body: JSON.stringify(payload)
+    });
+    const data = await handle<{ site: BooruSite }>(res);
+    return data.site;
+  },
+  updateBooruSite: async (id: string, payload: Partial<{
+    name: string;
+    username: string | null;
+    apiKey: string | null;
+    enabled: boolean;
+    capFavorites: boolean;
+    capTags: boolean;
+    capSourceMatch: boolean;
+    capSearch: boolean;
+    engine: BooruEngineType;
+    baseUrl: string;
+  }>) => {
+    const res = await apiFetch(`${API_BASE}/booru-sites/${id}`, {
+      method: 'PUT',
+      headers: jsonHeaders,
+      body: JSON.stringify(payload)
+    });
+    const data = await handle<{ site: BooruSite }>(res);
+    return data.site;
+  },
+  deleteBooruSite: async (id: string) => {
+    const res = await apiFetch(`${API_BASE}/booru-sites/${id}`, { method: 'DELETE' });
+    return handle<{ ok: boolean }>(res);
+  },
+  testBooruSite: async (id: string) => {
+    const res = await apiFetch(`${API_BASE}/booru-sites/${id}/test`, { method: 'POST' });
+    return handle<{ ok: boolean; status?: number; error?: string }>(res);
+  },
+  reorderBooruSites: async (orderedIds: string[]) => {
+    const res = await apiFetch(`${API_BASE}/booru-sites/reorder`, {
+      method: 'POST',
+      headers: jsonHeaders,
+      body: JSON.stringify({ orderedIds })
+    });
+    const data = await handle<{ sites: BooruSite[] }>(res);
+    return data.sites;
   }
 };


### PR DESCRIPTION
## Summary

Closes #104. Replaces the hardcoded E621/DANBOORU credentials path with a per-user, engine-driven list of booru sites. Adding a site to your account is enough to wire up tag fetch, favorites sync and source-URL match — no code change per site.

## What changed

**Engine abstraction** (`backend/src/lib/booruEngines/`)
- 8 engine modules: `danbooru`, `e621`, `moebooru`, `gelbooru`, `sankaku`, `philomena`, `shimmie`, `szurubooru`.
- Common contract: tag fetch, favorites sync/unfav, source-URL match, `probe`/`probeSample`.
- `services/tagging.ts` and `services/favorites.ts` now dispatch through the registry instead of bespoke per-site functions.

**Data model** (`backend/src/lib/dataStore.ts`)
- New `user_booru_sites` table + CRUD.
- Idempotent boot-time seed (`booruSitesSeed.ts`) migrates existing `provider_credentials` (E621/DANBOORU) into preset rows — current users keep working with zero action.
- `deleteBooruSite` cascade-purges a custom site's `favorite_items` in the same transaction (no FK, so manual cleanup prevents orphaned rows).
- `FavoriteProvider`/`TagSource` widen to opaque strings: legacy preset keys still match historical rows; custom sites use the site UUID.

**API** (`backend/src/routes/booruSites.ts`)
- `/booru-sites` CRUD + `/detect` (hostname lookup + parallel JSON/XML probe race, returns a sample thumbnail and per-engine attempts log) + `/:id/test`.
- `/credentials` kept as a back-compat shim for E621/DANBOORU/SAUCENAO.

**Frontend** (`BooruSitesPanel.tsx`, `App.tsx`, `api.ts`)
- Settings panel: list/reorder/enable sites, add a custom site by name + URL with auto-detected engine + credential fields, test connection.
- Page-bottom "Developer options" toggle reveals the probe attempts table.

## Reviewer notes

- Search/browse was intentionally **descoped** to a follow-up issue (#107) — `cap_search` column retained as future-proofing, no UI.
- Detection is advisory: on failure it shows an honest "could not identify" message (unsupported / login / CAPTCHA wall), no dead-end manual picker.
- Two-pass internal review (Opus): a critical orphaned-favorites bug on site delete was found and fixed before this PR.

## Test plan

- [x] Backend unit suite green (164 tests): engine probe/extract, detection (MockAgent: probe-shape, unknown, unreachable, hostname), seed migration idempotency, delete cascade + cross-user isolation, URL matcher matrix.
- [x] `npm run build` (backend) + `tsc --noEmit` + `vite build` (frontend) all clean.
- [ ] Manual: add a custom Shimmie2 site (e.g. a public board), confirm auto-detect + sample thumbnail, save token, sync.
- [ ] Manual: existing E621 user — confirm preset row auto-seeded on boot, favorites sync still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)