### PR TITLE
fix: disable worker healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,11 +62,7 @@ services:
       - ./backend/storage:/app/storage
       - gooncave-library-data:/gooncave-library
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://localhost:4100/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
+      disable: true
 
   tagger:
     build:


### PR DESCRIPTION
## Summary
- Worker (`node dist/worker.js`) does not start an HTTP server
- Previous healthcheck probed `http://localhost:4100/health`, which can never succeed
- Container was permanently unhealthy (failing streak 1900+); disabling the check resolves it without restart-loop side effects

## Test plan
- [x] `docker compose up -d worker` — container `Up`, no health label
- [x] `docker ps --filter health=unhealthy` returns no rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)