### PR TITLE
ci: switch CodeQL from default to advanced setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # No paths-ignore: every PR must post the status so branch protection
+    # required checks ("Analyze (javascript-typescript)", "Analyze (python)")
+    # never stay stuck in "Expected — Waiting for status to be reported".
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, actions, python]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- Replaces CodeQL **Default Setup** with an advanced workflow (\`.github/workflows/codeql.yml\`) so the required checks \`Analyze (javascript-typescript)\` and \`Analyze (python)\` are always posted on every PR.

## Why

GitHub's CodeQL Default Setup auto-skips analysis on PRs that touch only workflow YAML or markdown. Branch protection on \`main\` requires those Analyze checks → check stays pending → PR unmergeable. Advanced workflow runs unconditionally, status always posted.

Matrix \`[javascript-typescript, actions, python]\` covers the same surface as prior Default Setup (\`actions, javascript, javascript-typescript, python, typescript\`); \`javascript\` and \`typescript\` are deprecated aliases that resolve to \`javascript-typescript\`.

## Operational prerequisite

Disable Default Setup before merge (otherwise both setups race on the same category and analyze jobs fail):

\`\`\`
gh api -X PATCH repos/LiukScot/gooncave/code-scanning/default-setup -f state=not-configured
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)