### PR TITLE
feat(frontend): Tailwind 4 + shadcn/ui replace Bootstrap (#103 point 1/6)

### DIFF
--- a/frontend/components.json
+++ b/frontend/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/index.css",
+    "baseColor": "zinc",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,11 +8,21 @@
       "name": "imagesearch-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "bootstrap": "^5.3.8",
+        "@tailwindcss/vite": "^4.3.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^1.16.0",
+        "next-themes": "^0.4.6",
+        "radix-ui": "^1.4.3",
         "react": "^19.2.0",
-        "react-dom": "^19.2.6"
+        "react-dom": "^19.2.6",
+        "sonner": "^2.0.7",
+        "tailwind-merge": "^3.6.0",
+        "tailwindcss": "^4.3.0",
+        "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
+        "@types/node": "^25.9.1",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
@@ -26,7 +36,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -38,7 +47,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -49,25 +57,99 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -86,22 +168,1508 @@
       "version": "0.132.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
       "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-accessible-icon": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz",
+      "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
       "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
+      "dependencies": {
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
+      "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
+      "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
+      "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
+      "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-one-time-password-field": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
+      "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-password-toggle-field": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
+      "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
+      "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-toggle-group": "1.1.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.2",
@@ -110,7 +1678,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -127,7 +1694,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -144,7 +1710,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -161,7 +1726,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -178,7 +1742,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -195,7 +1758,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -212,7 +1774,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -229,7 +1790,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -246,7 +1806,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -263,7 +1822,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -280,7 +1838,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -297,7 +1854,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -314,7 +1870,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -333,7 +1888,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -350,7 +1904,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -364,7 +1917,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -374,11 +1926,267 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
+      "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "tailwindcss": "4.3.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -411,20 +2219,20 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
-      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
-      "dev": true,
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/react": {
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -434,7 +2242,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -596,6 +2404,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -606,25 +2426,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/bootstrap": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
-      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/twbs"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/bootstrap"
-        }
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "@popperjs/core": "^2.11.8"
-      }
-    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -633,6 +2434,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/convert-source-map": {
@@ -646,17 +2468,35 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.0.tgz",
+      "integrity": "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/entities": {
@@ -703,7 +2543,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -721,7 +2560,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -731,6 +2569,21 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/happy-dom": {
       "version": "20.9.0",
@@ -750,11 +2603,19 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -787,7 +2648,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -808,7 +2668,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -829,7 +2688,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -850,7 +2708,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -871,7 +2728,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -892,7 +2748,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -913,7 +2768,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -934,7 +2788,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -955,7 +2808,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -976,7 +2828,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -997,7 +2848,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1011,11 +2861,19 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -1025,7 +2883,6 @@
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1038,6 +2895,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/obug": {
@@ -1062,14 +2929,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1082,7 +2947,6 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -1107,6 +2971,83 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/radix-ui": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
+      "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-accessible-icon": "1.1.7",
+        "@radix-ui/react-accordion": "1.2.12",
+        "@radix-ui/react-alert-dialog": "1.1.15",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-aspect-ratio": "1.1.7",
+        "@radix-ui/react-avatar": "1.1.10",
+        "@radix-ui/react-checkbox": "1.3.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-context-menu": "2.2.16",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-dropdown-menu": "2.1.16",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-form": "0.1.8",
+        "@radix-ui/react-hover-card": "1.1.15",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-menubar": "1.1.16",
+        "@radix-ui/react-navigation-menu": "1.2.14",
+        "@radix-ui/react-one-time-password-field": "0.1.8",
+        "@radix-ui/react-password-toggle-field": "0.1.3",
+        "@radix-ui/react-popover": "1.1.15",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-progress": "1.1.7",
+        "@radix-ui/react-radio-group": "1.3.8",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-scroll-area": "1.2.10",
+        "@radix-ui/react-select": "2.2.6",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-slider": "1.3.6",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-switch": "1.2.6",
+        "@radix-ui/react-tabs": "1.1.13",
+        "@radix-ui/react-toast": "1.2.15",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-toggle-group": "1.1.11",
+        "@radix-ui/react-toolbar": "1.1.11",
+        "@radix-ui/react-tooltip": "1.2.8",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
@@ -1128,11 +3069,79 @@
         "react": "^19.2.6"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
       "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.132.0",
@@ -1175,11 +3184,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -1198,6 +3216,35 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1220,7 +3267,6 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -1247,9 +3293,16 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
+      }
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -1266,17 +3319,68 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.14",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,11 +11,21 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "bootstrap": "^5.3.8",
+    "@tailwindcss/vite": "^4.3.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.16.0",
+    "next-themes": "^0.4.6",
+    "radix-ui": "^1.4.3",
     "react": "^19.2.0",
-    "react-dom": "^19.2.6"
+    "react-dom": "^19.2.6",
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^3.6.0",
+    "tailwindcss": "^4.3.0",
+    "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@types/node": "^25.9.1",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,13 +19,6 @@ import {
 } from './api';
 import type { CredentialProvider, CredentialSummary, DuplicateScanStatus, FavoriteSyncStatus, ProviderRun } from './api';
 import { BooruSitesPanel } from './BooruSitesPanel';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Card, CardContent } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Separator } from '@/components/ui/separator';
