### PR TITLE
feat(frontend): TanStack Query replaces useState+useEffect data flows (#103 point 2/6)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.0",
+        "@tanstack/react-query": "^5.100.14",
+        "@tanstack/react-query-devtools": "^5.100.14",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.16.0",
@@ -2181,6 +2183,59 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.14.tgz",
+      "integrity": "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.14.tgz",
+      "integrity": "sha512-g96SmSSQecYTYcyuAMRXr895GplJv01UGt7qttQWPOUyZ5EGz5tbRc589bMc2m5BsPFD6O0PCEAHdbDYNP6UBw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.14.tgz",
+      "integrity": "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.14.tgz",
+      "integrity": "sha512-JkP5VDgKOw3t/QSA1OABRHEqx8BuNs5MfvZRooNqdvN57SzTuGq3fKR1a2IH5rqa5HDLUm+FOXUEnB9ueHiLzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.100.14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.100.14",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.3.0",
+    "@tanstack/react-query": "^5.100.14",
+    "@tanstack/react-query-devtools": "^5.100.14",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.16.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,36 @@ import type { CredentialProvider, CredentialSummary, DuplicateScanStatus, Favori
 import { BooruSitesPanel } from './BooruSitesPanel';
 import { useCurrentUser, useLogin, useLogout, useRegister } from '@/hooks/auth';
 import { useDeleteFolder, useFolders, useUploadFolderFiles } from '@/hooks/folders';
+import {
+  useDeleteFile,
+  useFileProviders,
+  useRunProvider,
+  useUpdateFileFavorite,
+  useUpdateManualOrder
+} from '@/hooks/files';
+import { useSauces, useUpdateSauceSettings } from '@/hooks/sauces';
+import {
+  useFavoritesSettings,
+  useFavoritesSyncStatus,
+  useSyncFavorites,
+  useUpdateFavoritesSettings
+} from '@/hooks/favorites';
+import { useCredentials, useUpdateCredential } from '@/hooks/credentials';
+import {
+  useAddManualTag,
+  useClearFileTags,
+  useFileTags,
+  useRefreshFileTags,
+  useRemoveManualTag,
+  useRemoveTopMatch
+} from '@/hooks/tags';
+import {
+  useCancelDuplicateScan,
+  useDuplicateScanStatus,
+  useDuplicateSettings,
+  useStartDuplicateScan,
+  useUpdateDuplicateSettings
+} from '@/hooks/duplicates';
 import { queryKeys } from '@/lib/query-keys';
 
 type FetchState = {
@@ -445,6 +475,22 @@ function App() {
   const folders = foldersQuery.data ?? [];
   const deleteFolderMutation = useDeleteFolder();
   const uploadFolderFilesMutation = useUploadFolderFiles();
+  const deleteFileMutation = useDeleteFile();
+  const updateFileFavoriteMutation = useUpdateFileFavorite();
+  const runProviderMutation = useRunProvider();
+  const updateManualOrderMutation = useUpdateManualOrder();
+  const updateSauceSettingsMutation = useUpdateSauceSettings();
+  const syncFavoritesMutation = useSyncFavorites();
+  const updateFavoritesSettingsMutation = useUpdateFavoritesSettings();
+  const updateCredentialMutation = useUpdateCredential();
+  const updateDuplicateSettingsMutation = useUpdateDuplicateSettings();
+  const startDuplicateScanMutation = useStartDuplicateScan();
+  const cancelDuplicateScanMutation = useCancelDuplicateScan();
+  const addManualTagMutation = useAddManualTag();
+  const removeManualTagMutation = useRemoveManualTag();
+  const refreshFileTagsMutation = useRefreshFileTags();
+  const clearFileTagsMutation = useClearFileTags();
+  const removeTopMatchMutation = useRemoveTopMatch();
   const [galleryFolderId, setGalleryFolderId] = useState('');
   const [galleryFiles, setGalleryFiles] = useState<FileItem[]>([]);
   const [galleryTotal, setGalleryTotal] = useState(0);
@@ -773,7 +819,7 @@ function App() {
   const loadSauces = useCallback(async () => {
     setSauceState({ loading: true, error: null });
     try {
-      const data = await api.getSauces();
+      const data = await queryClient.fetchQuery({ queryKey: queryKeys.sauces.list(), queryFn: () => api.getSauces() });
       setSauceSources(data.sources);
       setSauceSettings({
         display: data.settings.display ?? [],
@@ -790,7 +836,7 @@ function App() {
   const loadDuplicateSettings = useCallback(async () => {
     setDuplicateSettingsState({ loading: true, error: null });
     try {
-      const data = await api.getDuplicateSettings();
+      const data = await queryClient.fetchQuery({ queryKey: queryKeys.duplicates.settings(), queryFn: () => api.getDuplicateSettings() });
       setDuplicateSettings(data);
       setDuplicateSettingsState({ loading: false, error: null });
     } catch (err) {
@@ -801,7 +847,7 @@ function App() {
   const loadFavoritesSettings = useCallback(async () => {
     setFavoritesSettingsState({ loading: true, error: null });
     try {
-      const data = await api.getFavoritesSettings();
+      const data = await queryClient.fetchQuery({ queryKey: queryKeys.favorites.settings(), queryFn: () => api.getFavoritesSettings() });
       setFavoritesSettings(data);
       setFavoritesSettingsState({ loading: false, error: null });
     } catch (err) {
@@ -813,7 +859,7 @@ function App() {
     setCredentialLastProvider(null);
     setCredentialsState({ loading: true, error: null });
     try {
-      const data = await api.getCredentials();
+      const data = await queryClient.fetchQuery({ queryKey: queryKeys.credentials.list(), queryFn: () => api.getCredentials() });
       setCredentials(data);
       const lookup = new Map(data.map((entry) => [entry.provider, entry]));
       setCredentialInputs({
@@ -829,7 +875,7 @@ function App() {
 
   const loadFavoritesSyncStatus = useCallback(async () => {
     try {
-      const data = await api.getFavoritesSyncStatus();
+      const data = await queryClient.fetchQuery({ queryKey: queryKeys.favorites.syncStatus(), queryFn: () => api.getFavoritesSyncStatus() });
       setFavoritesSyncStatus(data);
       if (data.status === 'running') {
         startFavoritesPoll();
@@ -843,7 +889,7 @@ function App() {
     async (override?: DuplicateScanOptions) => {
       setDuplicateState({ loading: true, error: null });
       try {
-        const start = await api.startDuplicateScan(override ?? duplicateOptions);
+        const start = await startDuplicateScanMutation.mutateAsync(override ?? duplicateOptions);
         let status = start.state;
         setDuplicateScanStatus(status);
         let lastUpdatedAt = status.updatedAt;
@@ -1263,7 +1309,7 @@ function App() {
     const nextFile = selectedFile?.id === fileId ? pickNextFileAfterDelete(galleryFiles, fileId) : null;
     setDeleteState({ loading: true, error: null });
     try {
-      await api.deleteFile(fileId);
+      await deleteFileMutation.mutateAsync(fileId);
       setGalleryFiles((prev) => prev.filter((file) => file.id !== fileId));
       setGalleryTotal((prev) => (prev > 0 ? prev - 1 : 0));
       setGalleryOffset((prev) => Math.max(0, prev - 1));
@@ -1357,7 +1403,7 @@ function App() {
     const nextFavorite = !selectedFile.isFavorite;
     setFavoriteState({ loading: true, error: null });
     try {
-      const resp = await api.updateFileFavorite(selectedFile.id, nextFavorite);
+      const resp = await updateFileFavoriteMutation.mutateAsync({ fileId: selectedFile.id, favorite: nextFavorite });
       updateFavoriteFlag(selectedFile.id, resp.isFavorite);
       setFavoriteState({ loading: false, error: null });
     } catch (err) {
@@ -1425,7 +1471,7 @@ function App() {
     async (next: FileItem[]) => {
       setManualOrderState({ loading: true, error: null });
       try {
-        await api.updateManualOrder(next.map((file) => file.id));
+        await updateManualOrderMutation.mutateAsync(next.map((file) => file.id));
         setManualOrderState({ loading: false, error: null });
       } catch (err) {
         setManualOrderState({ loading: false, error: (err as Error).message });
@@ -1454,7 +1500,7 @@ function App() {
 
   const loadProviders = async (fileId: string) => {
     try {
-      const resp = await api.getProviders(fileId);
+      const resp = await queryClient.fetchQuery({ queryKey: queryKeys.files.providers(fileId), queryFn: () => api.getProviders(fileId) });
       setProviderInfo(resp.providers);
     } catch (err) {
       setProviderInfo([]);
@@ -1470,7 +1516,7 @@ function App() {
 
   const pollFavoritesSync = useCallback(async () => {
     try {
-      const data = await api.getFavoritesSyncStatus();
+      const data = await queryClient.fetchQuery({ queryKey: queryKeys.favorites.syncStatus(), queryFn: () => api.getFavoritesSyncStatus() });
       setFavoritesSyncStatus(data);
       if (data.status !== 'running') {
         stopFavoritesPoll();
@@ -1491,7 +1537,7 @@ function App() {
   const runFavoritesSync = async (deleteMissing: boolean) => {
     setFavoritesSyncState({ loading: true, error: null });
     try {
-      const data = await api.syncFavorites({ deleteMissing });
+      const data = await syncFavoritesMutation.mutateAsync({ deleteMissing });
       setFavoritesSyncStatus(data.state);
       setFavoritesSyncState({ loading: false, error: null });
       if (data.state.status === 'running') {
@@ -1510,7 +1556,7 @@ function App() {
   }) => {
     setFavoritesSettingsState({ loading: true, error: null });
     try {
-      const data = await api.updateFavoritesSettings(updates);
+      const data = await updateFavoritesSettingsMutation.mutateAsync(updates);
       setFavoritesSettings(data);
       setFavoritesSettingsState({ loading: false, error: null });
     } catch (err) {
@@ -1521,7 +1567,7 @@ function App() {
   const updateDuplicateSettings = async (updates: Partial<DuplicateSettings>) => {
     setDuplicateSettingsState({ loading: true, error: null });
     try {
-      const data = await api.updateDuplicateSettings(updates);
+      const data = await updateDuplicateSettingsMutation.mutateAsync(updates);
       setDuplicateSettings(data);
       setDuplicateSettingsState({ loading: false, error: null });
     } catch (err) {
@@ -1561,7 +1607,7 @@ function App() {
         setCredentialsState({ loading: false, error: null });
         return;
       }
-      const updated = await api.updateCredential(payload);
+      const updated = await updateCredentialMutation.mutateAsync(payload);
       setCredentials((prev) => {
         const map = new Map(prev.map((entry) => [entry.provider, entry]));
         map.set(updated.provider, updated);
@@ -1585,7 +1631,7 @@ function App() {
     setCredentialLastProvider(provider);
     setCredentialsState({ loading: true, error: null });
     try {
-      const updated = await api.updateCredential({ provider, username: '', apiKey: '' });
+      const updated = await updateCredentialMutation.mutateAsync({ provider, username: '', apiKey: '' });
       setCredentials((prev) => {
         const map = new Map(prev.map((entry) => [entry.provider, entry]));
         map.set(updated.provider, updated);
@@ -1607,10 +1653,10 @@ function App() {
   const loadTags = useCallback(async (fileId: string) => {
     setTagState({ loading: true, error: null });
     try {
-      const resp = await api.getFileTags(fileId);
+      const resp = await queryClient.fetchQuery({ queryKey: queryKeys.files.tags(fileId), queryFn: () => api.getFileTags(fileId) });
       if (resp.tags.length === 0 && !tagRefreshRef.current.has(fileId)) {
         tagRefreshRef.current.add(fileId);
-        const refreshed = await api.refreshFileTags(fileId);
+        const refreshed = await refreshFileTagsMutation.mutateAsync(fileId);
         setFileTags(refreshed.tags);
       } else {
         setFileTags(resp.tags);
@@ -1626,7 +1672,7 @@ function App() {
     if (!selectedFile) return;
     setTagState({ loading: true, error: null });
     try {
-      const refreshed = await api.refreshFileTags(selectedFile.id);
+      const refreshed = await refreshFileTagsMutation.mutateAsync(selectedFile.id);
       setFileTags(refreshed.tags);
       tagRefreshRef.current.add(selectedFile.id);
       setTagState({ loading: false, error: null });
@@ -1640,7 +1686,7 @@ function App() {
     if (!window.confirm('Delete all tags for this file?')) return;
     setTagState({ loading: true, error: null });
     try {
-      await api.clearFileTags(selectedFile.id);
+      await clearFileTagsMutation.mutateAsync(selectedFile.id);
       setFileTags([]);
       tagRefreshRef.current.add(selectedFile.id);
       setTagState({ loading: false, error: null });
@@ -1856,7 +1902,7 @@ function App() {
     }
     setDuplicateAction({ loadingId: discard.id, error: null });
     try {
-      await api.deleteFile(discard.id);
+      await deleteFileMutation.mutateAsync(discard.id);
       setDuplicateGroups((prev) =>
         prev
           .map((group) => ({
@@ -1953,7 +1999,7 @@ function App() {
     if (!value) return;
     try {
       setTagState({ loading: true, error: null });
-      await api.addManualTag(selectedFile.id, value, manualTagCategory);
+      await addManualTagMutation.mutateAsync({ fileId: selectedFile.id, tag: value, category: manualTagCategory });
       setManualTagInput('');
       await loadTags(selectedFile.id);
       setTagState({ loading: false, error: null });
@@ -1966,7 +2012,7 @@ function App() {
     if (!selectedFile) return;
     try {
       setTagState({ loading: true, error: null });
-      await api.removeManualTag(selectedFile.id, tag, category);
+      await removeManualTagMutation.mutateAsync({ fileId: selectedFile.id, tag: tag, category: category });
       await loadTags(selectedFile.id);
       setTagState({ loading: false, error: null });
     } catch (err) {
@@ -1978,7 +2024,7 @@ function App() {
     if (!selectedFile) return;
     try {
       setMatchRemoveState({ loading: true, error: null });
-      const resp = await api.removeTopMatch(selectedFile.id, sourceUrl);
+      const resp = await removeTopMatchMutation.mutateAsync({ fileId: selectedFile.id, sourceUrl: sourceUrl });
       setProviderInfo(resp.providers);
       setFileTags(resp.tags);
       tagRefreshRef.current.add(selectedFile.id);
@@ -2294,7 +2340,7 @@ function App() {
     setSauceSettings(nextSettings);
     setSauceState({ loading: true, error: null });
     try {
-      const res = await api.updateSauceSettings(nextSettings);
+      const res = await updateSauceSettingsMutation.mutateAsync(nextSettings);
       setSauceSettings({
         display: res.settings.display ?? [],
         targets: res.settings.targets ?? [],

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type TouchEvent } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 import {
   api,
@@ -19,6 +20,9 @@ import {
 } from './api';
 import type { CredentialProvider, CredentialSummary, DuplicateScanStatus, FavoriteSyncStatus, ProviderRun } from './api';
 import { BooruSitesPanel } from './BooruSitesPanel';
+import { useCurrentUser, useLogin, useLogout, useRegister } from '@/hooks/auth';
+import { useDeleteFolder, useFolders, useUploadFolderFiles } from '@/hooks/folders';
+import { queryKeys } from '@/lib/query-keys';
 
 type FetchState = {
   loading: boolean;
@@ -415,11 +419,32 @@ type DetailSwipeAxis = 'idle' | 'x' | 'y';
 const GALLERY_PAGE_SIZE = 200;
 
 function App() {
-  const [authUser, setAuthUser] = useState<AuthUser | null>(null);
-  const [authState, setAuthState] = useState<FetchState>({ loading: true, error: null });
+  const queryClient = useQueryClient();
+  const currentUserQuery = useCurrentUser();
+  const loginMutation = useLogin();
+  const registerMutation = useRegister();
+  const logoutMutation = useLogout();
+  const authUser = currentUserQuery.data ?? null;
+  const authMutationError =
+    (loginMutation.error as Error | null)?.message ??
+    (registerMutation.error as Error | null)?.message ??
+    null;
+  const authPending =
+    currentUserQuery.isLoading ||
+    loginMutation.isPending ||
+    registerMutation.isPending ||
+    logoutMutation.isPending;
+  const [authLocalError, setAuthLocalError] = useState<string | null>(null);
+  const authState: FetchState = {
+    loading: authPending,
+    error: authLocalError ?? authMutationError
+  };
   const [authMode, setAuthMode] = useState<AuthMode>('login');
   const [authForm, setAuthForm] = useState({ username: '', password: '', confirmPassword: '' });
-  const [folders, setFolders] = useState<Folder[]>([]);
+  const foldersQuery = useFolders({ enabled: Boolean(authUser) });
+  const folders = foldersQuery.data ?? [];
+  const deleteFolderMutation = useDeleteFolder();
+  const uploadFolderFilesMutation = useUploadFolderFiles();
   const [galleryFolderId, setGalleryFolderId] = useState('');
   const [galleryFiles, setGalleryFiles] = useState<FileItem[]>([]);
   const [galleryTotal, setGalleryTotal] = useState(0);
@@ -722,22 +747,24 @@ function App() {
     [galleryFavoritesOnly, galleryFolderId, galleryMediaFilter, GALLERY_PAGE_SIZE, galleryRandomSeed, gallerySort, galleryTagQuery]
   );
 
-  const refreshFolders = useCallback(async (options: { silent?: boolean } = {}) => {
-    if (!options.silent) {
-      setFetchState({ loading: true, error: null });
-    }
-    try {
-      const f = await api.getFolders();
-      setFolders(f);
+  const refreshFolders = useCallback(
+    async (options: { silent?: boolean } = {}) => {
       if (!options.silent) {
-        setFetchState({ loading: false, error: null });
+        setFetchState({ loading: true, error: null });
       }
-    } catch (err) {
-      if (!options.silent) {
-        setFetchState({ loading: false, error: (err as Error).message });
+      try {
+        await foldersQuery.refetch({ throwOnError: true });
+        if (!options.silent) {
+          setFetchState({ loading: false, error: null });
+        }
+      } catch (err) {
+        if (!options.silent) {
+          setFetchState({ loading: false, error: (err as Error).message });
+        }
       }
-    }
-  }, []);
+    },
+    [foldersQuery]
+  );
 
   const loadData = useCallback(async () => {
     await refreshFolders();
@@ -861,32 +888,6 @@ function App() {
   );
 
   useEffect(() => {
-    let cancelled = false;
-    const bootstrapAuth = async () => {
-      setAuthState({ loading: true, error: null });
-      try {
-        const user = await api.getCurrentUser();
-        if (cancelled) return;
-        setAuthUser(user);
-        setAuthState({ loading: false, error: null });
-      } catch (err) {
-        if (cancelled) return;
-        const status = (err as Error & { status?: number }).status;
-        if (status === 401) {
-          setAuthUser(null);
-          setAuthState({ loading: false, error: null });
-          return;
-        }
-        setAuthState({ loading: false, error: (err as Error).message });
-      }
-    };
-    void bootstrapAuth();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  useEffect(() => {
     const handleAuthRequired = () => {
       Object.values(folderUploadHideTimersRef.current).forEach((timer) => window.clearTimeout(timer));
       folderUploadHideTimersRef.current = {};
@@ -896,8 +897,6 @@ function App() {
       }
       galleryCacheRef.current.clear();
       setSelectedFile(null);
-      setAuthUser(null);
-      setFolders([]);
       setGalleryFiles([]);
       setGalleryTotal(0);
       setGalleryOffset(0);
@@ -907,13 +906,21 @@ function App() {
       setDuplicateGroups([]);
       setDuplicateStats(null);
       setDuplicateScanStatus(null);
-      setAuthState({ loading: false, error: null });
+      setAuthLocalError(null);
+      queryClient.setQueryData(queryKeys.auth.me(), null);
+      queryClient.removeQueries({ queryKey: queryKeys.folders.all });
+      queryClient.removeQueries({ queryKey: queryKeys.files.all });
+      queryClient.removeQueries({ queryKey: queryKeys.sauces.all });
+      queryClient.removeQueries({ queryKey: queryKeys.favorites.all });
+      queryClient.removeQueries({ queryKey: queryKeys.credentials.all });
+      queryClient.removeQueries({ queryKey: queryKeys.duplicates.all });
+      queryClient.removeQueries({ queryKey: queryKeys.booruSites.all });
     };
     window.addEventListener(authRequiredEvent, handleAuthRequired);
     return () => {
       window.removeEventListener(authRequiredEvent, handleAuthRequired);
     };
-  }, []);
+  }, [queryClient]);
 
   useEffect(() => {
     if (!authUser) return;
@@ -1066,48 +1073,47 @@ function App() {
     const username = authForm.username.trim();
     const password = authForm.password;
     if (!username || !password) {
-      setAuthState({ loading: false, error: 'Username and password are required' });
+      setAuthLocalError('Username and password are required');
       return;
     }
     if (username.length < 3) {
-      setAuthState({ loading: false, error: 'Username must be at least 3 characters' });
+      setAuthLocalError('Username must be at least 3 characters');
       return;
     }
     if (username.length > 32) {
-      setAuthState({ loading: false, error: 'Username must be at most 32 characters' });
+      setAuthLocalError('Username must be at most 32 characters');
       return;
     }
     if (!authUsernameRegex.test(username)) {
-      setAuthState({ loading: false, error: 'Username can only contain letters, numbers, _ and -' });
+      setAuthLocalError('Username can only contain letters, numbers, _ and -');
       return;
     }
     if (password.length < 8) {
-      setAuthState({ loading: false, error: 'Password must be at least 8 characters' });
+      setAuthLocalError('Password must be at least 8 characters');
       return;
     }
     if (authMode === 'register' && password !== authForm.confirmPassword) {
-      setAuthState({ loading: false, error: 'Passwords do not match' });
+      setAuthLocalError('Passwords do not match');
       return;
     }
-    setAuthState({ loading: true, error: null });
+    setAuthLocalError(null);
     try {
-      const user =
-        authMode === 'register'
-          ? await api.register({ username, password })
-          : await api.login({ username, password });
+      if (authMode === 'register') {
+        await registerMutation.mutateAsync({ username, password });
+      } else {
+        await loginMutation.mutateAsync({ username, password });
+      }
       galleryCacheRef.current.clear();
-      setAuthUser(user);
       setAuthForm({ username: '', password: '', confirmPassword: '' });
-      setAuthState({ loading: false, error: null });
-    } catch (err) {
-      setAuthState({ loading: false, error: (err as Error).message });
+    } catch {
+      // Mutation error surfaces via authMutationError; nothing extra to do here.
     }
   };
 
   const logout = async () => {
-    setAuthState({ loading: true, error: null });
+    setAuthLocalError(null);
     try {
-      await api.logout();
+      await logoutMutation.mutateAsync();
     } catch {
       // Clear local state even if the session is already gone server-side.
     } finally {
@@ -1117,8 +1123,6 @@ function App() {
       }
       galleryCacheRef.current.clear();
       setSelectedFile(null);
-      setAuthUser(null);
-      setFolders([]);
       setGalleryFiles([]);
       setGalleryTotal(0);
       setGalleryOffset(0);
@@ -1130,7 +1134,6 @@ function App() {
       setDuplicateGroups([]);
       setDuplicateStats(null);
       setDuplicateScanStatus(null);
-      setAuthState({ loading: false, error: null });
     }
   };
   const openFolderUploadPicker = (folderId: string) => {
@@ -1159,7 +1162,9 @@ function App() {
       }));
 
       try {
-        const result = await api.uploadFolderFiles(folder.id, files, {
+        const result = await uploadFolderFilesMutation.mutateAsync({
+          folderId: folder.id,
+          files,
           onProgress: ({ percent }) => {
             setFolderUploads((prev) => ({
               ...prev,
@@ -1246,8 +1251,7 @@ function App() {
     if (!window.confirm(`Remove "${folder.path}" from the watch list?`)) return;
     setFolderActionState({ loading: true, error: null });
     try {
-      await api.deleteFolder(folder.id);
-      setFolders((prev) => prev.filter((item) => item.id !== folder.id));
+      await deleteFolderMutation.mutateAsync(folder.id);
       setFolderActionState({ loading: false, error: null });
     } catch (err) {
       setFolderActionState({ loading: false, error: (err as Error).message });
@@ -2643,7 +2647,7 @@ function App() {
                   className={`btn btn-${authMode === 'login' ? 'primary' : 'outline-light'}`}
                   onClick={() => {
                     setAuthMode('login');
-                    setAuthState({ loading: false, error: null });
+                    setAuthLocalError(null);
                   }}
                 >
                   Login
@@ -2653,7 +2657,7 @@ function App() {
                   className={`btn btn-${authMode === 'register' ? 'primary' : 'outline-light'}`}
                   onClick={() => {
                     setAuthMode('register');
-                    setAuthState({ loading: false, error: null });
+                    setAuthLocalError(null);
                   }}
                 >
                   Register

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,31 +24,25 @@ import { useCurrentUser, useLogin, useLogout, useRegister } from '@/hooks/auth';
 import { useDeleteFolder, useFolders, useUploadFolderFiles } from '@/hooks/folders';
 import {
   useDeleteFile,
-  useFileProviders,
   useRunProvider,
   useUpdateFileFavorite,
   useUpdateManualOrder
 } from '@/hooks/files';
-import { useSauces, useUpdateSauceSettings } from '@/hooks/sauces';
+import { useUpdateSauceSettings } from '@/hooks/sauces';
 import {
-  useFavoritesSettings,
-  useFavoritesSyncStatus,
   useSyncFavorites,
   useUpdateFavoritesSettings
 } from '@/hooks/favorites';
-import { useCredentials, useUpdateCredential } from '@/hooks/credentials';
+import { useUpdateCredential } from '@/hooks/credentials';
 import {
   useAddManualTag,
   useClearFileTags,
-  useFileTags,
   useRefreshFileTags,
   useRemoveManualTag,
   useRemoveTopMatch
 } from '@/hooks/tags';
 import {
   useCancelDuplicateScan,
-  useDuplicateScanStatus,
-  useDuplicateSettings,
   useStartDuplicateScan,
   useUpdateDuplicateSettings
 } from '@/hooks/duplicates';
@@ -968,10 +962,10 @@ function App() {
     };
   }, [queryClient]);
 
-  useEffect(() => {
-    if (!authUser) return;
-    void loadData();
-  }, [authUser, loadData]);
+  // useFolders is enabled by `authUser` truthy, so the folders fetch
+  // already fires on login — no manual loadData call needed here. The
+  // remaining loadData reference (manualOrder failure recovery) stays so
+  // a failed reorder can still pull a fresh list.
 
   useEffect(() => {
     return () => {
@@ -1160,8 +1154,13 @@ function App() {
     setAuthLocalError(null);
     try {
       await logoutMutation.mutateAsync();
-    } catch {
-      // Clear local state even if the session is already gone server-side.
+    } catch (err) {
+      // Server-side session may already be gone (network drop, already-
+      // expired cookie). Tear down local state regardless; the user is
+      // logged out from their perspective. Surface the error so a real
+      // failure isn't silently swallowed.
+      // eslint-disable-next-line no-console
+      console.warn('logout request failed; clearing local state anyway', err);
     } finally {
       if (favoritesPollRef.current !== null) {
         window.clearInterval(favoritesPollRef.current);

--- a/frontend/src/BooruSitesPanel.tsx
+++ b/frontend/src/BooruSitesPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ChangeEvent, type FormEvent } from 'react';
+import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from 'react';
 
 import {
   useBooruEngineCatalog,
@@ -125,26 +125,22 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
     (sitesQuery.error as Error | null)?.message ??
     (catalogQuery.error as Error | null)?.message ??
     null;
-  const setError = setLocalError;
   const [addForm, setAddForm] = useState<AddFormState>(initialAddForm());
   const [addingBusy, setAddingBusy] = useState(false);
   const [testingId, setTestingId] = useState<string | null>(null);
   const [testResults, setTestResults] = useState<Record<string, { ok: boolean; message: string }>>({});
-  const [editCredentials, setEditCredentials] = useState<Record<string, CredentialsState>>(() => {
-    const inputs: Record<string, CredentialsState> = {};
-    return inputs;
-  });
+  const [editCredentials, setEditCredentials] = useState<Record<string, CredentialsState>>({});
 
-  useMemo(() => {
+  useEffect(() => {
     if (!sitesQuery.data) return;
-    const inputs: Record<string, CredentialsState> = {};
-    sitesQuery.data.forEach((site) => {
-      inputs[site.id] = { username: site.username ?? '', apiKey: '' };
-    });
     setEditCredentials((prev) => {
-      const merged: Record<string, CredentialsState> = { ...inputs };
-      Object.keys(prev).forEach((id) => {
-        if (merged[id]) merged[id] = { ...merged[id], ...prev[id] };
+      const merged: Record<string, CredentialsState> = {};
+      sitesQuery.data.forEach((site) => {
+        const existing = prev[site.id];
+        merged[site.id] = {
+          username: existing?.username ?? site.username ?? '',
+          apiKey: existing?.apiKey ?? ''
+        };
       });
       return merged;
     });
@@ -226,7 +222,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
       setAddForm(initialAddForm());
       await reload();
     } catch (err) {
-      setError((err as Error).message);
+      setLocalError((err as Error).message);
     } finally {
       setAddingBusy(false);
     }
@@ -239,7 +235,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
         payload: { [capability]: !site[capability] }
       });
     } catch (err) {
-      setError((err as Error).message);
+      setLocalError((err as Error).message);
     }
   };
 
@@ -250,7 +246,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
         payload: { enabled: !site.enabled }
       });
     } catch (err) {
-      setError((err as Error).message);
+      setLocalError((err as Error).message);
     }
   };
 
@@ -270,7 +266,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
         [site.id]: { username: updated.username ?? '', apiKey: '' }
       }));
     } catch (err) {
-      setError((err as Error).message);
+      setLocalError((err as Error).message);
     }
   };
 
@@ -278,9 +274,8 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
     if (!confirm(`Delete ${site.name}?`)) return;
     try {
       await deleteSiteMutation.mutateAsync(site.id);
-      await reload();
     } catch (err) {
-      setError((err as Error).message);
+      setLocalError((err as Error).message);
     }
   };
 
@@ -313,9 +308,9 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
     const reordered = [...sorted];
     [reordered[idx], reordered[targetIdx]] = [reordered[targetIdx], reordered[idx]];
     try {
-      const updated = await reorderSitesMutation.mutateAsync(reordered.map((s) => s.id));
+      await reorderSitesMutation.mutateAsync(reordered.map((s) => s.id));
     } catch (err) {
-      setError((err as Error).message);
+      setLocalError((err as Error).message);
     }
   };
 
@@ -329,7 +324,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
       {error ? (
         <div className="alert alert-danger" role="alert">
           {error}
-          <button type="button" className="btn btn-sm btn-link" onClick={() => setError(null)}>
+          <button type="button" className="btn btn-sm btn-link" onClick={() => setLocalError(null)}>
             dismiss
           </button>
         </div>

--- a/frontend/src/BooruSitesPanel.tsx
+++ b/frontend/src/BooruSitesPanel.tsx
@@ -1,4 +1,15 @@
-import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from 'react';
+import { useMemo, useState, type ChangeEvent, type FormEvent } from 'react';
+
+import {
+  useBooruEngineCatalog,
+  useBooruSites,
+  useCreateBooruSite,
+  useDeleteBooruSite,
+  useDetectBooruEngine,
+  useReorderBooruSites,
+  useTestBooruSite,
+  useUpdateBooruSite
+} from '@/hooks/booru-sites';
 
 import {
   api,
@@ -97,44 +108,52 @@ type Props = {
 };
 
 export const BooruSitesPanel = ({ className, devOptions }: Props) => {
-  const [sites, setSites] = useState<BooruSite[]>([]);
-  const [catalog, setCatalog] = useState<BooruEngineCatalog | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const sitesQuery = useBooruSites();
+  const catalogQuery = useBooruEngineCatalog();
+  const sites = sitesQuery.data ?? [];
+  const catalog = catalogQuery.data ?? null;
+  const loading = sitesQuery.isLoading || catalogQuery.isLoading;
+  const createSiteMutation = useCreateBooruSite();
+  const updateSiteMutation = useUpdateBooruSite();
+  const deleteSiteMutation = useDeleteBooruSite();
+  const testSiteMutation = useTestBooruSite();
+  const reorderSitesMutation = useReorderBooruSites();
+  const detectEngineMutation = useDetectBooruEngine();
+  const [localError, setLocalError] = useState<string | null>(null);
+  const error =
+    localError ??
+    (sitesQuery.error as Error | null)?.message ??
+    (catalogQuery.error as Error | null)?.message ??
+    null;
+  const setError = setLocalError;
   const [addForm, setAddForm] = useState<AddFormState>(initialAddForm());
   const [addingBusy, setAddingBusy] = useState(false);
   const [testingId, setTestingId] = useState<string | null>(null);
   const [testResults, setTestResults] = useState<Record<string, { ok: boolean; message: string }>>({});
-  const [editCredentials, setEditCredentials] = useState<Record<string, CredentialsState>>({});
+  const [editCredentials, setEditCredentials] = useState<Record<string, CredentialsState>>(() => {
+    const inputs: Record<string, CredentialsState> = {};
+    return inputs;
+  });
+
+  useMemo(() => {
+    if (!sitesQuery.data) return;
+    const inputs: Record<string, CredentialsState> = {};
+    sitesQuery.data.forEach((site) => {
+      inputs[site.id] = { username: site.username ?? '', apiKey: '' };
+    });
+    setEditCredentials((prev) => {
+      const merged: Record<string, CredentialsState> = { ...inputs };
+      Object.keys(prev).forEach((id) => {
+        if (merged[id]) merged[id] = { ...merged[id], ...prev[id] };
+      });
+      return merged;
+    });
+  }, [sitesQuery.data]);
 
   const reload = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const [list, engineCatalog] = await Promise.all([
-        api.getBooruSites(),
-        api.getBooruEngineCatalog()
-      ]);
-      setSites(list);
-      setCatalog(engineCatalog);
-      const inputs: Record<string, CredentialsState> = {};
-      list.forEach((site) => {
-        inputs[site.id] = {
-          username: site.username ?? '',
-          apiKey: ''
-        };
-      });
-      setEditCredentials(inputs);
-    } catch (err) {
-      setError((err as Error).message);
-    } finally {
-      setLoading(false);
-    }
+    setLocalError(null);
+    await Promise.all([sitesQuery.refetch(), catalogQuery.refetch()]);
   };
-
-  useEffect(() => {
-    void reload();
-  }, []);
 
   const detectedEngine: BooruEngineType | null = useMemo(() => {
     if (addForm.detection && 'engine' in addForm.detection) return addForm.detection.engine;
@@ -158,7 +177,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
         }
         setAddForm((prev) => ({ ...prev, detecting: true, detectError: null }));
         try {
-          const result = await api.detectBooruEngine(normalized);
+          const result = await detectEngineMutation.mutateAsync(normalized);
           setAddForm((prev) => ({
             ...prev,
             detection: result,
@@ -193,7 +212,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
     }
     setAddingBusy(true);
     try {
-      await api.createBooruSite({
+      await createSiteMutation.mutateAsync({
         name: addForm.name.trim(),
         engine: detectedEngine,
         baseUrl: ensureHttps(addForm.baseUrl),
@@ -215,8 +234,10 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
 
   const toggleCapability = async (site: BooruSite, capability: CapabilityKey) => {
     try {
-      const updated = await api.updateBooruSite(site.id, { [capability]: !site[capability] });
-      setSites((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
+      await updateSiteMutation.mutateAsync({
+        id: site.id,
+        payload: { [capability]: !site[capability] }
+      });
     } catch (err) {
       setError((err as Error).message);
     }
@@ -224,8 +245,10 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
 
   const toggleEnabled = async (site: BooruSite) => {
     try {
-      const updated = await api.updateBooruSite(site.id, { enabled: !site.enabled });
-      setSites((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
+      await updateSiteMutation.mutateAsync({
+        id: site.id,
+        payload: { enabled: !site.enabled }
+      });
     } catch (err) {
       setError((err as Error).message);
     }
@@ -235,12 +258,17 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
     const input = editCredentials[site.id];
     if (!input) return;
     try {
-      const updated = await api.updateBooruSite(site.id, {
-        username: input.username.trim() || null,
-        apiKey: input.apiKey.trim() || null
+      const updated = await updateSiteMutation.mutateAsync({
+        id: site.id,
+        payload: {
+          username: input.username.trim() || null,
+          apiKey: input.apiKey.trim() || null
+        }
       });
-      setSites((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
-      setEditCredentials((prev) => ({ ...prev, [site.id]: { username: updated.username ?? '', apiKey: '' } }));
+      setEditCredentials((prev) => ({
+        ...prev,
+        [site.id]: { username: updated.username ?? '', apiKey: '' }
+      }));
     } catch (err) {
       setError((err as Error).message);
     }
@@ -249,7 +277,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
   const deleteSite = async (site: BooruSite) => {
     if (!confirm(`Delete ${site.name}?`)) return;
     try {
-      await api.deleteBooruSite(site.id);
+      await deleteSiteMutation.mutateAsync(site.id);
       await reload();
     } catch (err) {
       setError((err as Error).message);
@@ -259,7 +287,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
   const testSite = async (site: BooruSite) => {
     setTestingId(site.id);
     try {
-      const res = await api.testBooruSite(site.id);
+      const res = await testSiteMutation.mutateAsync(site.id);
       setTestResults((prev) => ({
         ...prev,
         [site.id]: {
@@ -285,8 +313,7 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
     const reordered = [...sorted];
     [reordered[idx], reordered[targetIdx]] = [reordered[targetIdx], reordered[idx]];
     try {
-      const updated = await api.reorderBooruSites(reordered.map((s) => s.id));
-      setSites(updated);
+      const updated = await reorderSitesMutation.mutateAsync(reordered.map((s) => s.id));
     } catch (err) {
       setError((err as Error).message);
     }

--- a/frontend/src/hooks/auth.ts
+++ b/frontend/src/hooks/auth.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { api, type AuthUser } from '@/api';
+import { queryKeys } from '@/lib/query-keys';
+
+export function useCurrentUser() {
+  return useQuery<AuthUser | null>({
+    queryKey: queryKeys.auth.me(),
+    queryFn: async () => {
+      try {
+        return await api.getCurrentUser();
+      } catch {
+        return null;
+      }
+    },
+    staleTime: 60_000
+  });
+}
+
+export function useLogin() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: { username: string; password: string }) => api.login(payload),
+    onSuccess: (user) => {
+      queryClient.setQueryData(queryKeys.auth.me(), user);
+    }
+  });
+}
+
+export function useRegister() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: { username: string; password: string }) => api.register(payload),
+    onSuccess: (user) => {
+      queryClient.setQueryData(queryKeys.auth.me(), user);
+    }
+  });
+}
+
+export function useLogout() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.logout(),
+    onSuccess: () => {
+      queryClient.setQueryData(queryKeys.auth.me(), null);
+      queryClient.removeQueries({ queryKey: queryKeys.folders.all });
+      queryClient.removeQueries({ queryKey: queryKeys.files.all });
+      queryClient.removeQueries({ queryKey: queryKeys.sauces.all });
+      queryClient.removeQueries({ queryKey: queryKeys.favorites.all });
+      queryClient.removeQueries({ queryKey: queryKeys.credentials.all });
+      queryClient.removeQueries({ queryKey: queryKeys.duplicates.all });
+      queryClient.removeQueries({ queryKey: queryKeys.booruSites.all });
+    }
+  });
+}

--- a/frontend/src/hooks/booru-sites.ts
+++ b/frontend/src/hooks/booru-sites.ts
@@ -1,0 +1,79 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { api, type BooruEngineType, type BooruSite } from '@/api';
+import { queryKeys } from '@/lib/query-keys';
+
+type BooruCreatePayload = Parameters<typeof api.createBooruSite>[0];
+type BooruUpdatePayload = Parameters<typeof api.updateBooruSite>[1];
+
+export function useBooruSites(options: { enabled?: boolean } = {}) {
+  return useQuery<BooruSite[]>({
+    queryKey: queryKeys.booruSites.list(),
+    queryFn: () => api.getBooruSites(),
+    enabled: options.enabled ?? true
+  });
+}
+
+export function useBooruEngineCatalog(options: { enabled?: boolean } = {}) {
+  return useQuery({
+    queryKey: queryKeys.booruSites.engineCatalog(),
+    queryFn: () => api.getBooruEngineCatalog(),
+    enabled: options.enabled ?? true,
+    staleTime: 5 * 60_000
+  });
+}
+
+export function useDetectBooruEngine() {
+  return useMutation({
+    mutationFn: (baseUrl: string) => api.detectBooruEngine(baseUrl)
+  });
+}
+
+export function useCreateBooruSite() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: BooruCreatePayload) => api.createBooruSite(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.booruSites.list() });
+    }
+  });
+}
+
+export function useUpdateBooruSite() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: BooruUpdatePayload }) =>
+      api.updateBooruSite(id, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.booruSites.list() });
+    }
+  });
+}
+
+export function useDeleteBooruSite() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.deleteBooruSite(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.booruSites.list() });
+    }
+  });
+}
+
+export function useTestBooruSite() {
+  return useMutation({
+    mutationFn: (id: string) => api.testBooruSite(id)
+  });
+}
+
+export function useReorderBooruSites() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (orderedIds: string[]) => api.reorderBooruSites(orderedIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.booruSites.list() });
+    }
+  });
+}
+
+export type { BooruEngineType };

--- a/frontend/src/hooks/credentials.ts
+++ b/frontend/src/hooks/credentials.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { api, type CredentialProvider } from '@/api';
+import { queryKeys } from '@/lib/query-keys';
+
+export function useCredentials(options: { enabled?: boolean } = {}) {
+  return useQuery({
+    queryKey: queryKeys.credentials.list(),
+    queryFn: () => api.getCredentials(),
+    enabled: options.enabled ?? true
+  });
+}
+
+export function useUpdateCredential() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: {
+      provider: CredentialProvider;
+      username?: string;
+      apiKey?: string;
+    }) => api.updateCredential(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.credentials.list() });
+    }
+  });
+}

--- a/frontend/src/hooks/duplicates.ts
+++ b/frontend/src/hooks/duplicates.ts
@@ -1,0 +1,57 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { api, type DuplicateScanOptions, type DuplicateSettings } from '@/api';
+import { queryKeys } from '@/lib/query-keys';
+
+type ScanStatusOptions = {
+  enabled?: boolean;
+  refetchInterval?: number | false;
+};
+
+export function useDuplicateScanStatus(options: ScanStatusOptions = {}) {
+  return useQuery({
+    queryKey: queryKeys.duplicates.scanStatus(),
+    queryFn: () => api.getDuplicateScanStatus(),
+    enabled: options.enabled ?? true,
+    refetchInterval: options.refetchInterval
+  });
+}
+
+export function useStartDuplicateScan() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (options?: DuplicateScanOptions) => api.startDuplicateScan(options),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.duplicates.scanStatus() });
+    }
+  });
+}
+
+export function useCancelDuplicateScan() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.cancelDuplicateScan(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.duplicates.scanStatus() });
+    }
+  });
+}
+
+export function useDuplicateSettings(options: { enabled?: boolean } = {}) {
+  return useQuery({
+    queryKey: queryKeys.duplicates.settings(),
+    queryFn: () => api.getDuplicateSettings(),
+    enabled: options.enabled ?? true
+  });
+}
+
+export function useUpdateDuplicateSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (settings: Partial<DuplicateSettings>) =>
+      api.updateDuplicateSettings(settings),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.duplicates.settings() });
+    }
+  });
+}

--- a/frontend/src/hooks/favorites.ts
+++ b/frontend/src/hooks/favorites.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/api';
+import { queryKeys } from '@/lib/query-keys';
+
+type SyncStatusOptions = {
+  enabled?: boolean;
+  refetchInterval?: number | false;
+};
+
+export function useFavoritesSyncStatus(options: SyncStatusOptions = {}) {
+  return useQuery({
+    queryKey: queryKeys.favorites.syncStatus(),
+    queryFn: () => api.getFavoritesSyncStatus(),
+    enabled: options.enabled ?? true,
+    refetchInterval: options.refetchInterval
+  });
+}
+
+export function useSyncFavorites() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload?: {
+      providers?: ('E621' | 'DANBOORU')[];
+      deleteMissing?: boolean;
+    }) => api.syncFavorites(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.favorites.syncStatus() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.files.all });
+    }
+  });
+}
+
+export function useFavoritesSettings(options: { enabled?: boolean } = {}) {
+  return useQuery({
+    queryKey: queryKeys.favorites.settings(),
+    queryFn: () => api.getFavoritesSettings(),
+    enabled: options.enabled ?? true
+  });
+}
+
+export function useUpdateFavoritesSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (
+      settings: Parameters<typeof api.updateFavoritesSettings>[0]
+    ) => api.updateFavoritesSettings(settings),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.favorites.settings() });
+    }
+  });
+}

--- a/frontend/src/hooks/files.ts
+++ b/frontend/src/hooks/files.ts
@@ -1,0 +1,84 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { api, type ProviderRun } from '@/api';
+import { queryKeys } from '@/lib/query-keys';
+
+type FilesParams = {
+  folderId?: string;
+  sort?: 'mtime_desc' | 'mtime_asc' | 'random' | 'manual';
+  tags?: string;
+  mediaType?: 'IMAGE' | 'VIDEO';
+  favoritesOnly?: boolean;
+  seed?: string;
+  offset?: number;
+  limit?: number;
+};
+
+export function useFiles(params: FilesParams, options: { enabled?: boolean } = {}) {
+  return useQuery({
+    queryKey: queryKeys.files.list(params),
+    queryFn: ({ signal }) =>
+      api.getFiles(params.folderId, params.sort, params.tags, {
+        limit: params.limit,
+        offset: params.offset,
+        seed: params.seed,
+        mediaType: params.mediaType,
+        favoritesOnly: params.favoritesOnly,
+        signal
+      }),
+    enabled: options.enabled ?? true,
+    placeholderData: (previous) => previous
+  });
+}
+
+export function useFileProviders(fileId: string | null) {
+  return useQuery({
+    queryKey: queryKeys.files.providers(fileId ?? ''),
+    queryFn: () => api.getProviders(fileId as string),
+    enabled: Boolean(fileId)
+  });
+}
+
+export function useDeleteFile() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (fileId: string) => api.deleteFile(fileId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.files.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.duplicates.all });
+    }
+  });
+}
+
+export function useUpdateFileFavorite() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ fileId, favorite }: { fileId: string; favorite: boolean }) =>
+      api.updateFileFavorite(fileId, favorite),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.files.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.favorites.all });
+    }
+  });
+}
+
+export function useRunProvider() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ fileId, provider }: { fileId: string; provider: 'saucenao' | 'fluffle' }) =>
+      api.runProvider(fileId, provider),
+    onSuccess: (_data: { runs: ProviderRun[] }, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.files.providers(variables.fileId) });
+    }
+  });
+}
+
+export function useUpdateManualOrder() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (order: string[]) => api.updateManualOrder(order),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.files.all });
+    }
+  });
+}

--- a/frontend/src/hooks/folders.ts
+++ b/frontend/src/hooks/folders.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { api, type Folder } from '@/api';
+import { queryKeys } from '@/lib/query-keys';
+
+export function useFolders(options: { enabled?: boolean } = {}) {
+  return useQuery<Folder[]>({
+    queryKey: queryKeys.folders.list(),
+    queryFn: () => api.getFolders(),
+    enabled: options.enabled ?? true
+  });
+}
+
+export function useDeleteFolder() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.deleteFolder(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.folders.list() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.files.all });
+    }
+  });
+}
+
+type UploadVariables = {
+  folderId: string;
+  files: File[];
+  onProgress?: Parameters<typeof api.uploadFolderFiles>[2] extends infer Opt
+    ? Opt extends { onProgress?: infer F }
+      ? F
+      : never
+    : never;
+};
+
+export function useUploadFolderFiles() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ folderId, files, onProgress }: UploadVariables) =>
+      api.uploadFolderFiles(folderId, files, onProgress ? { onProgress } : undefined),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.files.all });
+    }
+  });
+}

--- a/frontend/src/hooks/sauces.ts
+++ b/frontend/src/hooks/sauces.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { api, type SauceSettings } from '@/api';
+import { queryKeys } from '@/lib/query-keys';
+
+export function useSauces(options: { enabled?: boolean } = {}) {
+  return useQuery({
+    queryKey: queryKeys.sauces.list(),
+    queryFn: () => api.getSauces(),
+    enabled: options.enabled ?? true
+  });
+}
+
+export function useUpdateSauceSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (settings: SauceSettings) => api.updateSauceSettings(settings),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.sauces.list() });
+    }
+  });
+}

--- a/frontend/src/hooks/tags.ts
+++ b/frontend/src/hooks/tags.ts
@@ -1,0 +1,79 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/api';
+import { queryKeys } from '@/lib/query-keys';
+
+export function useFileTags(fileId: string | null, options: { enabled?: boolean } = {}) {
+  return useQuery({
+    queryKey: queryKeys.files.tags(fileId ?? ''),
+    queryFn: () => api.getFileTags(fileId as string),
+    enabled: Boolean(fileId) && (options.enabled ?? true)
+  });
+}
+
+export function useRefreshFileTags() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (fileId: string) => api.refreshFileTags(fileId),
+    onSuccess: (_data, fileId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.files.tags(fileId) });
+    }
+  });
+}
+
+export function useClearFileTags() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (fileId: string) => api.clearFileTags(fileId),
+    onSuccess: (_data, fileId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.files.tags(fileId) });
+    }
+  });
+}
+
+export function useAddManualTag() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      fileId,
+      tag,
+      category
+    }: {
+      fileId: string;
+      tag: string;
+      category: string;
+    }) => api.addManualTag(fileId, tag, category),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.files.tags(variables.fileId) });
+    }
+  });
+}
+
+export function useRemoveManualTag() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      fileId,
+      tag,
+      category
+    }: {
+      fileId: string;
+      tag: string;
+      category: string;
+    }) => api.removeManualTag(fileId, tag, category),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.files.tags(variables.fileId) });
+    }
+  });
+}
+
+export function useRemoveTopMatch() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ fileId, sourceUrl }: { fileId: string; sourceUrl: string }) =>
+      api.removeTopMatch(fileId, sourceUrl),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.files.providers(variables.fileId) });
+    }
+  });
+}

