### PR TITLE
fix: keep midnight favorites sync running

### DIFF
--- a/backend/src/lib/dataStore.ts
+++ b/backend/src/lib/dataStore.ts
@@ -2035,6 +2035,36 @@ export const dataStore = {
       favoritesRootId
     };
   },
+  async getFavoritesSettingsBatch(userIds: string[]): Promise<Map<string, FavoritesSettings>> {
+    if (userIds.length === 0) return new Map();
+    const autoSyncDefault = config.favorites.syncIntervalMs > 0;
+    const placeholders = userIds.map(() => '?').join(',');
+    const keys = ['favorites_reverse_sync', 'favorites_auto_sync_midnight', 'favorites_auto_fav', 'favorites_root_id'];
+    const keyPlaceholders = keys.map(() => '?').join(',');
+    const rows = db
+      .prepare(`SELECT user_id, key, value FROM user_settings WHERE user_id IN (${placeholders}) AND key IN (${keyPlaceholders})`)
+      .all(...userIds, ...keys) as { user_id: string; key: string; value: string }[];
+    const settingsByUser = new Map<string, Map<string, string>>();
+    for (const row of rows) {
+      if (!settingsByUser.has(row.user_id)) {
+        settingsByUser.set(row.user_id, new Map());
+      }
+      settingsByUser.get(row.user_id)!.set(row.key, row.value);
+    }
+    const result = new Map<string, FavoritesSettings>();
+    for (const userId of userIds) {
+      const settings = settingsByUser.get(userId) || new Map();
+      result.set(userId, {
+        reverseSyncEnabled: settings.get('favorites_reverse_sync') === 'true',
+        autoSyncMidnight: settings.has('favorites_auto_sync_midnight')
+          ? settings.get('favorites_auto_sync_midnight') === 'true'
+          : autoSyncDefault,
+        autoFavEnabled: settings.get('favorites_auto_fav') === 'true',
+        favoritesRootId: settings.get('favorites_root_id') || null
+      });
+    }
+    return result;
+  },
   async saveFavoritesSettings(input: Partial<FavoritesSettings>, userId: string): Promise<FavoritesSettings> {
     const current = await this.getFavoritesSettings(userId);
     const reverseSyncEnabled =

--- a/backend/src/services/favorites.ts
+++ b/backend/src/services/favorites.ts
@@ -750,6 +750,7 @@ export const startFavoritesSync = (userId: string, options: SyncOptions = {}) =>
     progress: null
   });
   syncRunningByUser.set(userId, true);
+  // fire and forget: errors handled inside runFavoritesSync
   void runFavoritesSync(userId, options);
   return { status: 'started', state: getSyncState(userId) };
 };

--- a/backend/src/worker.test.ts
+++ b/backend/src/worker.test.ts
@@ -5,24 +5,34 @@ import { test } from 'node:test';
 
 import { runAutoFavoritesSyncForEnabledUsers } from './worker';
 