-import { cn } from '@/lib/utils';
 
 type FetchState = {
   loading: boolean;
@@ -270,7 +263,7 @@ const statusBadge = (status: string) => {
     case 'SCANNING':
       return 'bg-warning text-dark';
     case 'FAILED':
-      return 'bg-destructive';
+      return 'bg-danger';
     default:
       return 'bg-secondary';
   }
@@ -279,7 +272,7 @@ const statusBadge = (status: string) => {
 const folderUploadBarClass = (phase: FolderUploadPhase) => {
   switch (phase) {
     case 'uploading':
-      return 'bg-primary';
+      return 'bg-info';
     case 'processing':
       return 'bg-warning text-dark progress-bar-striped progress-bar-animated';
     case 'success':
@@ -287,7 +280,7 @@ const folderUploadBarClass = (phase: FolderUploadPhase) => {
     case 'warning':
       return 'bg-warning text-dark';
     case 'error':
-      return 'bg-destructive';
+      return 'bg-danger';
     default:
       return 'bg-secondary';
   }
@@ -1924,29 +1917,29 @@ function App() {
   };
 
   const renderDuplicateCard = (file: DuplicateFile, suggested: boolean, reason: string) => (
-    <div className={cn('duplicate-card', suggested && 'is-suggested')}>
+    <div className={`duplicate-card${suggested ? ' is-suggested' : ''}`}>
       <div className="duplicate-thumb">
         {file.thumbUrl ? (
           <img src={`${API_BASE}${file.thumbUrl}`} alt={file.path} loading="lazy" decoding="async" />
         ) : (
-          <div className="text-muted-foreground-foreground text-sm">{file.mediaType.toLowerCase()}</div>
+          <div className="text-muted-foreground text-sm">{file.mediaType.toLowerCase()}</div>
         )}
       </div>
       <div className="flex justify-between items-center">
         <div className="font-semibold truncate">{basenameFromPath(file.path)}</div>
-        {suggested ? <Badge className="bg-success text-success-foreground duplicate-suggested-badge">Suggested</Badge> : null}
+        {suggested ? <span className="badge bg-success duplicate-suggested-badge">Suggested</span> : null}
       </div>
-      <div className="text-muted-foreground-foreground text-sm">
+      <div className="text-muted-foreground text-sm">
         {fileTypeFromPath(file.path, file.mediaType)} · {formatSizeMb(file.sizeBytes)}
         {file.width && file.height ? ` · ${file.width}×${file.height}` : ''}
       </div>
       {file.favoriteProviders?.length ? (
-        <div className="text-muted-foreground-foreground text-sm">
+        <div className="text-muted-foreground text-sm">
           favorites: {file.favoriteProviders.map((provider) => provider.toLowerCase()).join(', ')}
         </div>
       ) : null}
       {suggested ? <div className="text-success text-sm duplicate-suggested-reason">{reason}</div> : null}
-      <div className="text-muted-foreground-foreground text-sm duplicate-path">{file.path}</div>
+      <div className="text-muted-foreground text-sm duplicate-path">{file.path}</div>
     </div>
   );
 
@@ -2493,7 +2486,7 @@ function App() {
             </button>
           </div>
           <div className="container file-detail-body file-detail-preview-body">
-            <div className="file-detail-section mb-6">
+            <div className="file-detail-section mb-4">
               <div className="file-detail-section-head">
                 <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
                   File info
@@ -2565,7 +2558,7 @@ function App() {
               </div>
             </div>
             <div className="file-detail-section-divider" />
-            <div className="file-detail-section mb-6">
+            <div className="file-detail-section mb-4">
               <div className="file-detail-section-head">
                 <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
                   Tags
@@ -2594,7 +2587,7 @@ function App() {
               </div>
             </div>
             <div className="file-detail-section-divider" />
-            <div className="file-detail-section mb-6">
+            <div className="file-detail-section mb-4">
               <div className="file-detail-section-head">
                 <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
                   Sauces
@@ -2636,10 +2629,10 @@ function App() {
 
   if (!authUser) {
     return (
-      <div className="bg-background text-foreground min-h-screen flex items-center justify-center px-6">
+      <div className="bg-background text-foreground min-h-screen flex items-center justify-center px-4">
         <div className="card bg-black text-foreground border-secondary" style={{ width: '100%', maxWidth: 420 }}>
           <div className="card-body p-6">
-            <div className="flex justify-between items-start mb-6">
+            <div className="flex justify-between items-start mb-4">
               <div>
                 <h1 className="h3 mb-1">GoonCave</h1>
                 <div className="text-muted-foreground text-sm">Local-network sign-in</div>
@@ -2673,7 +2666,7 @@ function App() {
                 void submitAuth();
               }}
             >
-              <div className="mb-6">
+              <div className="mb-4">
                 <label className="form-label">Username</label>
                 <input
                   className="form-control bg-background text-foreground border-secondary"
@@ -2682,7 +2675,7 @@ function App() {
                   autoComplete="username"
                 />
               </div>
-              <div className="mb-6">
+              <div className="mb-4">
                 <label className="form-label">Password</label>
                 <input
                   className="form-control bg-background text-foreground border-secondary"
@@ -2693,7 +2686,7 @@ function App() {
                 />
               </div>
               {authMode === 'register' ? (
-                <div className="mb-6">
+                <div className="mb-4">
                   <label className="form-label">Confirm password</label>
                   <input
                     className="form-control bg-background text-foreground border-secondary"
@@ -2719,7 +2712,7 @@ function App() {
     <div className="bg-background text-foreground min-h-screen">
       {selectedFile ? null : (
       <div className="container page-shell">
-        <div className="flex justify-between items-center mb-6">
+        <div className="flex justify-between items-center mb-4">
           <div>
             <h1 className="h3 mb-1">GoonCave</h1>
             <div className="text-muted-foreground text-sm">Signed in as {authUser.username}</div>
@@ -2751,16 +2744,16 @@ function App() {
           </button>
         </div>
 
-        {fetchState.error ? <div className="text-destructive mb-6">Error: {fetchState.error}</div> : null}
-        {manualOrderState.error ? <div className="text-destructive mb-6">Manual order: {manualOrderState.error}</div> : null}
-        {manualOrderState.loading ? <div className="text-muted-foreground text-sm mb-6">Saving manual order…</div> : null}
+        {fetchState.error ? <div className="text-destructive mb-4">Error: {fetchState.error}</div> : null}
+        {manualOrderState.error ? <div className="text-destructive mb-4">Manual order: {manualOrderState.error}</div> : null}
+        {manualOrderState.loading ? <div className="text-muted-foreground text-sm mb-4">Saving manual order…</div> : null}
         <div className={`row ${viewMode === 'folders' ? 'g-0 settings-sections' : 'g-4'}`}>
           {viewMode === 'folders' ? (
             <>
               <div className="col-12 settings-section">
                 <div className="card bg-transparent text-foreground border-0 h-full settings-section-card">
                   <div className="card-body">
-                    <div className="flex justify-between items-center mb-6">
+                    <div className="flex justify-between items-center mb-4">
                       <h2 className="h5 mb-0">Library folders</h2>
                     </div>
                     <input
@@ -2771,12 +2764,12 @@ function App() {
                       accept={uploadInputAccept}
                       onChange={onFolderUploadInputChange}
                     />
-                    <div className="text-muted-foreground text-sm mb-6">
+                    <div className="text-muted-foreground text-sm mb-4">
                       Your main library appears below automatically. Mounted folders also appear automatically when they
                       are direct children of your library root. Check the README for setup instructions.
                     </div>
                     {folderActionState.error ? (
-                      <div className="text-destructive text-sm mb-6">Folder error: {folderActionState.error}</div>
+                      <div className="text-destructive text-sm mb-4">Folder error: {folderActionState.error}</div>
                     ) : null}
                     {orderedFolders.length === 0 ? (
                       <p className="text-muted-foreground">No folders configured.</p>
@@ -2834,7 +2827,7 @@ function App() {
                                   </div>
                                 </div>
                                 {uploadState ? (
-                                  <div className="folder-upload-state mt-6">
+                                  <div className="folder-upload-state mt-4">
                                     <div className="progress folder-upload-progress" role="progressbar" aria-valuenow={uploadState.progress} aria-valuemin={0} aria-valuemax={100}>
                                       <div
                                         className={`progress-bar ${folderUploadBarClass(uploadState.phase)}`}
@@ -2864,7 +2857,7 @@ function App() {
                     <div className="flex justify-between items-center mb-2">
                       <h2 className="h5 mb-0">Sync favorites</h2>
                     </div>
-                    <p className="text-muted-foreground text-sm mb-6">
+                    <p className="text-muted-foreground text-sm mb-4">
                       Connect your e621 and Danbooru accounts to double-sync favorites.
                     </p>
 
@@ -2905,7 +2898,7 @@ function App() {
                         When you delete a file here, also remove it from favorites
                       </label>
                     </div>
-                    <div className="form-check form-switch mb-6">
+                    <div className="form-check form-switch mb-4">
                       <input
                         className="form-check-input"
                         type="checkbox"
@@ -2919,9 +2912,9 @@ function App() {
                       </label>
                     </div>
 
-                    <details className="mb-6">
+                    <details className="mb-4">
                       <summary className="text-muted-foreground text-sm">Legacy credential cards (E621 / Danbooru)</summary>
-                    <div className="credential-grid mb-6">
+                    <div className="credential-grid mb-4">
                       <div className="credential-col">
                         <div className="border border-secondary rounded p-2 credential-card">
                           <div className="flex justify-between items-center gap-2">
@@ -3082,7 +3075,7 @@ function App() {
                     {favoritesSyncStatus?.status === 'running' && favoritesProgress !== null ? (
                       <div className="progress bg-background border border-secondary mt-2" style={{ height: 8 }}>
                         <div
-                          className="progress-bar bg-primary"
+                          className="progress-bar bg-info"
                           role="progressbar"
                           style={{ width: `${favoritesProgress}%` }}
                           aria-valuenow={favoritesProgress}
@@ -3127,11 +3120,11 @@ function App() {
                     <div className="flex justify-between items-center mb-2">
                       <h2 className="h5 mb-0">Sauces</h2>
                     </div>
-                    <p className="text-muted-foreground text-sm mb-6">
+                    <p className="text-muted-foreground text-sm mb-4">
                       Pick which sources appear in the file view and which ones the scanner should look for
                       automatically. Targeted sources are retried daily for up to a week or until a match is found.
                     </p>
-                    <div className="credential-grid mb-6">
+                    <div className="credential-grid mb-4">
                       <div className="credential-col">
                         <div className="border border-secondary rounded p-2 credential-card">
                           <div className="flex justify-between items-center gap-2">
@@ -3214,14 +3207,14 @@ function App() {
                     {credentialsState.error && credentialLastProvider === 'SAUCENAO' ? (
                       <div className="text-destructive text-sm mb-2">Credentials error: {credentialsState.error}</div>
                     ) : null}
-                    <div className="sauce-progress-wrap mb-6">
+                    <div className="sauce-progress-wrap mb-4">
                       <div className="sauce-progress-bar border border-secondary bg-background" role="img" aria-label="Sauce target scan progress">
                         <div
                           className="sauce-progress-segment bg-success"
                           style={{ width: `${sauceProgressSegments.matched}%` }}
                         />
                         <div
-                          className="sauce-progress-segment bg-destructive"
+                          className="sauce-progress-segment bg-danger"
                           style={{ width: `${sauceProgressSegments.failed}%` }}
                         />
                         <div
@@ -3235,7 +3228,7 @@ function App() {
                           Target found ({sauceProgress.matched})
                         </span>
                         <span className="sauce-progress-legend-item">
-                          <span className="sauce-progress-dot bg-destructive" />
+                          <span className="sauce-progress-dot bg-danger" />
                           Failed ({sauceProgress.failed})
                         </span>
                         <span className="sauce-progress-legend-item">
@@ -3250,7 +3243,7 @@ function App() {
                       <p className="text-muted-foreground">No sources discovered yet.</p>
                     ) : (
                       <>
-                        <div className="flex flex-wrap gap-2 mb-6">
+                        <div className="flex flex-wrap gap-2 mb-4">
                           <button className="btn btn-outline-light btn-sm" onClick={() => setAllDisplay(true)}>
                             Show all
                           </button>
@@ -3313,7 +3306,7 @@ function App() {
               <div className="col-12 settings-section">
                 <div className="card bg-transparent text-foreground border-0 h-full settings-section-card">
                   <div className="card-body">
-                    <hr className="border-secondary mt-0 mb-6" />
+                    <hr className="border-secondary mt-0 mb-4" />
                     <div className="form-check form-switch">
                       <input
                         className="form-check-input"
@@ -3337,15 +3330,15 @@ function App() {
             <div className="col-12">
               <div className="card bg-transparent text-foreground border-0 h-full content-shell-card">
                 <div className="card-body">
-                  <div className="flex justify-between items-center mb-6">
+                  <div className="flex justify-between items-center mb-4">
                     {duplicateStats ? (
                       <span className="text-muted-foreground text-sm">{duplicateGroups.length} groups</span>
                     ) : null}
                   </div>
-                  <p className="text-muted-foreground text-sm mb-6">
+                  <p className="text-muted-foreground text-sm mb-4">
                     Groups files by media type and dimensions, then compares downscaled pixels (videos use sampled frames).
                   </p>
-                  <div className="form-check form-switch mb-6">
+                  <div className="form-check form-switch mb-4">
                     <input
                       className="form-check-input"
                       type="checkbox"
@@ -3361,7 +3354,7 @@ function App() {
                   {duplicateSettingsState.error ? (
                     <div className="text-destructive mb-2">Settings error: {duplicateSettingsState.error}</div>
                   ) : null}
-                  <div className="flex flex-wrap gap-6 items-end mb-6">
+                  <div className="flex flex-wrap gap-4 items-end mb-4">
                     <div>
                       <div className="text-muted-foreground text-sm mb-1">Media</div>
                       <select
@@ -3387,9 +3380,9 @@ function App() {
                       {duplicateState.loading ? 'Scanning…' : 'Run scan'}
                     </button>
                   </div>
-                  <details className="mb-6">
+                  <details className="mb-4">
                     <summary className="text-muted-foreground text-sm">Advanced</summary>
-                    <div className="flex flex-wrap gap-6 items-end mt-2">
+                    <div className="flex flex-wrap gap-4 items-end mt-2">
                       <div>
                         <label className="text-muted-foreground text-sm mb-1 block" htmlFor="duplicate-pixel-threshold">
                           Pixel threshold
@@ -3490,7 +3483,7 @@ function App() {
                   </details>
                   {duplicateState.error ? <div className="text-destructive mb-2">Error: {duplicateState.error}</div> : null}
                   {duplicateState.loading && duplicateScanStatus?.progress ? (
-                    <div className="mb-6">
+                    <div className="mb-4">
                       <div className="flex justify-between text-muted-foreground text-sm mb-1">
                         <span>{duplicateScanStatus.progress.message}</span>
                         <span>
@@ -3531,7 +3524,7 @@ function App() {
                     <div className="text-destructive mb-2">Delete error: {duplicateAction.error}</div>
                   ) : null}
                   {duplicateStats ? (
-                    <div className="text-muted-foreground text-sm mb-6">
+                    <div className="text-muted-foreground text-sm mb-4">
                       Eligible: {duplicateStats.eligibleFiles}/{duplicateStats.totalFiles} · Compared:{' '}
                       {duplicateStats.comparedFiles} · Comparisons: {duplicateStats.comparisons} · Skipped:{' '}
                       {duplicateStats.skippedNoSignature}
@@ -3553,7 +3546,7 @@ function App() {
                       const actionBusy =
                         duplicateAction.loadingId === pair.left.id || duplicateAction.loadingId === pair.right.id;
                       return (
-                        <div key={pair.key} className="duplicate-pair border border-secondary rounded p-6 mb-6">
+                        <div key={pair.key} className="duplicate-pair border border-secondary rounded p-4 mb-4">
                           <div className="flex justify-between items-center mb-2">
                             <div className="text-muted-foreground text-sm">Pair {index + 1}</div>
                             <div className="text-muted-foreground text-sm">
@@ -3566,7 +3559,7 @@ function App() {
                               {renderDuplicateCard(pair.right, rightSuggested, pair.reason)}
                             </div>
                           </div>
-                          <div className="flex flex-wrap gap-2 mt-6">
+                          <div className="flex flex-wrap gap-2 mt-4">
                             <button
                               className="btn btn-success btn-sm"
                               onClick={() => void resolveDuplicateChoice(pair.left, pair.right)}
@@ -3682,7 +3675,7 @@ function App() {
                         >
                           {galleryFilterLabel}
                         </button>
-                        <div className={`dropdown-menu dropdown-menu-dark p-6${isGalleryFilterOpen ? ' show' : ''}`}>
+                        <div className={`dropdown-menu dropdown-menu-dark p-4${isGalleryFilterOpen ? ' show' : ''}`}>
                           <div className="form-check mb-2">
                             <input
                               className="form-check-input"
@@ -3733,7 +3726,7 @@ function App() {
                       <span className="text-muted-foreground text-sm">{galleryCountText} items</span>
                     </div>
                   </div>
-                  <hr className="border-secondary my-6" />
+                  <hr className="border-secondary my-4" />
                   {galleryPageState.error ? (
                     <div className="text-destructive text-sm mb-2">Gallery: {galleryPageState.error}</div>
                   ) : null}
@@ -3827,7 +3820,7 @@ function App() {
                         })}
                       </div>
                       {galleryHasMore ? (
-                        <div className="flex justify-center mt-6">
+                        <div className="flex justify-center mt-4">
                           <button
                             className="btn btn-outline-light btn-sm"
                             onClick={() => void loadGalleryPage()}
@@ -3938,7 +3931,7 @@ function App() {
                 </button>
               </div>
               <div className="container file-detail-body">
-            <div className="file-detail-section mb-6">
+            <div className="file-detail-section mb-4">
               <div className="file-detail-section-head">
                 <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
                   File info
@@ -4043,7 +4036,7 @@ function App() {
               </div>
             </div>
             <div className="file-detail-section-divider" />
-            <div className="file-detail-tags file-detail-section mb-6">
+            <div className="file-detail-tags file-detail-section mb-4">
               <div className="flex justify-between items-center mb-2">
                 <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
                   Tags
@@ -4149,7 +4142,7 @@ function App() {
               </div>
             </div>
             <div className="file-detail-section-divider" />
-            <div className="file-detail-section mb-6">
+            <div className="file-detail-section mb-4">
               <div className="file-detail-section-head">
                 <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
                   Sauces
@@ -4176,7 +4169,7 @@ function App() {
                   <span className="file-detail-button-text">Scan</span>
                 </button>
               </div>
-              <div className="text-muted-foreground text-sm mb-6">
+              <div className="text-muted-foreground text-sm mb-4">
                 <div>
                   <span className="font-semibold file-detail-label">Provider scans:</span>{' '}
                   {providerMeta?.hasRuns ? `last run ${formatDateTime(providerMeta.latestRunAt)}` : 'never run yet'}
@@ -4195,7 +4188,7 @@ function App() {
             {providerState.error ? <div className="text-destructive text-sm mb-2">{providerState.error}</div> : null}
             {favoriteState.error ? <div className="text-destructive text-sm mb-2">{favoriteState.error}</div> : null}
             {deleteState.error ? <div className="text-destructive text-sm mb-2">{deleteState.error}</div> : null}
-            <div className="file-detail-topmatches mb-6">
+            <div className="file-detail-topmatches mb-4">
               {matchRemoveState.error ? (
                 <div className="text-destructive text-sm mb-2">{matchRemoveState.error}</div>
               ) : null}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2667,8 +2667,11 @@ function App() {
               }}
             >
               <div className="mb-4">
-                <label className="form-label">Username</label>
+                <label className="form-label" htmlFor="auth-username">Username</label>
                 <input
+                  id="auth-username"
+                  name="username"
+                  type="text"
                   className="form-control bg-background text-foreground border-secondary"
                   value={authForm.username}
                   onChange={(event) => setAuthForm((prev) => ({ ...prev, username: event.target.value }))}
@@ -2676,8 +2679,10 @@ function App() {
                 />
               </div>
               <div className="mb-4">
-                <label className="form-label">Password</label>
+                <label className="form-label" htmlFor="auth-password">Password</label>
                 <input
+                  id="auth-password"
+                  name="password"
                   className="form-control bg-background text-foreground border-secondary"
                   type="password"
                   value={authForm.password}
@@ -2687,8 +2692,10 @@ function App() {
               </div>
               {authMode === 'register' ? (
                 <div className="mb-4">
-                  <label className="form-label">Confirm password</label>
+                  <label className="form-label" htmlFor="auth-confirm-password">Confirm password</label>
                   <input
+                    id="auth-confirm-password"
+                    name="confirm-password"
                     className="form-control bg-background text-foreground border-secondary"
                     type="password"
                     value={authForm.confirmPassword}
@@ -2951,22 +2958,29 @@ function App() {
                           </div>
                           {!e621Ready && credentialExpanded.E621 ? (
                             <div className="mt-2 credential-fields" id="credential-e621">
-                              <label className="form-label text-sm text-muted-foreground">Username</label>
+                              <label className="form-label text-sm text-muted-foreground" htmlFor="cred-e621-username">Username</label>
                               <input
+                                id="cred-e621-username"
+                                name="e621-username"
+                                type="text"
                                 className="form-control form-control-sm mb-2"
                                 value={credentialInputs.E621.username}
                                 onChange={(event) => updateCredentialInput('E621', 'username', event.target.value)}
                                 placeholder="Enter your e621 username"
                                 disabled={credentialsState.loading}
+                                autoComplete="username"
                               />
-                              <label className="form-label text-sm text-muted-foreground">API key</label>
+                              <label className="form-label text-sm text-muted-foreground" htmlFor="cred-e621-apikey">API key</label>
                               <input
+                                id="cred-e621-apikey"
+                                name="e621-api-key"
                                 type="password"
                                 className="form-control form-control-sm"
                                 value={credentialInputs.E621.apiKey}
                                 onChange={(event) => updateCredentialInput('E621', 'apiKey', event.target.value)}
                                 placeholder="Enter API key"
                                 disabled={credentialsState.loading}
+                                autoComplete="off"
                               />
                               <div className="flex items-center gap-2 mt-2">
                                 <button
@@ -3017,22 +3031,29 @@ function App() {
                           </div>
                           {!danbooruReady && credentialExpanded.DANBOORU ? (
                             <div className="mt-2 credential-fields" id="credential-danbooru">
-                              <label className="form-label text-sm text-muted-foreground">Username</label>
+                              <label className="form-label text-sm text-muted-foreground" htmlFor="cred-danbooru-username">Username</label>
                               <input
+                                id="cred-danbooru-username"
+                                name="danbooru-username"
+                                type="text"
                                 className="form-control form-control-sm mb-2"
                                 value={credentialInputs.DANBOORU.username}
                                 onChange={(event) => updateCredentialInput('DANBOORU', 'username', event.target.value)}
                                 placeholder="Enter your Danbooru username"
                                 disabled={credentialsState.loading}
+                                autoComplete="username"
                               />
-                              <label className="form-label text-sm text-muted-foreground">API key</label>
+                              <label className="form-label text-sm text-muted-foreground" htmlFor="cred-danbooru-apikey">API key</label>
                               <input
+                                id="cred-danbooru-apikey"
+                                name="danbooru-api-key"
                                 type="password"
                                 className="form-control form-control-sm"
                                 value={credentialInputs.DANBOORU.apiKey}
                                 onChange={(event) => updateCredentialInput('DANBOORU', 'apiKey', event.target.value)}
                                 placeholder="Enter API key"
                                 disabled={credentialsState.loading}
+                                autoComplete="off"
                               />
                               <div className="flex items-center gap-2 mt-2">
                                 <button
@@ -3161,15 +3182,20 @@ function App() {
                           </div>
                           {!saucenaoReady && credentialExpanded.SAUCENAO ? (
                             <div className="mt-2 credential-fields" id="credential-saucenao">
-                              <label className="form-label text-sm text-muted-foreground">Username</label>
+                              <label className="form-label text-sm text-muted-foreground" htmlFor="cred-saucenao-username">Username</label>
                               <input
+                                id="cred-saucenao-username"
+                                name="saucenao-username"
+                                type="text"
                                 className="form-control form-control-sm mb-2"
                                 value=""
                                 placeholder="Not used for SauceNAO"
                                 disabled
                               />
-                              <label className="form-label text-sm text-muted-foreground">API key</label>
+                              <label className="form-label text-sm text-muted-foreground" htmlFor="cred-saucenao-apikey">API key</label>
                               <input
+                                id="cred-saucenao-apikey"
+                                name="saucenao-api-key"
                                 type="password"
                                 className="form-control form-control-sm"
                                 value={credentialInputs.SAUCENAO.apiKey}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,13 @@ import {
 } from './api';
 import type { CredentialProvider, CredentialSummary, DuplicateScanStatus, FavoriteSyncStatus, ProviderRun } from './api';
 import { BooruSitesPanel } from './BooruSitesPanel';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
 
 type FetchState = {
   loading: boolean;
@@ -263,7 +270,7 @@ const statusBadge = (status: string) => {
     case 'SCANNING':
       return 'bg-warning text-dark';
     case 'FAILED':
-      return 'bg-danger';
+      return 'bg-destructive';
     default:
       return 'bg-secondary';
   }
@@ -272,7 +279,7 @@ const statusBadge = (status: string) => {
 const folderUploadBarClass = (phase: FolderUploadPhase) => {
   switch (phase) {
     case 'uploading':
-      return 'bg-info';
+      return 'bg-primary';
     case 'processing':
       return 'bg-warning text-dark progress-bar-striped progress-bar-animated';
     case 'success':
@@ -280,7 +287,7 @@ const folderUploadBarClass = (phase: FolderUploadPhase) => {
     case 'warning':
       return 'bg-warning text-dark';
     case 'error':
-      return 'bg-danger';
+      return 'bg-destructive';
     default:
       return 'bg-secondary';
   }
@@ -1917,29 +1924,29 @@ function App() {
   };
 
   const renderDuplicateCard = (file: DuplicateFile, suggested: boolean, reason: string) => (
-    <div className={`duplicate-card${suggested ? ' is-suggested' : ''}`}>
+    <div className={cn('duplicate-card', suggested && 'is-suggested')}>
       <div className="duplicate-thumb">
         {file.thumbUrl ? (
           <img src={`${API_BASE}${file.thumbUrl}`} alt={file.path} loading="lazy" decoding="async" />
         ) : (
-          <div className="text-secondary small">{file.mediaType.toLowerCase()}</div>
+          <div className="text-muted-foreground-foreground text-sm">{file.mediaType.toLowerCase()}</div>
         )}
       </div>
-      <div className="d-flex justify-content-between align-items-center">
-        <div className="fw-semibold text-truncate">{basenameFromPath(file.path)}</div>
-        {suggested ? <span className="badge bg-success duplicate-suggested-badge">Suggested</span> : null}
+      <div className="flex justify-between items-center">
+        <div className="font-semibold truncate">{basenameFromPath(file.path)}</div>
+        {suggested ? <Badge className="bg-success text-success-foreground duplicate-suggested-badge">Suggested</Badge> : null}
       </div>
-      <div className="text-secondary small">
+      <div className="text-muted-foreground-foreground text-sm">
         {fileTypeFromPath(file.path, file.mediaType)} · {formatSizeMb(file.sizeBytes)}
         {file.width && file.height ? ` · ${file.width}×${file.height}` : ''}
       </div>
       {file.favoriteProviders?.length ? (
-        <div className="text-secondary small">
+        <div className="text-muted-foreground-foreground text-sm">
           favorites: {file.favoriteProviders.map((provider) => provider.toLowerCase()).join(', ')}
         </div>
       ) : null}
-      {suggested ? <div className="text-success small duplicate-suggested-reason">{reason}</div> : null}
-      <div className="text-secondary small duplicate-path">{file.path}</div>
+      {suggested ? <div className="text-success text-sm duplicate-suggested-reason">{reason}</div> : null}
+      <div className="text-muted-foreground-foreground text-sm duplicate-path">{file.path}</div>
     </div>
   );
 
@@ -2457,7 +2464,7 @@ function App() {
   const renderNeighborPreview = (file: FileItem | null, direction: 'prev' | 'next') => (
     <div className={`file-detail-panel file-detail-panel-preview file-detail-panel-${direction}`} aria-hidden={!file}>
       {file ? (
-        <div className={`file-detail-preview-shell file-detail-layer text-light${file.mediaType === 'VIDEO' ? ' is-video' : ''}`}>
+        <div className={`file-detail-preview-shell file-detail-layer text-foreground${file.mediaType === 'VIDEO' ? ' is-video' : ''}`}>
           <div className="container file-detail-back-bar">
             <button className="file-detail-back-btn file-detail-preview-control" type="button" tabIndex={-1} aria-hidden="true">
               <svg className="file-detail-back-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -2465,7 +2472,7 @@ function App() {
               </svg>
               {direction === 'prev' ? 'Previous file' : 'Next file'}
             </button>
-            <div className="d-flex align-items-center gap-2 ms-auto file-detail-sequence-controls">
+            <div className="flex items-center gap-2 ml-auto file-detail-sequence-controls">
               <button className="btn btn-outline-secondary btn-sm file-detail-preview-control" type="button" tabIndex={-1} aria-hidden="true">
                 ‹ Prev
               </button>
@@ -2486,9 +2493,9 @@ function App() {
             </button>
           </div>
           <div className="container file-detail-body file-detail-preview-body">
-            <div className="file-detail-section mb-3">
+            <div className="file-detail-section mb-6">
               <div className="file-detail-section-head">
-                <div className="text-uppercase fw-semibold file-detail-section-title file-detail-section-title-accent">
+                <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
                   File info
                 </div>
                 <div className="file-detail-section-actions">
@@ -2544,26 +2551,26 @@ function App() {
                   </button>
                 </div>
               </div>
-              <div className="text-secondary small">
-                <span className="fw-semibold file-detail-label">File name:</span> {basenameFromPath(file.path) || file.path}
+              <div className="text-muted-foreground text-sm">
+                <span className="font-semibold file-detail-label">File name:</span> {basenameFromPath(file.path) || file.path}
                 <br />
                 {file.durationMs ? `${(file.durationMs / 1000).toFixed(1)}s` : ''}
                 {file.durationMs ? <br /> : null}
-                <span className="fw-semibold file-detail-label">Type:</span> {fileTypeFromPath(file.path, file.mediaType)}
+                <span className="font-semibold file-detail-label">Type:</span> {fileTypeFromPath(file.path, file.mediaType)}
                 <br />
-                <span className="fw-semibold file-detail-label">Size:</span> {formatSizeMb(file.sizeBytes)}
+                <span className="font-semibold file-detail-label">Size:</span> {formatSizeMb(file.sizeBytes)}
                 {file.width && file.height ? ` (${file.width}×${file.height})` : ''}
                 <br />
-                <span className="fw-semibold file-detail-label">Modified:</span> {formatDateTime(file.mtime)}
+                <span className="font-semibold file-detail-label">Modified:</span> {formatDateTime(file.mtime)}
               </div>
             </div>
             <div className="file-detail-section-divider" />
-            <div className="file-detail-section mb-3">
+            <div className="file-detail-section mb-6">
               <div className="file-detail-section-head">
-                <div className="text-uppercase fw-semibold file-detail-section-title file-detail-section-title-accent">
+                <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
                   Tags
                 </div>
-                <div className="d-flex gap-2">
+                <div className="flex gap-2">
                   <button className="btn btn-outline-light btn-sm file-detail-refresh-button file-detail-icon-button file-detail-preview-control" type="button" tabIndex={-1} aria-hidden="true">
                     <svg
                       className="file-detail-refresh-icon"
@@ -2582,14 +2589,14 @@ function App() {
                   </button>
                 </div>
               </div>
-              <div className="text-secondary small file-detail-preview-copy">
+              <div className="text-muted-foreground text-sm file-detail-preview-copy">
                 Tags load when this file becomes active.
               </div>
             </div>
             <div className="file-detail-section-divider" />
-            <div className="file-detail-section mb-3">
+            <div className="file-detail-section mb-6">
               <div className="file-detail-section-head">
-                <div className="text-uppercase fw-semibold file-detail-section-title file-detail-section-title-accent">
+                <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
                   Sauces
                 </div>
                 <button className="btn btn-outline-light btn-sm file-detail-scan-button file-detail-icon-button file-detail-preview-control" type="button" tabIndex={-1} aria-hidden="true">
@@ -2609,7 +2616,7 @@ function App() {
                   <span className="file-detail-button-text">Scan</span>
                 </button>
               </div>
-              <div className="text-secondary small file-detail-preview-copy">
+              <div className="text-muted-foreground text-sm file-detail-preview-copy">
                 Match results load when this file becomes active.
               </div>
             </div>
@@ -2621,21 +2628,21 @@ function App() {
 
   if (authState.loading && !authUser) {
     return (
-      <div className="bg-dark text-light min-vh-100 d-flex align-items-center justify-content-center">
-        <div className="text-secondary">Checking session…</div>
+      <div className="bg-background text-foreground min-h-screen flex items-center justify-center">
+        <div className="text-muted-foreground">Checking session…</div>
       </div>
     );
   }
 
   if (!authUser) {
     return (
-      <div className="bg-dark text-light min-vh-100 d-flex align-items-center justify-content-center px-3">
-        <div className="card bg-black text-light border-secondary" style={{ width: '100%', maxWidth: 420 }}>
-          <div className="card-body p-4">
-            <div className="d-flex justify-content-between align-items-start mb-3">
+      <div className="bg-background text-foreground min-h-screen flex items-center justify-center px-6">
+        <div className="card bg-black text-foreground border-secondary" style={{ width: '100%', maxWidth: 420 }}>
+          <div className="card-body p-6">
+            <div className="flex justify-between items-start mb-6">
               <div>
                 <h1 className="h3 mb-1">GoonCave</h1>
-                <div className="text-secondary small">Local-network sign-in</div>
+                <div className="text-muted-foreground text-sm">Local-network sign-in</div>
               </div>
               <div className="btn-group btn-group-sm" role="group" aria-label="auth mode">
                 <button
@@ -2666,19 +2673,19 @@ function App() {
                 void submitAuth();
               }}
             >
-              <div className="mb-3">
+              <div className="mb-6">
                 <label className="form-label">Username</label>
                 <input
-                  className="form-control bg-dark text-light border-secondary"
+                  className="form-control bg-background text-foreground border-secondary"
                   value={authForm.username}
                   onChange={(event) => setAuthForm((prev) => ({ ...prev, username: event.target.value }))}
                   autoComplete="username"
                 />
               </div>
-              <div className="mb-3">
+              <div className="mb-6">
                 <label className="form-label">Password</label>
                 <input
-                  className="form-control bg-dark text-light border-secondary"
+                  className="form-control bg-background text-foreground border-secondary"
                   type="password"
                   value={authForm.password}
                   onChange={(event) => setAuthForm((prev) => ({ ...prev, password: event.target.value }))}
@@ -2686,10 +2693,10 @@ function App() {
                 />
               </div>
               {authMode === 'register' ? (
-                <div className="mb-3">
+                <div className="mb-6">
                   <label className="form-label">Confirm password</label>
                   <input
-                    className="form-control bg-dark text-light border-secondary"
+                    className="form-control bg-background text-foreground border-secondary"
                     type="password"
                     value={authForm.confirmPassword}
                     onChange={(event) => setAuthForm((prev) => ({ ...prev, confirmPassword: event.target.value }))}
@@ -2698,7 +2705,7 @@ function App() {
                 </div>
               ) : null}
               {authState.error ? <div className="alert alert-danger py-2">{authState.error}</div> : null}
-              <button className="btn btn-primary w-100" type="submit" disabled={authState.loading}>
+              <button className="btn btn-primary w-full" type="submit" disabled={authState.loading}>
                 {authState.loading ? 'Working…' : authMode === 'login' ? 'Login' : 'Create account'}
               </button>
             </form>
@@ -2709,13 +2716,13 @@ function App() {
   }
 
   return (
-    <div className="bg-dark text-light min-vh-100">
+    <div className="bg-background text-foreground min-h-screen">
       {selectedFile ? null : (
       <div className="container page-shell">
-        <div className="d-flex justify-content-between align-items-center mb-3">
+        <div className="flex justify-between items-center mb-6">
           <div>
             <h1 className="h3 mb-1">GoonCave</h1>
-            <div className="text-secondary small">Signed in as {authUser.username}</div>
+            <div className="text-muted-foreground text-sm">Signed in as {authUser.username}</div>
           </div>
           <div>
             <button className="btn btn-outline-light btn-sm" type="button" onClick={() => void logout()}>
@@ -2723,7 +2730,7 @@ function App() {
             </button>
           </div>
         </div>
-        <div className="btn-group mb-4" role="group" aria-label="view switcher">
+        <div className="btn-group mb-6" role="group" aria-label="view switcher">
           <button
             className={`btn btn-${viewMode === 'gallery' ? 'primary' : 'outline-light'}`}
             onClick={() => void onSwitchView('gallery')}
@@ -2744,35 +2751,35 @@ function App() {
           </button>
         </div>
 
-        {fetchState.error ? <div className="text-danger mb-3">Error: {fetchState.error}</div> : null}
-        {manualOrderState.error ? <div className="text-danger mb-3">Manual order: {manualOrderState.error}</div> : null}
-        {manualOrderState.loading ? <div className="text-secondary small mb-3">Saving manual order…</div> : null}
+        {fetchState.error ? <div className="text-destructive mb-6">Error: {fetchState.error}</div> : null}
+        {manualOrderState.error ? <div className="text-destructive mb-6">Manual order: {manualOrderState.error}</div> : null}
+        {manualOrderState.loading ? <div className="text-muted-foreground text-sm mb-6">Saving manual order…</div> : null}
         <div className={`row ${viewMode === 'folders' ? 'g-0 settings-sections' : 'g-4'}`}>
           {viewMode === 'folders' ? (
             <>
               <div className="col-12 settings-section">
-                <div className="card bg-transparent text-light border-0 h-100 settings-section-card">
+                <div className="card bg-transparent text-foreground border-0 h-full settings-section-card">
                   <div className="card-body">
-                    <div className="d-flex justify-content-between align-items-center mb-3">
+                    <div className="flex justify-between items-center mb-6">
                       <h2 className="h5 mb-0">Library folders</h2>
                     </div>
                     <input
                       ref={uploadInputRef}
                       type="file"
-                      className="d-none"
+                      className="hidden"
                       multiple
                       accept={uploadInputAccept}
                       onChange={onFolderUploadInputChange}
                     />
-                    <div className="text-secondary small mb-3">
+                    <div className="text-muted-foreground text-sm mb-6">
                       Your main library appears below automatically. Mounted folders also appear automatically when they
                       are direct children of your library root. Check the README for setup instructions.
                     </div>
                     {folderActionState.error ? (
-                      <div className="text-danger small mb-3">Folder error: {folderActionState.error}</div>
+                      <div className="text-destructive text-sm mb-6">Folder error: {folderActionState.error}</div>
                     ) : null}
                     {orderedFolders.length === 0 ? (
-                      <p className="text-secondary">No folders configured.</p>
+                      <p className="text-muted-foreground">No folders configured.</p>
                     ) : (
                       <div className="list-group folder-list">
                         {orderedFolders.map((folder) => {
@@ -2783,15 +2790,15 @@ function App() {
                           return (
                             <div
                               key={folder.id}
-                              className={`list-group-item d-flex justify-content-between align-items-center bg-secondary text-light border border-secondary folder-card${folderInfo.isRoot ? ' folder-card-root' : ''}${uploadBusy ? ' folder-card-uploading' : ''}`}
+                              className={`list-group-item flex justify-between items-center bg-secondary text-foreground border border-secondary folder-card${folderInfo.isRoot ? ' folder-card-root' : ''}${uploadBusy ? ' folder-card-uploading' : ''}`}
                             >
                               <div className="folder-card-body">
                                 <div className="folder-card-header">
                                   <div className="folder-card-heading">
-                                    <div className="fw-semibold folder-card-title">{folderInfo.title}</div>
-                                    {folderInfo.subtitle ? <div className="text-secondary small">{folderInfo.subtitle}</div> : null}
+                                    <div className="font-semibold folder-card-title">{folderInfo.title}</div>
+                                    {folderInfo.subtitle ? <div className="text-muted-foreground text-sm">{folderInfo.subtitle}</div> : null}
                                   </div>
-                                  <div className="d-flex gap-2 folder-card-actions">
+                                  <div className="flex gap-2 folder-card-actions">
                                     <button
                                       className="btn btn-outline-light btn-sm"
                                       onClick={() => openFolderUploadPicker(folder.id)}
@@ -2823,11 +2830,11 @@ function App() {
                                 <div className="folder-card-meta">
                                   <div className="folder-card-pathline">
                                     <span className="folder-card-meta-label">Path</span>
-                                    <span className="text-secondary small folder-card-path" title={folder.path}>{folder.path}</span>
+                                    <span className="text-muted-foreground text-sm folder-card-path" title={folder.path}>{folder.path}</span>
                                   </div>
                                 </div>
                                 {uploadState ? (
-                                  <div className="folder-upload-state mt-3">
+                                  <div className="folder-upload-state mt-6">
                                     <div className="progress folder-upload-progress" role="progressbar" aria-valuenow={uploadState.progress} aria-valuemin={0} aria-valuemax={100}>
                                       <div
                                         className={`progress-bar ${folderUploadBarClass(uploadState.phase)}`}
@@ -2836,9 +2843,9 @@ function App() {
                                         {uploadState.progress}%
                                       </div>
                                     </div>
-                                    <div className="small mt-2 folder-upload-message">{uploadState.message}</div>
+                                    <div className="text-sm mt-2 folder-upload-message">{uploadState.message}</div>
                                     {uploadState.detail ? (
-                                      <div className="small text-secondary mt-1 folder-upload-detail">{uploadState.detail}</div>
+                                      <div className="text-sm text-muted-foreground mt-1 folder-upload-detail">{uploadState.detail}</div>
                                     ) : null}
                                   </div>
                                 ) : null}
@@ -2852,18 +2859,18 @@ function App() {
                 </div>
               </div>
               <div className="col-12 settings-section">
-                <div className="card bg-transparent text-light border-0 h-100 settings-section-card">
+                <div className="card bg-transparent text-foreground border-0 h-full settings-section-card">
                   <div className="card-body">
-                    <div className="d-flex justify-content-between align-items-center mb-2">
+                    <div className="flex justify-between items-center mb-2">
                       <h2 className="h5 mb-0">Sync favorites</h2>
                     </div>
-                    <p className="text-secondary small mb-3">
+                    <p className="text-muted-foreground text-sm mb-6">
                       Connect your e621 and Danbooru accounts to double-sync favorites.
                     </p>
 
-                    <BooruSitesPanel className="mb-4" devOptions={booruDevOptions} />
+                    <BooruSitesPanel className="mb-6" devOptions={booruDevOptions} />
 
-                    <div className="d-flex flex-wrap gap-2 mb-2">
+                    <div className="flex flex-wrap gap-2 mb-2">
                       <button
                         className="btn btn-outline-light btn-sm"
                         onClick={() => void runFavoritesSync(true)}
@@ -2881,7 +2888,7 @@ function App() {
                         onChange={(event) => void updateFavoritesSettings({ autoSyncMidnight: event.target.checked })}
                         disabled={favoritesSettingsState.loading}
                       />
-                      <label className="form-check-label text-secondary small" htmlFor="auto-sync-toggle-top">
+                      <label className="form-check-label text-muted-foreground text-sm" htmlFor="auto-sync-toggle-top">
                         Run a daily sync at midnight to keep favorites current
                       </label>
                     </div>
@@ -2894,11 +2901,11 @@ function App() {
                         onChange={(event) => void updateFavoritesSettings({ reverseSyncEnabled: event.target.checked })}
                         disabled={favoritesSettingsState.loading}
                       />
-                      <label className="form-check-label text-secondary small" htmlFor="reverse-sync-toggle-top">
+                      <label className="form-check-label text-muted-foreground text-sm" htmlFor="reverse-sync-toggle-top">
                         When you delete a file here, also remove it from favorites
                       </label>
                     </div>
-                    <div className="form-check form-switch mb-3">
+                    <div className="form-check form-switch mb-6">
                       <input
                         className="form-check-input"
                         type="checkbox"
@@ -2907,19 +2914,19 @@ function App() {
                         onChange={(event) => void updateFavoritesSettings({ autoFavEnabled: event.target.checked })}
                         disabled={favoritesSettingsState.loading}
                       />
-                      <label className="form-check-label text-secondary small" htmlFor="auto-fav-toggle-top">
+                      <label className="form-check-label text-muted-foreground text-sm" htmlFor="auto-fav-toggle-top">
                         When the sources scanner finds a match on a logged-in source, auto-favorite it there
                       </label>
                     </div>
 
-                    <details className="mb-3">
-                      <summary className="text-secondary small">Legacy credential cards (E621 / Danbooru)</summary>
-                    <div className="credential-grid mb-3">
+                    <details className="mb-6">
+                      <summary className="text-muted-foreground text-sm">Legacy credential cards (E621 / Danbooru)</summary>
+                    <div className="credential-grid mb-6">
                       <div className="credential-col">
                         <div className="border border-secondary rounded p-2 credential-card">
-                          <div className="d-flex justify-content-between align-items-center gap-2">
-                            <div className="fw-semibold">e621</div>
-                            <div className="d-flex align-items-center gap-2">
+                          <div className="flex justify-between items-center gap-2">
+                            <div className="font-semibold">e621</div>
+                            <div className="flex items-center gap-2">
                               {e621Ready ? (
                                 <>
                                   <button
@@ -2951,7 +2958,7 @@ function App() {
                           </div>
                           {!e621Ready && credentialExpanded.E621 ? (
                             <div className="mt-2 credential-fields" id="credential-e621">
-                              <label className="form-label small text-secondary">Username</label>
+                              <label className="form-label text-sm text-muted-foreground">Username</label>
                               <input
                                 className="form-control form-control-sm mb-2"
                                 value={credentialInputs.E621.username}
@@ -2959,7 +2966,7 @@ function App() {
                                 placeholder="Enter your e621 username"
                                 disabled={credentialsState.loading}
                               />
-                              <label className="form-label small text-secondary">API key</label>
+                              <label className="form-label text-sm text-muted-foreground">API key</label>
                               <input
                                 type="password"
                                 className="form-control form-control-sm"
@@ -2968,7 +2975,7 @@ function App() {
                                 placeholder="Enter API key"
                                 disabled={credentialsState.loading}
                               />
-                              <div className="d-flex align-items-center gap-2 mt-2">
+                              <div className="flex items-center gap-2 mt-2">
                                 <button
                                   className="btn btn-outline-light btn-sm"
                                   onClick={() => void saveCredential('E621')}
@@ -2983,9 +2990,9 @@ function App() {
                       </div>
                       <div className="credential-col">
                         <div className="border border-secondary rounded p-2 credential-card">
-                          <div className="d-flex justify-content-between align-items-center gap-2">
-                            <div className="fw-semibold">Danbooru</div>
-                            <div className="d-flex align-items-center gap-2">
+                          <div className="flex justify-between items-center gap-2">
+                            <div className="font-semibold">Danbooru</div>
+                            <div className="flex items-center gap-2">
                               {danbooruReady ? (
                                 <>
                                   <button
@@ -3017,7 +3024,7 @@ function App() {
                           </div>
                           {!danbooruReady && credentialExpanded.DANBOORU ? (
                             <div className="mt-2 credential-fields" id="credential-danbooru">
-                              <label className="form-label small text-secondary">Username</label>
+                              <label className="form-label text-sm text-muted-foreground">Username</label>
                               <input
                                 className="form-control form-control-sm mb-2"
                                 value={credentialInputs.DANBOORU.username}
@@ -3025,7 +3032,7 @@ function App() {
                                 placeholder="Enter your Danbooru username"
                                 disabled={credentialsState.loading}
                               />
-                              <label className="form-label small text-secondary">API key</label>
+                              <label className="form-label text-sm text-muted-foreground">API key</label>
                               <input
                                 type="password"
                                 className="form-control form-control-sm"
@@ -3034,7 +3041,7 @@ function App() {
                                 placeholder="Enter API key"
                                 disabled={credentialsState.loading}
                               />
-                              <div className="d-flex align-items-center gap-2 mt-2">
+                              <div className="flex items-center gap-2 mt-2">
                                 <button
                                   className="btn btn-outline-light btn-sm"
                                   onClick={() => void saveCredential('DANBOORU')}
@@ -3053,29 +3060,29 @@ function App() {
                     (credentialLastProvider === null ||
                       credentialLastProvider === 'E621' ||
                       credentialLastProvider === 'DANBOORU') ? (
-                      <div className="text-danger small mb-2">Credentials error: {credentialsState.error}</div>
+                      <div className="text-destructive text-sm mb-2">Credentials error: {credentialsState.error}</div>
                     ) : null}
                     {favoritesSettingsState.error ? (
-                      <div className="text-danger small">Settings error: {favoritesSettingsState.error}</div>
+                      <div className="text-destructive text-sm">Settings error: {favoritesSettingsState.error}</div>
                     ) : null}
                     {favoritesSyncState.loading || favoritesSyncStatus?.status === 'running' ? (
-                      <div className="text-secondary small">
+                      <div className="text-muted-foreground text-sm">
                         {favoritesSyncStatus?.message ?? 'Syncing favorites…'}
                       </div>
                     ) : null}
                     {favoritesSyncStatus ? (
-                      <div className="text-secondary small mt-1">
+                      <div className="text-muted-foreground text-sm mt-1">
                         <div>Last sync started: {formatDateTime(favoritesSyncStatus.startedAt)}</div>
                         <div>Last sync updated: {formatDateTime(favoritesSyncStatus.updatedAt)}</div>
                       </div>
                     ) : null}
                     {favoritesSyncState.error ? (
-                      <div className="text-danger small">Error: {favoritesSyncState.error}</div>
+                      <div className="text-destructive text-sm">Error: {favoritesSyncState.error}</div>
                     ) : null}
                     {favoritesSyncStatus?.status === 'running' && favoritesProgress !== null ? (
-                      <div className="progress bg-dark border border-secondary mt-2" style={{ height: 8 }}>
+                      <div className="progress bg-background border border-secondary mt-2" style={{ height: 8 }}>
                         <div
-                          className="progress-bar bg-info"
+                          className="progress-bar bg-primary"
                           role="progressbar"
                           style={{ width: `${favoritesProgress}%` }}
                           aria-valuenow={favoritesProgress}
@@ -3085,7 +3092,7 @@ function App() {
                       </div>
                     ) : null}
                     {favoritesSyncStatus?.progress?.providers?.length ? (
-                      <div className="text-secondary small mt-2">
+                      <div className="text-muted-foreground text-sm mt-2">
                         {favoritesSyncStatus.progress.providers.map((entry) => (
                           <div key={entry.provider}>
                             {entry.provider}: {entry.stage} · {entry.processed}/{entry.total} · +{entry.added} / -
@@ -3095,14 +3102,14 @@ function App() {
                       </div>
                     ) : null}
                     {favoritesSummary.length ? (
-                      <div className="text-secondary small">
+                      <div className="text-muted-foreground text-sm">
                         {favoritesSummary.map((line) => (
                           <div key={line}>{line}</div>
                         ))}
                       </div>
                     ) : null}
                     {favoritesErrors.length ? (
-                      <div className="text-danger small mt-2">
+                      <div className="text-destructive text-sm mt-2">
                         {favoritesErrors.slice(0, 6).map((line) => (
                           <div key={line}>{line}</div>
                         ))}
@@ -3115,21 +3122,21 @@ function App() {
                 </div>
               </div>
               <div className="col-12 settings-section">
-                <div className="card bg-transparent text-light border-0 h-100 settings-section-card">
+                <div className="card bg-transparent text-foreground border-0 h-full settings-section-card">
                   <div className="card-body">
-                    <div className="d-flex justify-content-between align-items-center mb-2">
+                    <div className="flex justify-between items-center mb-2">
                       <h2 className="h5 mb-0">Sauces</h2>
                     </div>
-                    <p className="text-secondary small mb-3">
+                    <p className="text-muted-foreground text-sm mb-6">
                       Pick which sources appear in the file view and which ones the scanner should look for
                       automatically. Targeted sources are retried daily for up to a week or until a match is found.
                     </p>
-                    <div className="credential-grid mb-3">
+                    <div className="credential-grid mb-6">
                       <div className="credential-col">
                         <div className="border border-secondary rounded p-2 credential-card">
-                          <div className="d-flex justify-content-between align-items-center gap-2">
-                            <div className="fw-semibold">SauceNAO</div>
-                            <div className="d-flex align-items-center gap-2">
+                          <div className="flex justify-between items-center gap-2">
+                            <div className="font-semibold">SauceNAO</div>
+                            <div className="flex items-center gap-2">
                               {saucenaoReady ? (
                                 <>
                                   <button
@@ -3161,14 +3168,14 @@ function App() {
                           </div>
                           {!saucenaoReady && credentialExpanded.SAUCENAO ? (
                             <div className="mt-2 credential-fields" id="credential-saucenao">
-                              <label className="form-label small text-secondary">Username</label>
+                              <label className="form-label text-sm text-muted-foreground">Username</label>
                               <input
                                 className="form-control form-control-sm mb-2"
                                 value=""
                                 placeholder="Not used for SauceNAO"
                                 disabled
                               />
-                              <label className="form-label small text-secondary">API key</label>
+                              <label className="form-label text-sm text-muted-foreground">API key</label>
                               <input
                                 type="password"
                                 className="form-control form-control-sm"
@@ -3177,7 +3184,7 @@ function App() {
                                 placeholder="Enter API key"
                                 disabled={credentialsState.loading}
                               />
-                              <div className="d-flex align-items-center gap-2 mt-2">
+                              <div className="flex items-center gap-2 mt-2">
                                 <button
                                   className="btn btn-outline-light btn-sm"
                                   onClick={() => void saveCredential('SAUCENAO')}
@@ -3192,12 +3199,12 @@ function App() {
                       </div>
                       <div className="credential-col">
                         <div className="border border-secondary rounded p-2 credential-card">
-                          <div className="d-flex justify-content-between align-items-center gap-2">
-                            <div className="d-flex align-items-center gap-2 flex-wrap">
-                              <div className="fw-semibold">Fluffle</div>
-                              <div className="text-secondary small">No login required.</div>
+                          <div className="flex justify-between items-center gap-2">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <div className="font-semibold">Fluffle</div>
+                              <div className="text-muted-foreground text-sm">No login required.</div>
                             </div>
-                            <div className="d-flex align-items-center gap-2">
+                            <div className="flex items-center gap-2">
                               <span className="btn btn-success btn-sm credential-status">Working</span>
                             </div>
                           </div>
@@ -3205,16 +3212,16 @@ function App() {
                       </div>
                     </div>
                     {credentialsState.error && credentialLastProvider === 'SAUCENAO' ? (
-                      <div className="text-danger small mb-2">Credentials error: {credentialsState.error}</div>
+                      <div className="text-destructive text-sm mb-2">Credentials error: {credentialsState.error}</div>
                     ) : null}
-                    <div className="sauce-progress-wrap mb-3">
-                      <div className="sauce-progress-bar border border-secondary bg-dark" role="img" aria-label="Sauce target scan progress">
+                    <div className="sauce-progress-wrap mb-6">
+                      <div className="sauce-progress-bar border border-secondary bg-background" role="img" aria-label="Sauce target scan progress">
                         <div
                           className="sauce-progress-segment bg-success"
                           style={{ width: `${sauceProgressSegments.matched}%` }}
                         />
                         <div
-                          className="sauce-progress-segment bg-danger"
+                          className="sauce-progress-segment bg-destructive"
                           style={{ width: `${sauceProgressSegments.failed}%` }}
                         />
                         <div
@@ -3222,13 +3229,13 @@ function App() {
                           style={{ width: `${sauceProgressSegments.pending}%` }}
                         />
                       </div>
-                      <div className="sauce-progress-legend text-secondary small mt-2">
+                      <div className="sauce-progress-legend text-muted-foreground text-sm mt-2">
                         <span className="sauce-progress-legend-item">
                           <span className="sauce-progress-dot bg-success" />
                           Target found ({sauceProgress.matched})
                         </span>
                         <span className="sauce-progress-legend-item">
-                          <span className="sauce-progress-dot bg-danger" />
+                          <span className="sauce-progress-dot bg-destructive" />
                           Failed ({sauceProgress.failed})
                         </span>
                         <span className="sauce-progress-legend-item">
@@ -3238,12 +3245,12 @@ function App() {
                       </div>
                       <hr className="sauce-progress-separator" />
                     </div>
-                    {sauceState.error ? <div className="text-danger mb-2">Error: {sauceState.error}</div> : null}
+                    {sauceState.error ? <div className="text-destructive mb-2">Error: {sauceState.error}</div> : null}
                     {sauceSources.length === 0 ? (
-                      <p className="text-secondary">No sources discovered yet.</p>
+                      <p className="text-muted-foreground">No sources discovered yet.</p>
                     ) : (
                       <>
-                        <div className="d-flex flex-wrap gap-2 mb-3">
+                        <div className="flex flex-wrap gap-2 mb-6">
                           <button className="btn btn-outline-light btn-sm" onClick={() => setAllDisplay(true)}>
                             Show all
                           </button>
@@ -3264,7 +3271,7 @@ function App() {
                                 <th>Source</th>
                                 <th className="text-center">Show</th>
                                 <th className="text-center">Target</th>
-                                <th className="text-end">Hits</th>
+                                <th className="text-right">Hits</th>
                               </tr>
                             </thead>
                             <tbody>
@@ -3291,7 +3298,7 @@ function App() {
                                         onChange={() => toggleTargetSauce(key)}
                                       />
                                     </td>
-                                    <td className="text-end text-secondary">{source.count}</td>
+                                    <td className="text-right text-muted-foreground">{source.count}</td>
                                   </tr>
                                 );
                               })}
@@ -3304,9 +3311,9 @@ function App() {
                 </div>
               </div>
               <div className="col-12 settings-section">
-                <div className="card bg-transparent text-light border-0 h-100 settings-section-card">
+                <div className="card bg-transparent text-foreground border-0 h-full settings-section-card">
                   <div className="card-body">
-                    <hr className="border-secondary mt-0 mb-3" />
+                    <hr className="border-secondary mt-0 mb-6" />
                     <div className="form-check form-switch">
                       <input
                         className="form-check-input"
@@ -3316,7 +3323,7 @@ function App() {
                         onChange={(e) => setBooruDevOptionsPersistent(e.target.checked)}
                       />
                       <label
-                        className="form-check-label text-secondary small"
+                        className="form-check-label text-muted-foreground text-sm"
                         htmlFor="booru-dev-options-toggle"
                       >
                         Developer options
@@ -3328,17 +3335,17 @@ function App() {
             </>
           ) : viewMode === 'duplicates' ? (
             <div className="col-12">
-              <div className="card bg-transparent text-light border-0 h-100 content-shell-card">
+              <div className="card bg-transparent text-foreground border-0 h-full content-shell-card">
                 <div className="card-body">
-                  <div className="d-flex justify-content-between align-items-center mb-3">
+                  <div className="flex justify-between items-center mb-6">
                     {duplicateStats ? (
-                      <span className="text-secondary small">{duplicateGroups.length} groups</span>
+                      <span className="text-muted-foreground text-sm">{duplicateGroups.length} groups</span>
                     ) : null}
                   </div>
-                  <p className="text-secondary small mb-3">
+                  <p className="text-muted-foreground text-sm mb-6">
                     Groups files by media type and dimensions, then compares downscaled pixels (videos use sampled frames).
                   </p>
-                  <div className="form-check form-switch mb-3">
+                  <div className="form-check form-switch mb-6">
                     <input
                       className="form-check-input"
                       type="checkbox"
@@ -3347,18 +3354,18 @@ function App() {
                       onChange={(event) => void updateDuplicateSettings({ autoResolve: event.target.checked })}
                       disabled={duplicateSettingsState.loading}
                     />
-                    <label className="form-check-label text-secondary small" htmlFor="duplicate-auto-resolve-toggle">
+                    <label className="form-check-label text-muted-foreground text-sm" htmlFor="duplicate-auto-resolve-toggle">
                       Auto-resolve duplicates (prefer synced favorites, then quality)
                     </label>
                   </div>
                   {duplicateSettingsState.error ? (
-                    <div className="text-danger mb-2">Settings error: {duplicateSettingsState.error}</div>
+                    <div className="text-destructive mb-2">Settings error: {duplicateSettingsState.error}</div>
                   ) : null}
-                  <div className="d-flex flex-wrap gap-3 align-items-end mb-3">
+                  <div className="flex flex-wrap gap-6 items-end mb-6">
                     <div>
-                      <div className="text-secondary small mb-1">Media</div>
+                      <div className="text-muted-foreground text-sm mb-1">Media</div>
                       <select
-                        className="form-select form-select-sm bg-dark text-light border-secondary"
+                        className="form-select form-select-sm bg-background text-foreground border-secondary"
                         value={duplicateOptions.mediaType ?? 'ALL'}
                         onChange={(event) =>
                           setDuplicateOptions((prev) => ({
@@ -3380,17 +3387,17 @@ function App() {
                       {duplicateState.loading ? 'Scanning…' : 'Run scan'}
                     </button>
                   </div>
-                  <details className="mb-3">
-                    <summary className="text-secondary small">Advanced</summary>
-                    <div className="d-flex flex-wrap gap-3 align-items-end mt-2">
+                  <details className="mb-6">
+                    <summary className="text-muted-foreground text-sm">Advanced</summary>
+                    <div className="flex flex-wrap gap-6 items-end mt-2">
                       <div>
-                        <label className="text-secondary small mb-1 d-block" htmlFor="duplicate-pixel-threshold">
+                        <label className="text-muted-foreground text-sm mb-1 block" htmlFor="duplicate-pixel-threshold">
                           Pixel threshold
                         </label>
                         <input
                           id="duplicate-pixel-threshold"
                           name="pixelThreshold"
-                          className="form-control form-control-sm bg-dark text-light border-secondary"
+                          className="form-control form-control-sm bg-background text-foreground border-secondary"
                           type="number"
                           step="0.005"
                           min={0}
@@ -3405,13 +3412,13 @@ function App() {
                         />
                       </div>
                       <div>
-                        <label className="text-secondary small mb-1 d-block" htmlFor="duplicate-sample-size">
+                        <label className="text-muted-foreground text-sm mb-1 block" htmlFor="duplicate-sample-size">
                           Sample size
                         </label>
                         <input
                           id="duplicate-sample-size"
                           name="sampleSize"
-                          className="form-control form-control-sm bg-dark text-light border-secondary"
+                          className="form-control form-control-sm bg-background text-foreground border-secondary"
                           type="number"
                           step="8"
                           min={8}
@@ -3430,13 +3437,13 @@ function App() {
                         />
                       </div>
                       <div>
-                        <label className="text-secondary small mb-1 d-block" htmlFor="duplicate-video-frames">
+                        <label className="text-muted-foreground text-sm mb-1 block" htmlFor="duplicate-video-frames">
                           Video frames
                         </label>
                         <input
                           id="duplicate-video-frames"
                           name="videoFrames"
-                          className="form-control form-control-sm bg-dark text-light border-secondary"
+                          className="form-control form-control-sm bg-background text-foreground border-secondary"
                           type="number"
                           step="1"
                           min={1}
@@ -3455,13 +3462,13 @@ function App() {
                         />
                       </div>
                       <div>
-                        <label className="text-secondary small mb-1 d-block" htmlFor="duplicate-max-comparisons">
+                        <label className="text-muted-foreground text-sm mb-1 block" htmlFor="duplicate-max-comparisons">
                           Max comparisons
                         </label>
                         <input
                           id="duplicate-max-comparisons"
                           name="maxComparisons"
-                          className="form-control form-control-sm bg-dark text-light border-secondary"
+                          className="form-control form-control-sm bg-background text-foreground border-secondary"
                           type="number"
                           step="100"
                           min={1}
@@ -3481,10 +3488,10 @@ function App() {
                       </div>
                     </div>
                   </details>
-                  {duplicateState.error ? <div className="text-danger mb-2">Error: {duplicateState.error}</div> : null}
+                  {duplicateState.error ? <div className="text-destructive mb-2">Error: {duplicateState.error}</div> : null}
                   {duplicateState.loading && duplicateScanStatus?.progress ? (
-                    <div className="mb-3">
-                      <div className="d-flex justify-content-between text-secondary small mb-1">
+                    <div className="mb-6">
+                      <div className="flex justify-between text-muted-foreground text-sm mb-1">
                         <span>{duplicateScanStatus.progress.message}</span>
                         <span>
                           {duplicateScanStatus.progress.total > 0
@@ -3513,7 +3520,7 @@ function App() {
                           }}
                         />
                       </div>
-                      <div className="text-secondary small mt-1">
+                      <div className="text-muted-foreground text-sm mt-1">
                         Phase: {duplicateScanStatus.progress.phase} · Processed {duplicateScanStatus.progress.processed}/
                         {duplicateScanStatus.progress.total} · Comparisons {duplicateScanStatus.progress.comparisons} · Groups{' '}
                         {duplicateScanStatus.progress.groups} · Skipped {duplicateScanStatus.progress.skippedNoSignature}
@@ -3521,17 +3528,17 @@ function App() {
                     </div>
                   ) : null}
                   {duplicateAction.error ? (
-                    <div className="text-danger mb-2">Delete error: {duplicateAction.error}</div>
+                    <div className="text-destructive mb-2">Delete error: {duplicateAction.error}</div>
                   ) : null}
                   {duplicateStats ? (
-                    <div className="text-secondary small mb-3">
+                    <div className="text-muted-foreground text-sm mb-6">
                       Eligible: {duplicateStats.eligibleFiles}/{duplicateStats.totalFiles} · Compared:{' '}
                       {duplicateStats.comparedFiles} · Comparisons: {duplicateStats.comparisons} · Skipped:{' '}
                       {duplicateStats.skippedNoSignature}
                     </div>
                   ) : null}
                   {duplicatePairs.length === 0 ? (
-                    <p className="text-secondary">
+                    <p className="text-muted-foreground">
                       {duplicateState.loading
                         ? 'Scanning duplicates…'
                         : duplicateStats
@@ -3546,10 +3553,10 @@ function App() {
                       const actionBusy =
                         duplicateAction.loadingId === pair.left.id || duplicateAction.loadingId === pair.right.id;
                       return (
-                        <div key={pair.key} className="duplicate-pair border border-secondary rounded p-3 mb-3">
-                          <div className="d-flex justify-content-between align-items-center mb-2">
-                            <div className="text-secondary small">Pair {index + 1}</div>
-                            <div className="text-secondary small">
+                        <div key={pair.key} className="duplicate-pair border border-secondary rounded p-6 mb-6">
+                          <div className="flex justify-between items-center mb-2">
+                            <div className="text-muted-foreground text-sm">Pair {index + 1}</div>
+                            <div className="text-muted-foreground text-sm">
                               Suggested: keep {suggestedSide} ({pair.reason})
                             </div>
                           </div>
@@ -3559,7 +3566,7 @@ function App() {
                               {renderDuplicateCard(pair.right, rightSuggested, pair.reason)}
                             </div>
                           </div>
-                          <div className="d-flex flex-wrap gap-2 mt-3">
+                          <div className="flex flex-wrap gap-2 mt-6">
                             <button
                               className="btn btn-success btn-sm"
                               onClick={() => void resolveDuplicateChoice(pair.left, pair.right)}
@@ -3591,13 +3598,13 @@ function App() {
             </div>
           ) : (
             <div className="col-12">
-              <div className="card bg-transparent text-light border-0 h-100 content-shell-card">
+              <div className="card bg-transparent text-foreground border-0 h-full content-shell-card">
                 <div className="card-body">
-                  <div className="gallery-controls d-flex flex-wrap align-items-center mb-2">
-                    <div className="gallery-control-group gallery-control-search d-flex flex-wrap align-items-center gap-2">
-                      <span className="text-secondary small">Search for tags:</span>
+                  <div className="gallery-controls flex flex-wrap items-center mb-2">
+                    <div className="gallery-control-group gallery-control-search flex flex-wrap items-center gap-2">
+                      <span className="text-muted-foreground text-sm">Search for tags:</span>
                       <input
-                        className="form-control form-control-sm bg-dark text-light border-secondary gallery-control-search-input"
+                        className="form-control form-control-sm bg-background text-foreground border-secondary gallery-control-search-input"
                         placeholder="Filter by tags (space or comma separated)"
                         value={galleryTagInput}
                         onChange={(event) => setGalleryTagInput(event.target.value)}
@@ -3615,10 +3622,10 @@ function App() {
                       ) : null}
                     </div>
                     <span className="gallery-control-separator" aria-hidden="true" />
-                    <div className="gallery-control-group d-flex align-items-center gap-2">
-                      <span className="text-secondary small">Folder:</span>
+                    <div className="gallery-control-group flex items-center gap-2">
+                      <span className="text-muted-foreground text-sm">Folder:</span>
                       <select
-                        className="form-select form-select-sm bg-dark text-light border-secondary gallery-folder-select"
+                        className="form-select form-select-sm bg-background text-foreground border-secondary gallery-folder-select"
                         value={galleryFolderId}
                         onChange={(event) => setGalleryFolderId(event.target.value)}
                       >
@@ -3634,8 +3641,8 @@ function App() {
                       </select>
                     </div>
                     <span className="gallery-control-separator" aria-hidden="true" />
-                    <div className="gallery-control-group d-flex align-items-center gap-2">
-                      <span className="text-secondary small">Order by:</span>
+                    <div className="gallery-control-group flex items-center gap-2">
+                      <span className="text-muted-foreground text-sm">Order by:</span>
                       <div className="btn-group btn-group-sm" role="group">
                         <button
                           className={`btn btn-${gallerySort === 'manual' ? 'primary' : 'outline-light'}`}
@@ -3664,8 +3671,8 @@ function App() {
                       </div>
                     </div>
                     <span className="gallery-control-separator" aria-hidden="true" />
-                    <div className="gallery-control-group d-flex align-items-center gap-2">
-                      <span className="text-secondary small">Filters:</span>
+                    <div className="gallery-control-group flex items-center gap-2">
+                      <span className="text-muted-foreground text-sm">Filters:</span>
                       <div className="dropdown" ref={galleryFilterRef}>
                         <button
                           className="btn btn-outline-light btn-sm dropdown-toggle"
@@ -3675,7 +3682,7 @@ function App() {
                         >
                           {galleryFilterLabel}
                         </button>
-                        <div className={`dropdown-menu dropdown-menu-dark p-3${isGalleryFilterOpen ? ' show' : ''}`}>
+                        <div className={`dropdown-menu dropdown-menu-dark p-6${isGalleryFilterOpen ? ' show' : ''}`}>
                           <div className="form-check mb-2">
                             <input
                               className="form-check-input"
@@ -3722,16 +3729,16 @@ function App() {
                       </div>
                     </div>
                     <span className="gallery-control-separator" aria-hidden="true" />
-                    <div className="gallery-control-group ms-auto">
-                      <span className="text-secondary small">{galleryCountText} items</span>
+                    <div className="gallery-control-group ml-auto">
+                      <span className="text-muted-foreground text-sm">{galleryCountText} items</span>
                     </div>
                   </div>
-                  <hr className="border-secondary my-3" />
+                  <hr className="border-secondary my-6" />
                   {galleryPageState.error ? (
-                    <div className="text-danger small mb-2">Gallery: {galleryPageState.error}</div>
+                    <div className="text-destructive text-sm mb-2">Gallery: {galleryPageState.error}</div>
                   ) : null}
                   {galleryFiles.length === 0 ? (
-                    <p className="text-secondary">
+                    <p className="text-muted-foreground">
                       {galleryPageState.loading
                         ? 'Loading files…'
                         : selectedGalleryFolder
@@ -3745,7 +3752,7 @@ function App() {
                           return (
                             <div key={file.id} className="col">
                               <div
-                                className={`gallery-card h-100${gallerySort === 'manual' ? ' gallery-item-manual' : ''}${
+                                className={`gallery-card h-full${gallerySort === 'manual' ? ' gallery-item-manual' : ''}${
                                   draggingId === file.id ? ' gallery-item-dragging' : ''
                                 }${dragOverId === file.id && draggingId !== file.id ? ' gallery-item-drop-target' : ''}`}
                                 role="button"
@@ -3805,13 +3812,13 @@ function App() {
                                   />
                                 ) : (
                                   <div
-                                    className="mb-2 rounded d-flex align-items-center justify-content-center bg-dark"
+                                    className="mb-2 rounded flex items-center justify-center bg-background"
                                     style={{ height: 220 }}
                                   >
-                                    <span className="text-secondary small">{file.mediaType.toLowerCase()}</span>
+                                    <span className="text-muted-foreground text-sm">{file.mediaType.toLowerCase()}</span>
                                   </div>
                                 )}
-                                <div className="text-secondary small">
+                                <div className="text-muted-foreground text-sm">
                                   {file.durationMs ? `${(file.durationMs / 1000).toFixed(1)}s` : ''}
                                 </div>
                               </div>
@@ -3820,7 +3827,7 @@ function App() {
                         })}
                       </div>
                       {galleryHasMore ? (
-                        <div className="d-flex justify-content-center mt-3">
+                        <div className="flex justify-center mt-6">
                           <button
                             className="btn btn-outline-light btn-sm"
                             onClick={() => void loadGalleryPage()}
@@ -3855,7 +3862,7 @@ function App() {
             style={{ transform: `translate3d(calc(-100% + ${detailSwipeOffset}px), 0, 0)` }}
           >
             {renderNeighborPreview(prevLoadedFile, 'prev')}
-            <div className={`file-detail-panel file-detail-panel-current file-detail-layer text-light${selectedFile.mediaType === 'VIDEO' ? ' is-video' : ''}`}>
+            <div className={`file-detail-panel file-detail-panel-current file-detail-layer text-foreground${selectedFile.mediaType === 'VIDEO' ? ' is-video' : ''}`}>
               <div className="container file-detail-back-bar">
                 <button className="file-detail-back-btn" onClick={closeFile}>
                   <svg className="file-detail-back-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -3863,7 +3870,7 @@ function App() {
                   </svg>
                   Back to gallery
                 </button>
-                <div className="d-flex align-items-center gap-2 ms-auto file-detail-sequence-controls">
+                <div className="flex items-center gap-2 ml-auto file-detail-sequence-controls">
                   <button
                     className="btn btn-outline-secondary btn-sm"
                     onClick={() => goRelative(-1)}
@@ -3931,9 +3938,9 @@ function App() {
                 </button>
               </div>
               <div className="container file-detail-body">
-            <div className="file-detail-section mb-3">
+            <div className="file-detail-section mb-6">
               <div className="file-detail-section-head">
-                <div className="text-uppercase fw-semibold file-detail-section-title file-detail-section-title-accent">
+                <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
                   File info
                 </div>
                 <div className="file-detail-section-actions">
@@ -4021,27 +4028,27 @@ function App() {
                   </button>
                 </div>
               </div>
-              <div className="text-secondary small">
-                <span className="fw-semibold file-detail-label">File name:</span> {selectedFileName}
+              <div className="text-muted-foreground text-sm">
+                <span className="font-semibold file-detail-label">File name:</span> {selectedFileName}
                 <br />
                 {selectedFile.durationMs ? `${(selectedFile.durationMs / 1000).toFixed(1)}s` : ''}
                 {selectedFile.durationMs ? <br /> : null}
-                <span className="fw-semibold file-detail-label">Type:</span> {selectedFileType}
+                <span className="font-semibold file-detail-label">Type:</span> {selectedFileType}
                 <br />
-                <span className="fw-semibold file-detail-label">Size:</span>{' '}
+                <span className="font-semibold file-detail-label">Size:</span>{' '}
                 {(selectedFile.sizeBytes / 1024 / 1024).toFixed(2)} MB
                 {selectedFile.width && selectedFile.height ? ` (${selectedFile.width}×${selectedFile.height})` : ''}
                 <br />
-                <span className="fw-semibold file-detail-label">Modified:</span> {formatDateTime(selectedFile.mtime)}
+                <span className="font-semibold file-detail-label">Modified:</span> {formatDateTime(selectedFile.mtime)}
               </div>
             </div>
             <div className="file-detail-section-divider" />
-            <div className="file-detail-tags file-detail-section mb-3">
-              <div className="d-flex justify-content-between align-items-center mb-2">
-                <div className="text-uppercase fw-semibold file-detail-section-title file-detail-section-title-accent">
+            <div className="file-detail-tags file-detail-section mb-6">
+              <div className="flex justify-between items-center mb-2">
+                <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
                   Tags
                 </div>
-                <div className="d-flex gap-2">
+                <div className="flex gap-2">
                   <button
                     className={`btn btn-outline-light btn-sm file-detail-refresh-button file-detail-icon-button${
                       tagState.loading ? ' is-loading' : ''
@@ -4067,9 +4074,9 @@ function App() {
                   </button>
                 </div>
               </div>
-              <div className="d-flex flex-wrap gap-2 align-items-center mb-2">
+              <div className="flex flex-wrap gap-2 items-center mb-2">
                 <input
-                  className="form-control form-control-sm bg-dark text-light border-secondary"
+                  className="form-control form-control-sm bg-background text-foreground border-secondary"
                   style={{ maxWidth: 220 }}
                   placeholder="Add tag"
                   value={manualTagInput}
@@ -4082,7 +4089,7 @@ function App() {
                   }}
                 />
                 <select
-                  className="form-select form-select-sm bg-dark text-light border-secondary"
+                  className="form-select form-select-sm bg-background text-foreground border-secondary"
                   style={{ maxWidth: 160 }}
                   value={manualTagCategory}
                   onChange={(event) => setManualTagCategory(event.target.value)}
@@ -4100,30 +4107,30 @@ function App() {
                   Add
                 </button>
               </div>
-              {tagState.error ? <div className="text-danger small mb-2">{tagState.error}</div> : null}
-              {tagState.loading ? <div className="text-secondary small mb-2">Updating tags…</div> : null}
+              {tagState.error ? <div className="text-destructive text-sm mb-2">{tagState.error}</div> : null}
+              {tagState.loading ? <div className="text-muted-foreground text-sm mb-2">Updating tags…</div> : null}
               {tagGroups.length === 0 ? (
-                <div className="text-secondary small">No tags yet.</div>
+                <div className="text-muted-foreground text-sm">No tags yet.</div>
               ) : (
                 tagGroups.map((group) => (
                   <div key={group.category} className="mb-2">
-                    <div className="small fw-semibold text-uppercase mb-1 file-detail-subtitle">
+                    <div className="text-sm font-semibold uppercase mb-1 file-detail-subtitle">
                       {group.category}
                     </div>
-                    <div className="d-flex flex-wrap gap-2">
+                    <div className="flex flex-wrap gap-2">
                       {group.tags.map((tag) => {
                         const sources = Array.from(tag.sources).join(', ');
                         const scoreText = tag.score !== null ? `score ${tag.score}` : 'score n/a';
                         return (
                           <span
                             key={`${group.category}-${tag.tag}`}
-                            className="badge bg-secondary text-light file-tag-pill"
+                            className="badge bg-secondary text-foreground file-tag-pill"
                             title={`${sources} • ${scoreText}`}
                           >
                             {tag.tag}
                             {tag.hasManual ? (
                               <button
-                                className="btn btn-link btn-sm p-0 ms-2 text-light file-tag-remove"
+                                className="btn btn-link btn-sm p-0 ml-2 text-foreground file-tag-remove"
                                 onClick={() => void removeManualTag(tag.tag, group.category)}
                                 aria-label={`Remove ${tag.tag}`}
                               >
@@ -4137,14 +4144,14 @@ function App() {
                   </div>
                 ))
               )}
-              <div className="text-secondary small mt-2">
+              <div className="text-muted-foreground text-sm mt-2">
                 <span className="file-detail-label">Sources:</span> {tagSourceSummary}
               </div>
             </div>
             <div className="file-detail-section-divider" />
-            <div className="file-detail-section mb-3">
+            <div className="file-detail-section mb-6">
               <div className="file-detail-section-head">
-                <div className="text-uppercase fw-semibold file-detail-section-title file-detail-section-title-accent">
+                <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
                   Sauces
                 </div>
                 <button
@@ -4169,35 +4176,35 @@ function App() {
                   <span className="file-detail-button-text">Scan</span>
                 </button>
               </div>
-              <div className="text-secondary small mb-3">
+              <div className="text-muted-foreground text-sm mb-6">
                 <div>
-                  <span className="fw-semibold file-detail-label">Provider scans:</span>{' '}
+                  <span className="font-semibold file-detail-label">Provider scans:</span>{' '}
                   {providerMeta?.hasRuns ? `last run ${formatDateTime(providerMeta.latestRunAt)}` : 'never run yet'}
                 </div>
                 {providerMeta?.missingProviders.length ? (
                   <div>
-                    <span className="fw-semibold file-detail-label">Missing:</span>{' '}
+                    <span className="font-semibold file-detail-label">Missing:</span>{' '}
                     {providerMeta.missingProviders.join(', ')}
                   </div>
                 ) : null}
                 <div>
-                  <span className="fw-semibold file-detail-label">Next auto-scan:</span> {nextAutoScanText}
+                  <span className="font-semibold file-detail-label">Next auto-scan:</span> {nextAutoScanText}
                 </div>
               </div>
             </div>
-            {providerState.error ? <div className="text-danger small mb-2">{providerState.error}</div> : null}
-            {favoriteState.error ? <div className="text-danger small mb-2">{favoriteState.error}</div> : null}
-            {deleteState.error ? <div className="text-danger small mb-2">{deleteState.error}</div> : null}
-            <div className="file-detail-topmatches mb-3">
+            {providerState.error ? <div className="text-destructive text-sm mb-2">{providerState.error}</div> : null}
+            {favoriteState.error ? <div className="text-destructive text-sm mb-2">{favoriteState.error}</div> : null}
+            {deleteState.error ? <div className="text-destructive text-sm mb-2">{deleteState.error}</div> : null}
+            <div className="file-detail-topmatches mb-6">
               {matchRemoveState.error ? (
-                <div className="text-danger small mb-2">{matchRemoveState.error}</div>
+                <div className="text-destructive text-sm mb-2">{matchRemoveState.error}</div>
               ) : null}
               {providerHighlights.length ? (
                 <div className="file-detail-topmatches-list">
                   {providerHighlights.map((item) => (
                     <a
                       key={item.id}
-                      className="file-detail-topmatches-card text-decoration-none border border-secondary rounded p-2 bg-dark text-light"
+                      className="file-detail-topmatches-card text-decoration-none border border-secondary rounded p-2 bg-background text-foreground"
                       href={item.sourceUrl}
                       target="_blank"
                       rel="noreferrer"
@@ -4215,11 +4222,11 @@ function App() {
                       >
                         ×
                       </button>
-                      <div className="text-secondary small">{item.provider}</div>
-                      <div className="fw-semibold text-truncate" title={item.sourceName}>
+                      <div className="text-muted-foreground text-sm">{item.provider}</div>
+                      <div className="font-semibold truncate" title={item.sourceName}>
                         {item.sourceName}
                       </div>
-                      <div className="text-secondary small">
+                      <div className="text-muted-foreground text-sm">
                         {(() => {
                           const value = item.score;
                           const label = 'score';
@@ -4230,7 +4237,7 @@ function App() {
                   ))}
                 </div>
               ) : (
-                <div className="text-secondary small">
+                <div className="text-muted-foreground text-sm">
                   {!providerMeta?.hasRuns
                     ? 'No scan results yet.'
                     : displayFilterActive

--- a/frontend/src/BooruSitesPanel.tsx
+++ b/frontend/src/BooruSitesPanel.tsx
@@ -308,11 +308,11 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
         </div>
       ) : null}
 
-      <h5 className="mt-3 text-light">Configured booru sources</h5>
+      <h5 className="mt-6 text-foreground">Configured booru sources</h5>
       {sites.length === 0 ? (
-        <p className="text-secondary small">No sites configured. Add one below to enable favorites sync and tag fetch.</p>
+        <p className="text-muted-foreground text-sm">No sites configured. Add one below to enable favorites sync and tag fetch.</p>
       ) : (
-        <div className="mb-4 d-flex flex-column gap-2">
+        <div className="mb-6 flex flex-col gap-2">
           {[...sites]
             .sort((a, b) => a.sortOrder - b.sortOrder)
             .map((site) => {
@@ -321,14 +321,14 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
               const test = testResults[site.id];
               const edit = editCredentials[site.id] ?? { username: '', apiKey: '' };
               return (
-                <div key={site.id} className="border border-secondary rounded p-2 text-light">
-                  <div className="d-flex align-items-center gap-2">
-                    <div className="flex-grow-1">
+                <div key={site.id} className="border border-secondary rounded p-2 text-foreground">
+                  <div className="flex items-center gap-2">
+                    <div className="grow">
                       <strong>{site.name}</strong>{' '}
-                      <small className="text-secondary">
+                      <text-sm className="text-muted-foreground">
                         {ENGINE_LABELS[site.engine]} · {site.baseUrl}
                         {site.isPreset ? ' · preset' : ''}
-                      </small>
+                      </text-sm>
                     </div>
                     <button
                       type="button"
@@ -354,7 +354,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
                         checked={site.enabled}
                         onChange={() => toggleEnabled(site)}
                       />
-                      <label className="form-check-label text-secondary small" htmlFor={`enabled-${site.id}`}>
+                      <label className="form-check-label text-muted-foreground text-sm" htmlFor={`enabled-${site.id}`}>
                         enabled
                       </label>
                     </div>
@@ -371,7 +371,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
                             checked={site[cap]}
                             onChange={() => toggleCapability(site, cap)}
                           />
-                          <label className="form-check-label text-secondary small" htmlFor={`${site.id}-${cap}`}>
+                          <label className="form-check-label text-muted-foreground text-sm" htmlFor={`${site.id}-${cap}`}>
                             {CAPABILITY_LABELS[cap]}
                           </label>
                         </div>
@@ -383,10 +383,10 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
                     <div className="row g-2 mt-2">
                       {fields.username ? (
                         <div className="col-md-4">
-                          <label className="form-label small mb-1 text-secondary">{fields.usernameLabel}</label>
+                          <label className="form-label text-sm mb-1 text-muted-foreground">{fields.usernameLabel}</label>
                           <input
                             type="text"
-                            className="form-control form-control-sm bg-dark text-light border-secondary"
+                            className="form-control form-control-sm bg-background text-foreground border-secondary"
                             value={edit.username}
                             onChange={(e: ChangeEvent<HTMLInputElement>) =>
                               setEditCredentials((prev) => ({
@@ -399,13 +399,13 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
                       ) : null}
                       {fields.apiKey ? (
                         <div className="col-md-4">
-                          <label className="form-label small mb-1 text-secondary">
+                          <label className="form-label text-sm mb-1 text-muted-foreground">
                             {fields.apiKeyLabel}
-                            {site.hasApiKey ? <span className="text-secondary"> · saved</span> : null}
+                            {site.hasApiKey ? <span className="text-muted-foreground"> · saved</span> : null}
                           </label>
                           <input
                             type="password"
-                            className="form-control form-control-sm bg-dark text-light border-secondary"
+                            className="form-control form-control-sm bg-background text-foreground border-secondary"
                             placeholder={site.hasApiKey ? '••••••••' : ''}
                             value={edit.apiKey}
                             onChange={(e: ChangeEvent<HTMLInputElement>) =>
@@ -417,7 +417,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
                           />
                         </div>
                       ) : null}
-                      <div className="col-md-4 d-flex align-items-end gap-2">
+                      <div className="col-md-4 flex items-end gap-2">
                         <button
                           type="button"
                           className="btn btn-sm btn-outline-light"
@@ -449,14 +449,14 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
                   )}
 
                   {test ? (
-                    <div className={`small mt-2 ${test.ok ? 'text-success' : 'text-danger'}`}>
+                    <div className={`text-sm mt-2 ${test.ok ? 'text-success' : 'text-destructive'}`}>
                       {test.ok ? '✓ ' : '✗ '} {test.message}
                     </div>
                   ) : null}
 
                   {!site.isPreset ? (
                     <div className="mt-2">
-                      <button type="button" className="btn btn-sm btn-link text-danger" onClick={() => deleteSite(site)}>
+                      <button type="button" className="btn btn-sm btn-link text-destructive" onClick={() => deleteSite(site)}>
                         Delete site
                       </button>
                     </div>
@@ -467,16 +467,16 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
         </div>
       )}
 
-      <h5 className="mt-4 text-light">Add custom booru site</h5>
+      <h5 className="mt-6 text-foreground">Add custom booru site</h5>
       <form onSubmit={submitNewSite} className="row g-2">
         <div className="col-md-6">
-          <label htmlFor="booru-name" className="form-label small mb-1 text-secondary">
+          <label htmlFor="booru-name" className="form-label text-sm mb-1 text-muted-foreground">
             Name
           </label>
           <input
             id="booru-name"
             type="text"
-            className="form-control form-control-sm bg-dark text-light border-secondary"
+            className="form-control form-control-sm bg-background text-foreground border-secondary"
             value={addForm.name}
             onChange={(e) => setAddForm((prev) => ({ ...prev, name: e.target.value }))}
             placeholder="My booru"
@@ -484,7 +484,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
           />
         </div>
         <div className="col-md-6">
-          <label htmlFor="booru-url" className="form-label small mb-1 text-secondary">
+          <label htmlFor="booru-url" className="form-label text-sm mb-1 text-muted-foreground">
             Base URL
           </label>
           {/* type=text (not url) so the browser accepts "gelbooru.com" while
@@ -494,7 +494,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
           <input
             id="booru-url"
             type="text"
-            className="form-control form-control-sm bg-dark text-light border-secondary"
+            className="form-control form-control-sm bg-background text-foreground border-secondary"
             value={addForm.baseUrl}
             onChange={(e) => onUrlChange(e.target.value)}
             onBlur={(e) => {
@@ -510,23 +510,23 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
         </div>
 
         {addForm.detecting ? (
-          <div className="col-12 text-secondary small">Detecting engine…</div>
+          <div className="col-12 text-muted-foreground text-sm">Detecting engine…</div>
         ) : null}
 
         {addForm.detection && 'engine' in addForm.detection ? (
           <div className="col-12">
-            <div className="d-flex align-items-center gap-2 flex-wrap">
+            <div className="flex items-center gap-2 flex-wrap">
               <span className="badge text-bg-success">
                 Detected: {ENGINE_LABELS[addForm.detection.engine]}
               </span>
               {devOptions ? (
-                <small className="text-secondary">
+                <text-sm className="text-muted-foreground">
                   via {addForm.detection.confidence === 'hostname' ? 'known hostname' : 'API probe'}
-                </small>
+                </text-sm>
               ) : null}
             </div>
             {addForm.detection.sample?.thumbUrl ? (
-              <div className="mt-2 d-flex align-items-start gap-2">
+              <div className="mt-2 flex items-start gap-2">
                 <a
                   href={addForm.detection.sample.postUrl}
                   target="_blank"
@@ -548,19 +548,19 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
 
         {addForm.detection && 'error' in addForm.detection ? (
           <div className="col-12">
-            <div className="alert alert-warning py-2 small mb-2">
+            <div className="alert alert-warning py-2 text-sm mb-2">
               {addForm.detection.error === 'unreachable'
                 ? `Site unreachable. ${addForm.detection.message}`
                 : 'Could not identify the engine for this site. It may run an unsupported booru engine, require login, or sit behind a CAPTCHA/anti-bot wall. Only recognized engines can be added.'}
             </div>
             {devOptions && addForm.detection.attempts?.length ? (
               <details className="mb-2" open>
-                <summary className="text-secondary small">
+                <summary className="text-muted-foreground text-sm">
                   Probe attempts ({addForm.detection.attempts.length})
                 </summary>
-                <table className="table table-sm table-dark table-borderless mt-2 mb-0 small">
+                <table className="table table-sm table-dark table-borderless mt-2 mb-0 text-sm">
                   <thead>
-                    <tr className="text-secondary">
+                    <tr className="text-muted-foreground">
                       <th scope="col">Engine</th>
                       <th scope="col">Status</th>
                       <th scope="col">HTTP</th>
@@ -577,7 +577,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
                               attempt.status === 'matched'
                                 ? 'text-success'
                                 : attempt.status === 'no-match'
-                                  ? 'text-secondary'
+                                  ? 'text-muted-foreground'
                                   : 'text-warning'
                             }
                           >
@@ -585,7 +585,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
                           </span>
                         </td>
                         <td>{attempt.httpStatus ?? '—'}</td>
-                        <td className="text-secondary">{attempt.error ?? ''}</td>
+                        <td className="text-muted-foreground">{attempt.error ?? ''}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -599,12 +599,12 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
           <>
             {credentialFieldsForSchema(detectedSchema).username ? (
               <div className="col-md-6">
-                <label className="form-label small mb-1">
+                <label className="form-label text-sm mb-1">
                   {credentialFieldsForSchema(detectedSchema).usernameLabel}
                 </label>
                 <input
                   type="text"
-                  className="form-control form-control-sm bg-dark text-light border-secondary"
+                  className="form-control form-control-sm bg-background text-foreground border-secondary"
                   value={addForm.username}
                   onChange={(e) => setAddForm((prev) => ({ ...prev, username: e.target.value }))}
                 />
@@ -612,12 +612,12 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
             ) : null}
             {credentialFieldsForSchema(detectedSchema).apiKey ? (
               <div className="col-md-6">
-                <label className="form-label small mb-1">
+                <label className="form-label text-sm mb-1">
                   {credentialFieldsForSchema(detectedSchema).apiKeyLabel}
                 </label>
                 <input
                   type="password"
-                  className="form-control form-control-sm bg-dark text-light border-secondary"
+                  className="form-control form-control-sm bg-background text-foreground border-secondary"
                   value={addForm.apiKey}
                   onChange={(e) => setAddForm((prev) => ({ ...prev, apiKey: e.target.value }))}
                 />
@@ -625,7 +625,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
             ) : null}
 
             <div className="col-12 mt-2">
-              <small className="text-muted d-block mb-1">Capabilities</small>
+              <text-sm className="text-muted-foreground block mb-1">Capabilities</text-sm>
               <div className="row g-2">
                 {(Object.keys(CAPABILITY_LABELS) as CapabilityKey[]).map((cap) => (
                   <div key={cap} className="col-6 col-md-3">
@@ -642,7 +642,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
                           }))
                         }
                       />
-                      <label className="form-check-label text-secondary small" htmlFor={`new-${cap}`}>
+                      <label className="form-check-label text-muted-foreground text-sm" htmlFor={`new-${cap}`}>
                         {CAPABILITY_LABELS[cap]}
                       </label>
                     </div>
@@ -653,9 +653,9 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
           </>
         ) : null}
 
-        {addForm.detectError ? <div className="col-12 text-danger small">{addForm.detectError}</div> : null}
+        {addForm.detectError ? <div className="col-12 text-destructive text-sm">{addForm.detectError}</div> : null}
 
-        <div className="col-12 d-flex gap-2 mt-2">
+        <div className="col-12 flex gap-2 mt-2">
           <button type="submit" className="btn btn-sm btn-outline-light" disabled={addingBusy || !detectedEngine}>
             {addingBusy ? 'Adding…' : 'Add site'}
           </button>

--- a/frontend/src/BooruSitesPanel.tsx
+++ b/frontend/src/BooruSitesPanel.tsx
@@ -308,7 +308,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
         </div>
       ) : null}
 
-      <h5 className="mt-6 text-foreground">Configured booru sources</h5>
+      <h5 className="mt-4 text-foreground">Configured booru sources</h5>
       {sites.length === 0 ? (
         <p className="text-muted-foreground text-sm">No sites configured. Add one below to enable favorites sync and tag fetch.</p>
       ) : (

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,13 +1,397 @@
-html,
-body,
-#root {
-  height: 100%;
-  background: #1f2327;
-}
+@reference "./index.css";
 
-body {
-  margin: 0;
-  background: #1f2327;
+/* Custom selectors complementing Tailwind utilities. Class names preserved
+   so JSX can keep `className="gallery-card"`, etc. */
+
+/* === Bootstrap compatibility shim ===
+   Lets legacy class names (btn, card, form-control, row, col-*, table, ...)
+   keep rendering without bringing Bootstrap CSS along. Each rule maps to
+   Tailwind utilities via @apply so the design tokens come from index.css. */
+@layer components {
+  /* Buttons */
+  .btn {
+    @apply inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium
+      h-9 px-4 py-2 transition-colors
+      focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+      disabled:opacity-50 disabled:pointer-events-none;
+  }
+  .btn-sm {
+    @apply h-8 px-3 text-xs;
+  }
+  .btn-lg {
+    @apply h-10 px-6;
+  }
+  .btn-primary {
+    @apply bg-primary text-primary-foreground hover:bg-primary/90;
+  }
+  .btn-secondary {
+    @apply bg-secondary text-secondary-foreground hover:bg-secondary/80;
+  }
+  .btn-success {
+    @apply bg-success text-success-foreground hover:bg-success/90;
+  }
+  .btn-danger {
+    @apply bg-destructive text-destructive-foreground hover:bg-destructive/90;
+  }
+  .btn-warning {
+    @apply bg-warning text-warning-foreground hover:bg-warning/90;
+  }
+  .btn-info {
+    @apply bg-primary text-primary-foreground hover:bg-primary/90;
+  }
+  .btn-light {
+    @apply bg-secondary text-secondary-foreground hover:bg-secondary/80;
+  }
+  .btn-dark {
+    @apply bg-background text-foreground hover:bg-background/90;
+  }
+  .btn-link {
+    @apply text-primary underline-offset-4 hover:underline bg-transparent border-0 h-auto p-0;
+  }
+  .btn-outline-primary {
+    @apply border border-primary text-primary hover:bg-primary hover:text-primary-foreground;
+  }
+  .btn-outline-secondary {
+    @apply border border-input text-foreground hover:bg-accent hover:text-accent-foreground;
+  }
+  .btn-outline-success {
+    @apply border border-success text-success hover:bg-success hover:text-success-foreground;
+  }
+  .btn-outline-danger {
+    @apply border border-destructive text-destructive hover:bg-destructive hover:text-destructive-foreground;
+  }
+  .btn-outline-warning {
+    @apply border border-warning text-warning hover:bg-warning hover:text-warning-foreground;
+  }
+  .btn-outline-info {
+    @apply border border-primary text-primary hover:bg-primary hover:text-primary-foreground;
+  }
+  .btn-outline-light {
+    @apply border border-input text-foreground hover:bg-accent hover:text-accent-foreground;
+  }
+  .btn-outline-dark {
+    @apply border border-foreground text-foreground hover:bg-foreground hover:text-background;
+  }
+  .btn-group {
+    @apply inline-flex items-center;
+  }
+  .btn-group > .btn {
+    @apply rounded-none border-l-0;
+  }
+  .btn-group > .btn:first-child {
+    @apply rounded-l-md border-l;
+  }
+  .btn-group > .btn:last-child {
+    @apply rounded-r-md;
+  }
+  .btn-group-sm > .btn {
+    @apply h-8 px-3 text-xs;
+  }
+
+  /* Cards */
+  .card {
+    @apply rounded-lg border bg-card text-card-foreground shadow-sm;
+  }
+  .card-body {
+    @apply p-4;
+  }
+  .card-header {
+    @apply border-b px-4 py-3 font-medium;
+  }
+  .card-footer {
+    @apply border-t px-4 py-3;
+  }
+  .card-title {
+    @apply text-lg font-semibold leading-none tracking-tight;
+  }
+  .card-text {
+    @apply text-sm leading-relaxed;
+  }
+
+  /* Forms */
+  .form-control {
+    @apply flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs
+      transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium
+      placeholder:text-muted-foreground
+      focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring
+      disabled:cursor-not-allowed disabled:opacity-50;
+  }
+  .form-control-sm {
+    @apply h-8 text-xs px-2.5;
+  }
+  .form-control-lg {
+    @apply h-10 text-base px-4;
+  }
+  textarea.form-control {
+    @apply h-auto min-h-[80px] py-2;
+  }
+  .form-label {
+    @apply block text-sm font-medium leading-none mb-1;
+  }
+  .form-select {
+    @apply flex h-9 w-full items-center rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs
+      focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring
+      disabled:cursor-not-allowed disabled:opacity-50;
+  }
+  .form-select-sm {
+    @apply h-8 text-xs;
+  }
+  .form-check {
+    @apply relative flex items-center gap-2 min-h-[1.5rem];
+  }
+  .form-check-input {
+    @apply h-4 w-4 rounded border border-input bg-transparent
+      checked:bg-primary checked:border-primary
+      focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+      disabled:cursor-not-allowed disabled:opacity-50;
+  }
+  .form-check-input[type='radio'] {
+    @apply rounded-full;
+  }
+  .form-check-label {
+    @apply text-sm leading-none;
+  }
+  .form-switch {
+    @apply pl-10;
+  }
+  .form-switch .form-check-input {
+    @apply h-5 w-9 rounded-full bg-input border-0 appearance-none cursor-pointer
+      relative -ml-10 transition-colors checked:bg-primary;
+  }
+  .form-switch .form-check-input::before {
+    content: '';
+    @apply absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-background transition-transform;
+  }
+  .form-switch .form-check-input:checked::before {
+    @apply translate-x-4;
+  }
+  .input-group {
+    @apply inline-flex items-stretch w-full;
+  }
+  .input-group > .form-control,
+  .input-group > .form-select,
+  .input-group > .btn {
+    @apply rounded-none;
+  }
+  .input-group > :first-child {
+    @apply rounded-l-md;
+  }
+  .input-group > :last-child {
+    @apply rounded-r-md;
+  }
+  .input-group-text {
+    @apply inline-flex items-center px-3 text-sm bg-muted text-muted-foreground border border-input;
+  }
+
+  /* Grid */
+  .row {
+    @apply flex flex-wrap -mx-2;
+  }
+  .row > [class^='col'],
+  .row > [class*=' col'] {
+    @apply px-2;
+  }
+  .col {
+    @apply flex-1 min-w-0;
+  }
+  .col-auto {
+    @apply flex-none w-auto;
+  }
+  .col-1 { @apply w-[8.333%]; }
+  .col-2 { @apply w-[16.666%]; }
+  .col-3 { @apply w-[25%]; }
+  .col-4 { @apply w-[33.333%]; }
+  .col-5 { @apply w-[41.666%]; }
+  .col-6 { @apply w-[50%]; }
+  .col-7 { @apply w-[58.333%]; }
+  .col-8 { @apply w-[66.666%]; }
+  .col-9 { @apply w-[75%]; }
+  .col-10 { @apply w-[83.333%]; }
+  .col-11 { @apply w-[91.666%]; }
+  .col-12 { @apply w-full; }
+
+  @media (min-width: 768px) {
+    .col-md-1 { @apply w-[8.333%]; }
+    .col-md-2 { @apply w-[16.666%]; }
+    .col-md-3 { @apply w-[25%]; }
+    .col-md-4 { @apply w-[33.333%]; }
+    .col-md-5 { @apply w-[41.666%]; }
+    .col-md-6 { @apply w-[50%]; }
+    .col-md-7 { @apply w-[58.333%]; }
+    .col-md-8 { @apply w-[66.666%]; }
+    .col-md-9 { @apply w-[75%]; }
+    .col-md-10 { @apply w-[83.333%]; }
+    .col-md-11 { @apply w-[91.666%]; }
+    .col-md-12 { @apply w-full; }
+  }
+  @media (min-width: 1024px) {
+    .col-lg-1 { @apply w-[8.333%]; }
+    .col-lg-2 { @apply w-[16.666%]; }
+    .col-lg-3 { @apply w-[25%]; }
+    .col-lg-4 { @apply w-[33.333%]; }
+    .col-lg-5 { @apply w-[41.666%]; }
+    .col-lg-6 { @apply w-[50%]; }
+    .col-lg-12 { @apply w-full; }
+  }
+
+  .g-0 { @apply gap-0; }
+  .g-1 { @apply gap-1; }
+  .g-2 { @apply gap-2; }
+  .g-3 { @apply gap-4; }
+  .g-4 { @apply gap-6; }
+  .g-5 { @apply gap-12; }
+  .gx-0 { @apply gap-x-0; }
+  .gx-1 { @apply gap-x-1; }
+  .gx-2 { @apply gap-x-2; }
+  .gx-3 { @apply gap-x-4; }
+  .gy-0 { @apply gap-y-0; }
+  .gy-1 { @apply gap-y-1; }
+  .gy-2 { @apply gap-y-2; }
+  .gy-3 { @apply gap-y-4; }
+
+  /* Badges */
+  .badge {
+    @apply inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium;
+  }
+  .badge.bg-primary { @apply bg-primary text-primary-foreground; }
+  .badge.bg-secondary { @apply bg-secondary text-secondary-foreground; }
+  .badge.bg-success { @apply bg-success text-success-foreground; }
+  .badge.bg-danger { @apply bg-destructive text-destructive-foreground; }
+  .badge.bg-warning { @apply bg-warning text-warning-foreground; }
+  .badge.bg-info { @apply bg-primary text-primary-foreground; }
+  .badge.bg-light { @apply bg-secondary text-secondary-foreground; }
+  .badge.bg-dark { @apply bg-background text-foreground; }
+
+  /* Alerts */
+  .alert {
+    @apply rounded-md border px-4 py-3 text-sm;
+  }
+  .alert-primary { @apply border-primary/50 bg-primary/10 text-primary; }
+  .alert-secondary { @apply border-input bg-secondary/40 text-foreground; }
+  .alert-success { @apply border-success/50 bg-success/10 text-success; }
+  .alert-danger { @apply border-destructive/50 bg-destructive/10 text-destructive; }
+  .alert-warning { @apply border-warning/50 bg-warning/10 text-warning; }
+  .alert-info { @apply border-primary/50 bg-primary/10 text-primary; }
+
+  /* Progress */
+  .progress {
+    @apply relative h-2 w-full overflow-hidden rounded-full bg-secondary;
+  }
+  .progress-bar {
+    @apply h-full bg-primary transition-all flex items-center justify-center text-xs text-primary-foreground;
+  }
+  .progress-bar-striped {
+    background-image: linear-gradient(
+      45deg,
+      rgba(255, 255, 255, 0.15) 25%,
+      transparent 25%,
+      transparent 50%,
+      rgba(255, 255, 255, 0.15) 50%,
+      rgba(255, 255, 255, 0.15) 75%,
+      transparent 75%,
+      transparent
+    );
+    background-size: 1rem 1rem;
+  }
+  .progress-bar-animated {
+    animation: progress-bar-stripes 1s linear infinite;
+  }
+  @keyframes progress-bar-stripes {
+    from { background-position: 1rem 0; }
+    to { background-position: 0 0; }
+  }
+
+  /* Tables */
+  .table {
+    @apply w-full text-sm border-collapse;
+  }
+  .table > :not(caption) > * > * {
+    @apply px-2 py-2 border-b border-border;
+  }
+  .table-sm > :not(caption) > * > * {
+    @apply px-1 py-1;
+  }
+  .table-borderless > :not(caption) > * > * {
+    @apply border-0;
+  }
+  .table-responsive {
+    @apply w-full overflow-x-auto;
+  }
+  .table-dark {
+    @apply text-foreground;
+  }
+
+  /* List group */
+  .list-group {
+    @apply flex flex-col rounded-md border;
+  }
+  .list-group-item {
+    @apply px-3 py-2 border-b last:border-b-0 text-sm;
+  }
+
+  /* Dropdown menu (basic visual; behavior unchanged from existing code) */
+  .dropdown {
+    @apply relative inline-block;
+  }
+  .dropdown-toggle {
+    @apply inline-flex items-center gap-1;
+  }
+  .dropdown-menu {
+    @apply absolute z-50 min-w-[10rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md;
+  }
+  .dropdown-item {
+    @apply block w-full select-none rounded-sm px-2 py-1.5 text-sm outline-none
+      hover:bg-accent hover:text-accent-foreground cursor-pointer;
+  }
+
+  /* Modal (legacy; new code should use shadcn Dialog) */
+  .modal-backdrop {
+    @apply fixed inset-0 z-40 bg-black/50;
+  }
+  .modal {
+    @apply fixed inset-0 z-50 flex items-center justify-center;
+  }
+  .modal-dialog {
+    @apply w-full max-w-lg mx-4;
+  }
+  .modal-content {
+    @apply relative flex flex-col rounded-lg border bg-card text-card-foreground shadow-lg;
+  }
+  .modal-header {
+    @apply flex items-center justify-between border-b px-4 py-3;
+  }
+  .modal-body {
+    @apply p-4;
+  }
+  .modal-footer {
+    @apply flex justify-end gap-2 border-t px-4 py-3;
+  }
+
+  /* Navbar / nav (legacy minimal) */
+  .navbar {
+    @apply flex items-center px-4 py-2 bg-card;
+  }
+  .navbar-brand {
+    @apply mr-4 font-semibold;
+  }
+  .nav {
+    @apply flex flex-wrap;
+  }
+  .nav-link {
+    @apply px-3 py-2 text-sm hover:text-foreground;
+  }
+
+  /* Spinner */
+  .spinner-border {
+    @apply inline-block h-5 w-5 rounded-full border-2 border-current border-r-transparent animate-spin;
+  }
+  .spinner-border-sm {
+    @apply h-4 w-4 border-2;
+  }
+  .visually-hidden {
+    @apply absolute w-px h-px p-0 -m-px overflow-hidden whitespace-nowrap;
+    clip: rect(0, 0, 0, 0);
+  }
 }
 
 .page-shell {
@@ -74,28 +458,20 @@ body {
   align-self: stretch;
 }
 
-.settings-sections {
-  --bs-gutter-x: 0;
-  --bs-gutter-y: 0;
-}
-
-.settings-section {
-  margin-top: 0 !important;
-}
-
 .settings-section + .settings-section {
-  margin-top: 1.25rem !important;
+  margin-top: 1.25rem;
   padding-top: 1.25rem;
   border-top: 1px solid rgba(255, 255, 255, 0.12);
 }
 
-.settings-section-card {
+.settings-section-card,
+.content-shell-card {
   background: transparent !important;
   border: 0 !important;
 }
 
-.settings-section-card > .card-body,
-.content-shell-card > .card-body {
+.settings-section-card [data-slot='card-content'],
+.content-shell-card [data-slot='card-content'] {
   padding: 0;
 }
 
@@ -113,13 +489,13 @@ body {
 
 .file-detail-page {
   min-height: 100vh;
-  background: #1f2327;
+  background: hsl(var(--background));
 }
 
 .file-detail-frame {
   width: 100%;
   overflow: hidden;
-  background: #1f2327;
+  background: hsl(var(--background));
   touch-action: pan-y pinch-zoom;
 }
 
@@ -163,7 +539,7 @@ body {
 
 .file-detail-preview-shell {
   min-height: 100vh;
-  background: #1f2327;
+  background: hsl(var(--background));
 }
 
 .file-detail-preview-label {
@@ -197,12 +573,12 @@ body {
 }
 
 .file-detail-layer {
-  background: #1f2327;
+  background: hsl(var(--background));
   width: 100%;
 }
 
 .file-detail-scroll {
-  background: #1f2327;
+  background: hsl(var(--background));
 }
 
 .file-detail-media-wrap {
@@ -433,7 +809,6 @@ body {
       rgba(0, 0, 0, 0)
     );
   }
-
 }
 
 @media (hover: none) and (pointer: coarse) {
@@ -473,12 +848,9 @@ body {
   flex-shrink: 0;
 }
 
-.file-detail-delete-icon {
-  width: 1.1rem;
-  height: 1.1rem;
-}
-
-.file-detail-download-icon {
+.file-detail-delete-icon,
+.file-detail-download-icon,
+.file-detail-favorite-icon {
   width: 1.1rem;
   height: 1.1rem;
 }
@@ -489,28 +861,13 @@ body {
 }
 
 .file-detail-favorite-button:hover,
-.file-detail-favorite-button:focus-visible {
-  background-color: #f6c45a;
-  border-color: #f6c45a;
-  color: #1f1b11;
-}
-
-.file-detail-favorite-button.is-favorite {
-  background-color: #f6c45a;
-  border-color: #f6c45a;
-  color: #1f1b11;
-}
-
+.file-detail-favorite-button:focus-visible,
+.file-detail-favorite-button.is-favorite,
 .file-detail-favorite-button.is-favorite:hover,
 .file-detail-favorite-button.is-favorite:focus-visible {
   background-color: #f6c45a;
   border-color: #f6c45a;
   color: #1f1b11;
-}
-
-.file-detail-favorite-icon {
-  width: 1.1rem;
-  height: 1.1rem;
 }
 
 .file-detail-favorite-icon-filled {
@@ -587,10 +944,7 @@ body {
   background: #f2b84b;
 }
 
-.file-detail-label {
-  color: #fff;
-}
-
+.file-detail-label,
 .file-detail-subtitle {
   color: #fff;
 }
@@ -670,10 +1024,6 @@ body {
   width: 100%;
   max-width: 400px;
   min-width: 0;
-}
-
-.credential-card .form-label {
-  margin-bottom: 0.25rem;
 }
 
 .credential-card {
@@ -821,7 +1171,7 @@ body {
 
 .folder-card-path {
   color: rgba(255, 255, 255, 0.62) !important;
-  font-family: var(--bs-font-monospace);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
   font-size: 0.78rem;
   display: block;
   flex: 1 1 0;
@@ -887,7 +1237,7 @@ body {
   }
 
   .settings-section + .settings-section {
-    margin-top: 1rem !important;
+    margin-top: 1rem;
     padding-top: 1rem;
   }
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -6,7 +6,14 @@
 /* === Bootstrap compatibility shim ===
    Lets legacy class names (btn, card, form-control, row, col-*, table, ...)
    keep rendering without bringing Bootstrap CSS along. Each rule maps to
-   Tailwind utilities via @apply so the design tokens come from index.css. */
+   Tailwind utilities via @apply so the design tokens come from index.css.
+
+   Note for shadcn CLI: components.json has `tailwind.config: ""` because
+   Tailwind v4 is CSS-first — the design system is declared in
+   src/index.css via @theme, not in a JS config file. The @reference
+   directive above is the v4 mechanism that lets @apply resolve utilities
+   across separate CSS files. Without it the build fails with
+   "Cannot apply unknown utility class". */
 @layer components {
   /* Buttons */
   .btn {
@@ -165,24 +172,6 @@
   .form-switch .form-check-input:checked::before {
     @apply translate-x-4;
   }
-  .input-group {
-    @apply inline-flex items-stretch w-full;
-  }
-  .input-group > .form-control,
-  .input-group > .form-select,
-  .input-group > .btn {
-    @apply rounded-none;
-  }
-  .input-group > :first-child {
-    @apply rounded-l-md;
-  }
-  .input-group > :last-child {
-    @apply rounded-r-md;
-  }
-  .input-group-text {
-    @apply inline-flex items-center px-3 text-sm bg-muted text-muted-foreground border border-input;
-  }
-
   /* Grid */
   .row {
     @apply flex flex-wrap -mx-2;
@@ -266,12 +255,8 @@
   .alert {
     @apply rounded-md border px-4 py-3 text-sm;
   }
-  .alert-primary { @apply border-primary/50 bg-primary/10 text-primary; }
-  .alert-secondary { @apply border-input bg-secondary/40 text-foreground; }
-  .alert-success { @apply border-success/50 bg-success/10 text-success; }
   .alert-danger { @apply border-destructive/50 bg-destructive/10 text-destructive; }
   .alert-warning { @apply border-warning/50 bg-warning/10 text-warning; }
-  .alert-info { @apply border-primary/50 bg-primary/10 text-primary; }
 
   /* Progress */
   .progress {
@@ -344,50 +329,6 @@
       hover:bg-accent hover:text-accent-foreground cursor-pointer;
   }
 
-  /* Modal (legacy; new code should use shadcn Dialog) */
-  .modal-backdrop {
-    @apply fixed inset-0 z-40 bg-black/50;
-  }
-  .modal {
-    @apply fixed inset-0 z-50 flex items-center justify-center;
-  }
-  .modal-dialog {
-    @apply w-full max-w-lg mx-4;
-  }
-  .modal-content {
-    @apply relative flex flex-col rounded-lg border bg-card text-card-foreground shadow-lg;
-  }
-  .modal-header {
-    @apply flex items-center justify-between border-b px-4 py-3;
-  }
-  .modal-body {
-    @apply p-4;
-  }
-  .modal-footer {
-    @apply flex justify-end gap-2 border-t px-4 py-3;
-  }
-
-  /* Navbar / nav (legacy minimal) */
-  .navbar {
-    @apply flex items-center px-4 py-2 bg-card;
-  }
-  .navbar-brand {
-    @apply mr-4 font-semibold;
-  }
-  .nav {
-    @apply flex flex-wrap;
-  }
-  .nav-link {
-    @apply px-3 py-2 text-sm hover:text-foreground;
-  }
-
-  /* Spinner */
-  .spinner-border {
-    @apply inline-block h-5 w-5 rounded-full border-2 border-current border-r-transparent animate-spin;
-  }
-  .spinner-border-sm {
-    @apply h-4 w-4 border-2;
-  }
   .visually-hidden {
     @apply absolute w-px h-px p-0 -m-px overflow-hidden whitespace-nowrap;
     clip: rect(0, 0, 0, 0);
@@ -562,7 +503,7 @@
 }
 
 .file-detail-preview-name {
-  color: #fff;
+  color: hsl(var(--foreground));
   font-weight: 600;
   margin-bottom: 0.35rem;
   overflow-wrap: anywhere;
@@ -588,7 +529,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #111417;
+  background: hsl(var(--surface-media));
   touch-action: pan-y pinch-zoom;
 }
 
@@ -633,7 +574,7 @@
   border-radius: 0.4rem;
   border: 1px solid rgba(255, 255, 255, 0.3);
   background: rgba(0, 0, 0, 0.5);
-  color: #f8f9fa;
+  color: hsl(var(--foreground-soft));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -670,7 +611,7 @@
   gap: 0.4rem;
   background: none;
   border: none;
-  color: #8ab4f8;
+  color: hsl(var(--accent-link));
   font-size: 0.9rem;
   cursor: pointer;
   padding: 0.25rem 0.5rem;
@@ -694,7 +635,7 @@
 .duplicate-card {
   border: 1px solid rgba(255, 255, 255, 0.15);
   border-radius: 0.6rem;
-  background: #15181c;
+  background: hsl(var(--surface-card-raised));
   padding: 0.75rem;
   display: flex;
   flex-direction: column;
@@ -711,7 +652,7 @@
   width: 100%;
   aspect-ratio: 4 / 3;
   border-radius: 0.5rem;
-  background: #111417;
+  background: hsl(var(--surface-media));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -744,7 +685,7 @@
   max-width: 80px;
   border: 0;
   background: transparent;
-  color: #f8f9fa;
+  color: hsl(var(--foreground-soft));
   font-size: 2.75rem;
   line-height: 1;
   opacity: 0;
@@ -856,8 +797,8 @@
 }
 
 .file-detail-favorite-button {
-  color: #f6c45a;
-  border-color: #f6c45a;
+  color: hsl(var(--accent-gold-strong));
+  border-color: hsl(var(--accent-gold-strong));
 }
 
 .file-detail-favorite-button:hover,
@@ -865,9 +806,9 @@
 .file-detail-favorite-button.is-favorite,
 .file-detail-favorite-button.is-favorite:hover,
 .file-detail-favorite-button.is-favorite:focus-visible {
-  background-color: #f6c45a;
-  border-color: #f6c45a;
-  color: #1f1b11;
+  background-color: hsl(var(--accent-gold-strong));
+  border-color: hsl(var(--accent-gold-strong));
+  color: hsl(var(--accent-gold-foreground));
 }
 
 .file-detail-favorite-icon-filled {
@@ -925,7 +866,7 @@
 .file-detail-section-title {
   font-size: 1.1rem;
   letter-spacing: 0.04em;
-  color: #fff;
+  color: hsl(var(--foreground));
 }
 
 .file-detail-section-title-accent {
@@ -941,12 +882,12 @@
   bottom: 0.2rem;
   width: 0.25rem;
   border-radius: 999px;
-  background: #f2b84b;
+  background: hsl(var(--accent-gold));
 }
 
 .file-detail-label,
 .file-detail-subtitle {
-  color: #fff;
+  color: hsl(var(--foreground));
 }
 
 .file-detail-section-divider {
@@ -975,7 +916,7 @@
   border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.3);
   background: rgba(0, 0, 0, 0.45);
-  color: #f0f0f0;
+  color: hsl(var(--foreground-soft));
   line-height: 1;
   font-size: 1rem;
   display: inline-flex;
@@ -1194,7 +1135,7 @@
 }
 
 .folder-upload-message {
-  color: #f8f9fa;
+  color: hsl(var(--foreground-soft));
 }
 
 .folder-upload-detail {

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+        outline:
+          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,64 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-8",
+        "icon-lg": "size-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot.Root : "button"
+
+  return (
+    <Comp
+      data-slot="button"
+      data-variant={variant}
+      data-size={size}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon } from "lucide-react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,255 @@
+import * as React from "react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,87 @@
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import { Progress as ProgressPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      className={cn(
+        "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+        className
+      )}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="h-full w-full flex-1 bg-primary transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  )
+}
+
+export { Progress }

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/frontend/src/components/ui/separator.tsx
+++ b/frontend/src/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import { Separator as SeparatorPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -1,0 +1,38 @@
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -1,0 +1,33 @@
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,89 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,92 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+  --background: 213 11% 14%;
+  --foreground: 0 0% 100%;
+  --card: 210 11% 11%;
+  --card-foreground: 0 0% 100%;
+  --popover: 210 11% 11%;
+  --popover-foreground: 0 0% 100%;
+  --primary: 217 89% 76%;
+  --primary-foreground: 213 11% 8%;
+  --secondary: 210 8% 22%;
+  --secondary-foreground: 0 0% 100%;
+  --muted: 210 8% 22%;
+  --muted-foreground: 0 0% 65%;
+  --accent: 210 8% 28%;
+  --accent-foreground: 0 0% 100%;
+  --destructive: 0 72% 51%;
+  --destructive-foreground: 0 0% 100%;
+  --warning: 41 90% 56%;
+  --warning-foreground: 36 33% 9%;
+  --success: 145 63% 49%;
+  --success-foreground: 0 0% 100%;
+  --border: 0 0% 100% / 0.12;
+  --input: 210 8% 22%;
+  --ring: 217 89% 76%;
+  --radius: 0.5rem;
+
+  --color-surface: 213 11% 14%;
+  --color-surface-elevated: 210 11% 11%;
+  --color-surface-sunken: 213 14% 6%;
+}
+
+@theme inline {
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-warning: hsl(var(--warning));
+  --color-warning-foreground: hsl(var(--warning-foreground));
+  --color-success: hsl(var(--success));
+  --color-success-foreground: hsl(var(--success-foreground));
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+}
+
+@layer base {
+  *,
+  ::before,
+  ::after {
+    border-color: hsl(var(--border));
+  }
+
+  html,
+  body,
+  #root {
+    height: 100%;
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+  }
+
+  body {
+    margin: 0;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue",
+      Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -32,6 +32,20 @@
   --color-surface: 213 11% 14%;
   --color-surface-elevated: 210 11% 11%;
   --color-surface-sunken: 213 14% 6%;
+
+  /* Media surfaces (used by file viewer + duplicate cards) */
+  --surface-media: 210 12% 6%;
+  --surface-card-raised: 213 12% 9%;
+
+  /* Brand accent links + highlights */
+  --accent-link: 217 89% 76%;
+  --accent-gold: 39 87% 63%;
+  --accent-gold-foreground: 36 50% 9%;
+  --accent-gold-strong: 41 86% 62%;
+
+  /* Foreground tints */
+  --foreground-soft: 0 0% 97%;
+  --foreground-muted-overlay: 0 0% 100%;
 }
 
 @theme inline {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-import 'bootstrap/dist/css/bootstrap.min.css';
+import './index.css';
 import './app.css';
 import React from 'react';
 import { createRoot } from 'react-dom/client';

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -10,7 +10,11 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "strict": true
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
   },
   "include": ["vite.config.ts"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,15 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import path from 'node:path';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  },
   server: {
     port: 5174
   }


### PR DESCRIPTION
## Summary

PR #1 of 6 for the modernization roadmap tracked in #103. Replaces
Bootstrap 5 with Tailwind 4 + shadcn/ui at the toolchain level so the
follow-up PRs (TanStack Query, App.tsx split, Drizzle, Router, forms)
have a clean visual layer to build on.

- Bootstrap 5.3.8 removed (`package.json`, `main.tsx` import, all
  `var(--bs-*)` references).
- Tailwind 4 wired through `@tailwindcss/vite`, design tokens declared
  in `src/index.css` via `@theme` (CSS-first, no `tailwind.config.js`).
- shadcn/ui initialised under `src/components/ui/` with the 17
  primitives most likely to be consumed by upcoming PRs (Button, Input,
  Label, Card, Dialog, DropdownMenu, Select, Tabs, Badge, Separator,
  Sonner, Tooltip, Popover, Textarea, Checkbox, Switch, Progress).
  These are intentionally staged: they are imported only by themselves
  today. App.tsx and BooruSitesPanel.tsx still use legacy class names
  on purpose to keep this diff focused on the toolchain swap.
- Bootstrap class names are kept rendering via a compatibility shim in
  `src/app.css` under `@layer components` + `@apply`, scoped with
  `@reference "./index.css"` (the v4 directive that lets `@apply`
  resolve utilities across separate CSS files). The shim only ships
  rules for classes the app actually uses; dead Bootstrap parts
  (input-group, modal, navbar, spinner, three alert variants) are
  omitted per AGENTS.md §17.
- Safe 1:1 Bootstrap → Tailwind utility renames (`d-flex`→`flex`,
  `align-items-center`→`items-center`, `mb-3`→`mb-4`, `text-secondary`
  →`text-muted-foreground`, etc) applied across `App.tsx` and
  `BooruSitesPanel.tsx` via a Perl rewriter (`/tmp/bs2tw.pl`) that uses
  a hash-lookup substitution so each match is replaced exactly once —
  no cascading sed bug.
- A11y (§15): login / register / per-provider credential inputs now
  carry explicit `id` + `htmlFor` + `name` + `autocomplete` pairs.
- Design tokens (§2): hand-written hex literals in `app.css` are
  consolidated into HSL CSS variables in `index.css`
  (`--foreground-soft`, `--accent-link`, `--accent-gold*`,
  `--surface-media`, `--surface-card-raised`).

## Bundle

- CSS: `240KB raw → 78KB raw` (`33KB gz → 13KB gz`, ~60% smaller)
- JS: `299KB → 301KB` (essentially flat; Radix umbrella + Sonner added
  but shadcn primitives only ship the code App.tsx imports today,
  which is zero).

## Test plan

- [x] `cd frontend && npm run build` exits 0, no Tailwind "unknown
      utility class" errors.
- [x] `cd frontend && npm test` — vitest 13/13 pass.
- [x] `npx playwright test` — smoke suite 4/4 pass (auth round-trip,
      gallery empty state, duplicates empty state).
- [x] grep confirms zero `"bootstrap"` / `bootstrap/dist` /
      `var(--bs-*)` left under `frontend/src` (only false positive is
      a `bootstrapAuth` JS function name, unrelated to the framework).
- [ ] Human visual smoke: log in, browse gallery, open file detail,
      mark favorite, toggle duplicates view, open credential drawer.

## Out of scope (follow-up PRs)

- #103 point 2: TanStack Query (kill `frontend/src/api.ts`).
- #103 point 3: split `App.tsx` (4252 lines) into feature folders. The
  shadcn primitives staged in this PR will start being adopted there.
- #103 point 4: Drizzle ORM (`backend/lib/dataStore.ts`).
- #103 point 5: Router + Zustand.
- #103 point 6: React Hook Form + path aliases + Prettier/ESLint
  sharing.

## Review notes

Pre-push review pass flagged one critical bug (cascading sed inflated
every spacing class by ~50%) and a batch of suggestions; both the
critical fix and every suggestion are in this branch
(`90740f3` fixes the spacing, `3f9f378` applies the rest).

Refs #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)