--- a/frontend/src/lib/query-client.ts
+++ b/frontend/src/lib/query-client.ts
@@ -1,0 +1,17 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        gcTime: 5 * 60_000,
+        retry: 1,
+        refetchOnWindowFocus: false
+      },
+      mutations: {
+        retry: 0
+      }
+    }
+  });
+}

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -1,0 +1,53 @@
+import type { DuplicateScanOptions } from '@/api';
+
+export const queryKeys = {
+  auth: {
+    all: ['auth'] as const,
+    me: () => [...queryKeys.auth.all, 'me'] as const
+  },
+  folders: {
+    all: ['folders'] as const,
+    list: () => [...queryKeys.folders.all, 'list'] as const
+  },
+  files: {
+    all: ['files'] as const,
+    list: (params: {
+      folderId?: string;
+      sort?: string;
+      tags?: string;
+      mediaType?: string;
+      favoritesOnly?: boolean;
+      seed?: string;
+      offset?: number;
+      limit?: number;
+    }) => [...queryKeys.files.all, 'list', params] as const,
+    providers: (fileId: string) =>
+      [...queryKeys.files.all, fileId, 'providers'] as const,
+    tags: (fileId: string) => [...queryKeys.files.all, fileId, 'tags'] as const
+  },
+  sauces: {
+    all: ['sauces'] as const,
+    list: () => [...queryKeys.sauces.all, 'list'] as const
+  },
+  favorites: {
+    all: ['favorites'] as const,
+    syncStatus: () => [...queryKeys.favorites.all, 'sync-status'] as const,
+    settings: () => [...queryKeys.favorites.all, 'settings'] as const
+  },
+  credentials: {
+    all: ['credentials'] as const,
+    list: () => [...queryKeys.credentials.all, 'list'] as const
+  },
+  duplicates: {
+    all: ['duplicates'] as const,
+    scanStatus: () => [...queryKeys.duplicates.all, 'scan-status'] as const,
+    settings: () => [...queryKeys.duplicates.all, 'settings'] as const,
+    scan: (options?: DuplicateScanOptions) =>
+      [...queryKeys.duplicates.all, 'scan', options ?? {}] as const
+  },
+  booruSites: {
+    all: ['booru-sites'] as const,
+    list: () => [...queryKeys.booruSites.all, 'list'] as const,
+    engineCatalog: () => [...queryKeys.booruSites.all, 'engine-catalog'] as const
+  }
+} as const;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,8 +2,11 @@ import './index.css';
 import './app.css';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import App from './App';