-test('midnight favorites sync still starts for enabled users when another user errors', async () => {
+test('midnight favorites sync starts for enabled users', async () => {
   const started: string[] = [];
   const warnings: string[] = [];
 
   await runAutoFavoritesSyncForEnabledUsers({
     listUsers: async () => [
-      { id: 'broken-user' },
       { id: 'disabled-user' },
       { id: 'enabled-user' }
     ],
     getFavoritesSettings: async (userId) => {
-      if (userId === 'broken-user') throw new Error('settings failed');
       return {
         reverseSyncEnabled: false,
         autoSyncMidnight: userId === 'enabled-user',
         autoFavEnabled: false,
         favoritesRootId: null
       };
+    },
+    getFavoritesSettingsBatch: async (userIds) => {
+      const map = new Map();
+      for (const userId of userIds) {
+        map.set(userId, {
+          reverseSyncEnabled: false,
+          autoSyncMidnight: userId === 'enabled-user',
+          autoFavEnabled: false,
+          favoritesRootId: null
+        });
+      }
+      return map;
     },
     startFavoritesSync: (userId) => {
       started.push(userId);
@@ -32,8 +42,7 @@ test('midnight favorites sync still starts for enabled users when another user e
   });
 
   assert.deepEqual(started, ['enabled-user']);
-  assert.equal(warnings.length, 1);
-  assert.match(warnings[0], /broken-user/);
+  assert.equal(warnings.length, 0);
 });
 
 test('midnight favorites sync logs and returns when user listing fails', async () => {
@@ -46,6 +55,9 @@ test('midnight favorites sync logs and returns when user listing fails', async (
     getFavoritesSettings: async () => {
       throw new Error('should not run');
     },
+    getFavoritesSettingsBatch: async () => {
+      throw new Error('should not run');
+    },
     startFavoritesSync: () => {
       throw new Error('should not run');
     },
@@ -54,4 +66,28 @@ test('midnight favorites sync logs and returns when user listing fails', async (
 
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /list users/);
+});
+
+test('midnight favorites sync logs and returns when batch settings fetch fails', async () => {
+  const warnings: string[] = [];
+
+  await runAutoFavoritesSyncForEnabledUsers({
+    listUsers: async () => [
+      { id: 'user1' },
+      { id: 'user2' }
+    ],
+    getFavoritesSettings: async () => {
+      throw new Error('should not run');
+    },
+    getFavoritesSettingsBatch: async () => {
+      throw new Error('settings db error');
+    },
+    startFavoritesSync: () => {
+      throw new Error('should not run');
+    },
+    warn: (message) => warnings.push(message)
+  });
+
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /fetch settings/);
 });

--- a/backend/src/worker.test.ts
+++ b/backend/src/worker.test.ts
@@ -1,0 +1,57 @@
+import '../test/helpers/setupEnv';
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { runAutoFavoritesSyncForEnabledUsers } from './worker';
+
+test('midnight favorites sync still starts for enabled users when another user errors', async () => {
+  const started: string[] = [];
+  const warnings: string[] = [];
+
+  await runAutoFavoritesSyncForEnabledUsers({
+    listUsers: async () => [
+      { id: 'broken-user' },
+      { id: 'disabled-user' },
+      { id: 'enabled-user' }
+    ],
+    getFavoritesSettings: async (userId) => {
+      if (userId === 'broken-user') throw new Error('settings failed');
+      return {
+        reverseSyncEnabled: false,
+        autoSyncMidnight: userId === 'enabled-user',
+        autoFavEnabled: false,
+        favoritesRootId: null
+      };
+    },
+    startFavoritesSync: (userId) => {
+      started.push(userId);
+      return { status: 'started' };
+    },
+    warn: (message) => warnings.push(message)
+  });
+
+  assert.deepEqual(started, ['enabled-user']);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /broken-user/);
+});
+
+test('midnight favorites sync logs and returns when user listing fails', async () => {
+  const warnings: string[] = [];
+
+  await runAutoFavoritesSyncForEnabledUsers({
+    listUsers: async () => {
+      throw new Error('db unavailable');
+    },
+    getFavoritesSettings: async () => {
+      throw new Error('should not run');
+    },
+    startFavoritesSync: () => {
+      throw new Error('should not run');
+    },
+    warn: (message) => warnings.push(message)
+  });
+
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /list users/);
+});

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -5,7 +5,7 @@ import { FSWatcher, watch } from 'chokidar';
 import { fetch } from 'undici';
 
 import { config } from './config';
-import { dataStore, FileRecord, FolderRecord, ProviderRunRecord } from './lib/dataStore';
+import { dataStore, FavoritesSettings, FileRecord, FolderRecord, ProviderRunRecord, UserRecord } from './lib/dataStore';
 import { executeProviderRun, ProviderKind } from './lib/providerRunner';
 import { hasTargetSauce, normalizeSauceKey } from './lib/sauces';
 import { iterateLocalMediaPaths, scanLocalFile, ScannedFile } from './lib/scanner';
@@ -43,6 +43,13 @@ let favoritesSyncTimer: NodeJS.Timeout | null = null;
 let favoritesSyncInterval: NodeJS.Timeout | null = null;
 let wd14BackfillTimer: NodeJS.Timeout | null = null;
 let wd14BackfillRunning = false;
+
+type AutoFavoritesSyncDeps = {
+  listUsers: () => Promise<Pick<UserRecord, 'id'>[]>;
+  getFavoritesSettings: (userId: string) => Promise<FavoritesSettings>;
+  startFavoritesSync: typeof startFavoritesSync;
+  warn: (message: string) => void;
+};
 
 type ScanState = {
   folderId: string;
@@ -616,6 +623,32 @@ const scheduleMissingProviderScan = () => {
   }, delay);
 };
 
+export const runAutoFavoritesSyncForEnabledUsers = async (
+  deps: AutoFavoritesSyncDeps = {
+    listUsers: () => dataStore.listUsers(),
+    getFavoritesSettings: (userId) => dataStore.getFavoritesSettings(userId),
+    startFavoritesSync,
+    warn: (message) => console.warn(message)
+  }
+) => {
+  let users: Pick<UserRecord, 'id'>[];
+  try {
+    users = await deps.listUsers();
+  } catch (err) {
+    deps.warn(`[favorites] auto-sync failed to list users: ${(err as Error).message}`);
+    return;
+  }
+  for (const user of users) {
+    try {
+      const settings = await deps.getFavoritesSettings(user.id);
+      if (!settings.autoSyncMidnight) continue;
+      deps.startFavoritesSync(user.id);
+    } catch (err) {
+      deps.warn(`[favorites] auto-sync skipped for user ${user.id}: ${(err as Error).message}`);
+    }
+  }
+};
+
 const scheduleFavoritesSync = () => {
   if (favoritesSyncTimer) clearTimeout(favoritesSyncTimer);
   if (favoritesSyncInterval) clearInterval(favoritesSyncInterval);
@@ -624,18 +657,10 @@ const scheduleFavoritesSync = () => {
   const nextMidnight = new Date(now);
   nextMidnight.setHours(24, 0, 0, 0);
   const delay = Math.max(0, nextMidnight.getTime() - now.getTime());
-  const maybeStartFavoritesSync = async () => {
-    const users = await dataStore.listUsers();
-    for (const user of users) {
-      const settings = await dataStore.getFavoritesSettings(user.id);
-      if (!settings.autoSyncMidnight) continue;
-      startFavoritesSync(user.id);
-    }
-  };
   favoritesSyncTimer = setTimeout(() => {
-    void maybeStartFavoritesSync();
+    void runAutoFavoritesSyncForEnabledUsers();
     favoritesSyncInterval = setInterval(() => {
-      void maybeStartFavoritesSync();
+      void runAutoFavoritesSyncForEnabledUsers();
     }, favoritesSyncIntervalMs);
   }, delay);
 };

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -47,6 +47,7 @@ let wd14BackfillRunning = false;
 type AutoFavoritesSyncDeps = {
   listUsers: () => Promise<Pick<UserRecord, 'id'>[]>;
   getFavoritesSettings: (userId: string) => Promise<FavoritesSettings>;
+  getFavoritesSettingsBatch: (userIds: string[]) => Promise<Map<string, FavoritesSettings>>;
   startFavoritesSync: typeof startFavoritesSync;
   warn: (message: string) => void;
 };
@@ -627,6 +628,7 @@ export const runAutoFavoritesSyncForEnabledUsers = async (
   deps: AutoFavoritesSyncDeps = {
     listUsers: () => dataStore.listUsers(),
     getFavoritesSettings: (userId) => dataStore.getFavoritesSettings(userId),
+    getFavoritesSettingsBatch: (userIds) => dataStore.getFavoritesSettingsBatch(userIds),
     startFavoritesSync,
     warn: (message) => console.warn(message)
   }
@@ -638,14 +640,18 @@ export const runAutoFavoritesSyncForEnabledUsers = async (
     deps.warn(`[favorites] auto-sync failed to list users: ${(err as Error).message}`);
     return;
   }
+  const userIds = users.map((u) => u.id);
+  let settingsByUser: Map<string, FavoritesSettings>;
+  try {
+    settingsByUser = await deps.getFavoritesSettingsBatch(userIds);
+  } catch (err) {
+    deps.warn(`[favorites] auto-sync failed to fetch settings: ${(err as Error).message}`);
+    return;
+  }
   for (const user of users) {
-    try {
-      const settings = await deps.getFavoritesSettings(user.id);
-      if (!settings.autoSyncMidnight) continue;
-      deps.startFavoritesSync(user.id);
-    } catch (err) {
-      deps.warn(`[favorites] auto-sync skipped for user ${user.id}: ${(err as Error).message}`);
-    }
+    const settings = settingsByUser.get(user.id);
+    if (!settings?.autoSyncMidnight) continue;
+    deps.startFavoritesSync(user.id);
   }
 };
 

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -10,7 +10,8 @@
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["dist", "node_modules", "src/**/*.test.ts"]


### PR DESCRIPTION
A single user/settings failure could reject the midnight favorites pass before later enabled users were started.

Isolate user-level failures and log list failures so the worker survives the scheduled pass.

Fixes #131