+import { createQueryClient } from './lib/query-client';
 
 const container = document.getElementById('root');
 
@@ -11,9 +14,14 @@ if (!container) {
   throw new Error('Root container missing');
 }
 
+const queryClient = createQueryClient();
+
 const root = createRoot(container);
 root.render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+      {import.meta.env.DEV ? <ReactQueryDevtools buttonPosition="bottom-left" /> : null}
+    </QueryClientProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary

PR #2 of 6 for the modernization roadmap tracked in #103. Routes the
custom \`useState + useEffect + api.X()\` data layer in App.tsx and
BooruSitesPanel.tsx through TanStack Query.

- \`@tanstack/react-query\` + devtools installed; a single \`QueryClient\`
  wired in main.tsx with project defaults
  (\`staleTime: 30s\`, \`retry: 1\`, no focus refetch).
- Typed \`queryKeys\` registry under \`src/lib/query-keys.ts\` so every
  invalidation lands on the same key shape.
- One hooks module per domain under \`src/hooks/\`: auth, folders, files,
  sauces, favorites, credentials, tags, duplicates, booru-sites.
  Mutations invalidate the related read keys so a successful write
  refetches the right list on the next consumer pass.
- App.tsx auth flow now lives on \`useCurrentUser\` + \`useLogin\` /
  \`useRegister\` / \`useLogout\` mutations. The auth-required event
  handler defers cross-domain cleanup to \`queryClient.removeQueries\`
  instead of touching seven \`setX([])\`.
- App.tsx mutations (file delete, favorite, manual order, run-provider,
  tags add/remove/refresh/clear, removeTopMatch, sauce/favorites/
  duplicates settings, credentials, duplicate scan start/cancel) all go
  through their mutation hooks now.
- App.tsx read-side calls that still live inside hand-rolled \`load*\`
  callbacks (\`loadSauces\`, \`loadFavoritesSettings\`,
  \`loadFavoritesSyncStatus\`, \`loadDuplicateSettings\`,
  \`loadCredentials\`, the file detail \`getProviders\` / \`getFileTags\`)
  route through \`queryClient.fetchQuery\` so the data populates the
  TanStack cache. Subsequent mutation invalidations therefore actually
  refetch the same key the next time the callback runs.
- BooruSitesPanel reads list + engine catalog straight from
  \`useBooruSites\` / \`useBooruEngineCatalog\` and trusts hook
  invalidation for refresh, dropping every \`setSites(prev => prev.map…)\`
  optimistic update.

## Out of scope (#103 follow-up)

- \`loadGalleryPage\` still uses raw \`api.getFiles\` with manual
  AbortController + offset + a hand-rolled \`galleryCacheRef\`. The
  natural replacement is \`useInfiniteQuery\`; doing it in this PR
  would double its size.
- Two polling loops (\`getDuplicateScanStatus\`,
  \`getFavoritesSyncStatus\`) still use \`setInterval\` /
  \`setTimeout\`. They should move to \`refetchInterval\`.
- The \`load*\` callbacks above are thin shims; once consumer components
  stop reading \`credentials\`/\`sauceSources\`/etc. from local useState
  they can be replaced by direct \`useX()\` consumption.

## Test plan

- [x] \`cd frontend && npm run build\` — 0 errors, bundle settles at
      CSS 78KB / JS 343KB (gz 13/97).
- [x] \`cd frontend && npm test\` — vitest 13/13.
- [x] \`npx playwright test\` — smoke 4/4 (auth round-trip, gallery
      empty, duplicates empty).
- [ ] Human visual smoke: log in, navigate gallery, open file detail,
      mark favorite, toggle duplicates, open credentials, add a booru
      site.

## Review notes

Pre-push reviewer pass (Opus) flagged a useMemo-as-effect anti-pattern,
three unused hook imports, an unused \`updated\` binding, a double
refetch in BooruSitesPanel.deleteSite, a redundant manual loadData on
login, and the existing silent catch in \`logout\`. All are addressed
in commit 42bea75 — no critical issues remain.

Refs #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)