### PR TITLE
fix: sync favorite deletes and gallery layout

### DIFF
--- a/backend/src/lib/booruEngines/gelbooru.test.ts
+++ b/backend/src/lib/booruEngines/gelbooru.test.ts
@@ -157,3 +157,22 @@ test('fetchFavorites aborts when signal fires before loop', async () => {
     /aborted/i
   );
 });
+
+test('unfavorite rejects a redirect to the favorites view', async (t) => {
+  const agent = setupMockAgent(t);
+  mockPool(agent)
+    .intercept({ path: (p: string) => p.includes('page=favorites') && p.includes('s=delete') && p.includes('id=123') })
+    .reply(302, '', {
+      headers: {
+        location: '/index.php?page=favorites&s=view&id='
+      }
+    });
+  mockPool(agent)
+    .intercept({ path: (p: string) => p.includes('page=favorites') && p.includes('s=view') })
+    .reply(200, '<html>favorites</html>');
+
+  await assert.rejects(
+    () => gelbooruEngine.unfavorite!(baseSite(), '123'),
+    /unfavorite redirected/
+  );
+});

--- a/backend/src/lib/booruEngines/gelbooru.test.ts
+++ b/backend/src/lib/booruEngines/gelbooru.test.ts
@@ -167,9 +167,6 @@ test('unfavorite rejects a redirect to the favorites view', async (t) => {
         location: '/index.php?page=favorites&s=view&id='
       }
     });
-  mockPool(agent)
-    .intercept({ path: (p: string) => p.includes('page=favorites') && p.includes('s=view') })
-    .reply(200, '<html>favorites</html>');
 
   await assert.rejects(
     () => gelbooruEngine.unfavorite!(baseSite(), '123'),

--- a/backend/src/lib/booruEngines/gelbooru.ts
+++ b/backend/src/lib/booruEngines/gelbooru.ts
@@ -208,6 +208,28 @@ export const gelbooruEngine: BooruEngineModule = {
     return { items, downloadHeaders: headers };
   },
 
+  async unfavorite(site, postId) {
+    if (!site.username || !site.apiKey) throw new Error(`${site.name} credentials missing`);
+    const params = new URLSearchParams({
+      page: 'favorites',
+      s: 'delete',
+      id: postId,
+      user_id: site.username,
+      api_key: site.apiKey
+    });
+    const res = await fetch(safeJoin(site.baseUrl, `/index.php?${params.toString()}`), {
+      headers: buildHeaders(),
+      redirect: 'manual'
+    });
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get('location') ?? '';
+      throw new Error(`${site.name} unfavorite redirected (${res.status}) to ${location || 'unknown location'}`);
+    }
+    if (res.ok || res.status === 404) return;
+    const text = await res.text();
+    throw new Error(`${site.name} unfavorite failed (${res.status}): ${text.slice(0, 200)}`);
+  },
+
   extractIdFromUrl(url, site) {
     try {
       const parsed = new URL(url);

--- a/backend/src/lib/booruEngines/gelbooru.ts
+++ b/backend/src/lib/booruEngines/gelbooru.ts
@@ -225,6 +225,7 @@ export const gelbooruEngine: BooruEngineModule = {
       const location = res.headers.get('location') ?? '';
       throw new Error(`${site.name} unfavorite redirected (${res.status}) to ${location || 'unknown location'}`);
     }
+    // 404 means the favorite was already absent, so remote state is satisfied.
     if (res.ok || res.status === 404) return;
     const text = await res.text();
     throw new Error(`${site.name} unfavorite failed (${res.status}): ${text.slice(0, 200)}`);

--- a/backend/src/worker.test.ts
+++ b/backend/src/worker.test.ts
@@ -3,7 +3,7 @@ import '../test/helpers/setupEnv';
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { runAutoFavoritesSyncForEnabledUsers } from './worker';
+import { runAutoFavoritesSyncForEnabledUsers, shouldWarnMissingLocalFolder } from './worker';
 
 test('midnight favorites sync starts for enabled users', async () => {
   const started: string[] = [];
@@ -90,4 +90,12 @@ test('midnight favorites sync logs and returns when batch settings fetch fails',
 
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /fetch settings/);
+});
+
+test('shouldWarnMissingLocalFolder warns once until the folder exists again', () => {
+  assert.equal(shouldWarnMissingLocalFolder('folder-a', '/missing/path', false), true);
+  assert.equal(shouldWarnMissingLocalFolder('folder-a', '/missing/path', false), false);
+
+  assert.equal(shouldWarnMissingLocalFolder('folder-a', '/missing/path', true), false);
+  assert.equal(shouldWarnMissingLocalFolder('folder-a', '/missing/path', false), true);
 });

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -36,6 +36,7 @@ const scanFileRetryLimit = 2;
 const watchers = new Map<string, FSWatcher>();
 const scanStates = new Map<string, ScanState>();
 const folderMtimeCache = new Map<string, number>();
+const missingLocalFolderWarnings = new Set<string>();
 let providerRefreshRunning = false;
 let missingProviderRunning = false;
 let missingProviderTimer: NodeJS.Timeout | null = null;
@@ -164,6 +165,17 @@ const isManagedChildPath = (filePath: string, managedChildRoots: string[]) => {
   return managedChildRoots.some((childRoot) => {
     return isSameOrInsidePath(filePath, childRoot);
   });
+};
+
+export const shouldWarnMissingLocalFolder = (folderId: string, folderPath: string, exists: boolean) => {
+  const key = `${folderId}:${path.resolve(folderPath)}`;
+  if (exists) {
+    missingLocalFolderWarnings.delete(key);
+    return false;
+  }
+  if (missingLocalFolderWarnings.has(key)) return false;
+  missingLocalFolderWarnings.add(key);
+  return true;
 };
 
 const deleteExistingPathFromFolder = async (filePath: string, state: ScanState) => {
@@ -438,10 +450,13 @@ const startScanSession = async (folderId: string, reason: string) => {
 
 const startFolderWatch = (folderId: string, folderPath: string) => {
   if (watchers.has(folderId)) return false;
-  if (!fs.existsSync(folderPath)) {
+  const exists = fs.existsSync(folderPath);
+  if (!exists) {
+    if (!shouldWarnMissingLocalFolder(folderId, folderPath, false)) return false;
     console.warn(`[auto-scan] watch skipped, path not found: ${folderPath}`);
     return false;
   }
+  shouldWarnMissingLocalFolder(folderId, folderPath, true);
   const watcher = watch(folderPath, {
     ignoreInitial: true,
     awaitWriteFinish: {
@@ -517,12 +532,14 @@ const pollLocalFolderChanges = async () => {
     if (folder.type !== 'LOCAL') continue;
     try {
       const stats = await fs.promises.stat(folder.path);
+      shouldWarnMissingLocalFolder(folder.id, folder.path, true);
       const previous = folderMtimeCache.get(folder.id);
       folderMtimeCache.set(folder.id, stats.mtimeMs);
       if (previous !== undefined && stats.mtimeMs > previous) {
         queueFullScan(folder.id, 'mtime-poll');
       }
     } catch (err) {
+      if (!shouldWarnMissingLocalFolder(folder.id, folder.path, false)) continue;
       console.warn(`[auto-scan] mtime poll failed for ${folder.path}: ${(err as Error).message}`);
     }
   }

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -539,7 +539,9 @@ const pollLocalFolderChanges = async () => {
         queueFullScan(folder.id, 'mtime-poll');
       }
     } catch (err) {
-      if (!shouldWarnMissingLocalFolder(folder.id, folder.path, false)) continue;
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT' && !shouldWarnMissingLocalFolder(folder.id, folder.path, false)) {
+        continue;
+      }
       console.warn(`[auto-scan] mtime poll failed for ${folder.path}: ${(err as Error).message}`);
     }
   }

--- a/backend/test/files.test.ts
+++ b/backend/test/files.test.ts
@@ -4,10 +4,11 @@ import './helpers/setupEnv';
 
 import fs from 'fs';
 import assert from 'node:assert/strict';
-import { after, before, test } from 'node:test';
+import { after, before, test, type TestContext } from 'node:test';
 import path from 'path';
 
 import type { FastifyInstance } from 'fastify';
+import { getGlobalDispatcher, MockAgent, setGlobalDispatcher } from 'undici';
 
 import { dataStore } from '../src/lib/dataStore';
 
@@ -32,6 +33,18 @@ after(async () => {
 const cookieFor = async (userId: string) => {
   const session = await sessionCookieFor(userId);
   return `${session.name}=${session.value}`;
+};
+
+const setupMockAgent = (t: TestContext): MockAgent => {
+  const previous = getGlobalDispatcher();
+  const agent = new MockAgent();
+  agent.disableNetConnect();
+  setGlobalDispatcher(agent);
+  t.after(async () => {
+    await agent.close();
+    setGlobalDispatcher(previous);
+  });
+  return agent;
 };
 
 // Real PNG with valid 1x1 dimensions, so the scanner can pull width/height.
@@ -206,6 +219,133 @@ test('DELETE /files/:id removes the file from disk and DB', async () => {
   assert.equal(res.statusCode, 200);
   const body = res.json() as { status: string };
   assert.equal(body.status, 'deleted');
+  assert.equal(fs.existsSync(filePath), false);
+});
+
+test('DELETE /files/:id reverse-syncs custom Gelbooru favorites', async (t) => {
+  const agent = setupMockAgent(t);
+  let capturedPath = '';
+  agent
+    .get('https://gelbooru.com')
+    .intercept({
+      method: 'GET',
+      path: (requestPath: string) => {
+        const matches =
+          requestPath.includes('page=favorites') &&
+          requestPath.includes('s=delete') &&
+          requestPath.includes('id=123');
+        if (matches) capturedPath = requestPath;
+        return matches;
+      }
+    })
+    .reply(200, '');
+
+  const seeded = await seedUser({ username: 'files_delete_gelbooru_reverse' });
+  const cookie = await cookieFor(seeded.user.id);
+  await dataStore.saveFavoritesSettings({ reverseSyncEnabled: true }, seeded.user.id);
+  const site = await dataStore.insertBooruSite(
+    {
+      name: 'Gelbooru',
+      engine: 'gelbooru',
+      baseUrl: 'https://gelbooru.com',
+      username: '42',
+      apiKey: 'testkey',
+      isPreset: false,
+      enabled: true,
+      capFavorites: true,
+      capTags: true,
+      capSourceMatch: true,
+      capSearch: true
+    },
+    seeded.user.id
+  );
+  const folders = await dataStore.listFolders(seeded.user.id);
+  const filePath = writeFixtureFile(folders[0].path, 'gelbooru-fav.png', ONE_BY_ONE_PNG);
+  const file = await registerFixtureFile(folders[0].id, filePath);
+  await dataStore.upsertFavoriteItem(
+    {
+      provider: site.id,
+      remoteId: '123',
+      filePath: file.path,
+      sourceUrl: 'https://gelbooru.com/index.php?page=post&s=view&id=123',
+      fileUrl: null
+    },
+    seeded.user.id
+  );
+
+  const res = await app.inject({
+    method: 'DELETE',
+    url: `/files/${file.id}`,
+    headers: { cookie }
+  });
+  assert.equal(res.statusCode, 200);
+  const body = res.json() as { status: string; errors?: string[] };
+  assert.equal(body.status, 'deleted');
+  assert.equal(body.errors, undefined);
+  assert.match(capturedPath, /page=favorites/);
+  assert.match(capturedPath, /s=delete/);
+  assert.match(capturedPath, /id=123/);
+});
+
+test('DELETE /files/:id reports Gelbooru unfavorite redirects', async (t) => {
+  const agent = setupMockAgent(t);
+  agent
+    .get('https://rule34.xxx')
+    .intercept({
+      method: 'GET',
+      path: (requestPath: string) =>
+        requestPath.includes('page=favorites') &&
+        requestPath.includes('s=delete') &&
+        requestPath.includes('id=123')
+    })
+    .reply(302, '', {
+      headers: {
+        location: '/index.php?page=favorites&s=view&id='
+      }
+    });
+
+  const seeded = await seedUser({ username: 'files_delete_rule34_redirect' });
+  const cookie = await cookieFor(seeded.user.id);
+  await dataStore.saveFavoritesSettings({ reverseSyncEnabled: true }, seeded.user.id);
+  const site = await dataStore.insertBooruSite(
+    {
+      name: 'Rule34',
+      engine: 'gelbooru',
+      baseUrl: 'https://rule34.xxx',
+      username: '42',
+      apiKey: 'testkey',
+      isPreset: false,
+      enabled: true,
+      capFavorites: true,
+      capTags: true,
+      capSourceMatch: true,
+      capSearch: true
+    },
+    seeded.user.id
+  );
+  const folders = await dataStore.listFolders(seeded.user.id);
+  const filePath = writeFixtureFile(folders[0].path, 'rule34-fav.png', ONE_BY_ONE_PNG);
+  const file = await registerFixtureFile(folders[0].id, filePath);
+  await dataStore.upsertFavoriteItem(
+    {
+      provider: site.id,
+      remoteId: '123',
+      filePath: file.path,
+      sourceUrl: 'https://rule34.xxx/index.php?page=post&s=view&id=123',
+      fileUrl: null
+    },
+    seeded.user.id
+  );
+
+  const res = await app.inject({
+    method: 'DELETE',
+    url: `/files/${file.id}`,
+    headers: { cookie }
+  });
+  assert.equal(res.statusCode, 200);
+  const body = res.json() as { status: string; errors?: string[] };
+  assert.equal(body.status, 'deleted');
+  assert.match(body.errors?.join('\n') ?? '', /unfavorite redirected/);
   assert.equal(fs.existsSync(filePath), false);
 });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -245,55 +245,57 @@ function App() {
     <div className="bg-background text-foreground min-h-screen">
       {fileDetailCtl.selectedFile ? null : (
         <div className="container page-shell">
-          <div className="flex justify-between items-center mb-4">
-            <div>
-              <h1 className="h3 mb-1">GoonCave</h1>
-              <div className="text-muted-foreground text-sm">
-                Signed in as {auth.authUser.username}
+          <div className="page-chrome">
+            <div className="flex justify-between items-center mb-4">
+              <div>
+                <h1 className="h3 mb-1">GoonCave</h1>
+                <div className="text-muted-foreground text-sm">
+                  Signed in as {auth.authUser.username}
+                </div>
+              </div>
+              <div>
+                <button
+                  className="btn btn-outline-light btn-sm"
+                  type="button"
+                  onClick={() => void auth.logout()}
+                >
+                  Logout
+                </button>
               </div>
             </div>
-            <div>
+
+            <div className="btn-group mb-6" role="group" aria-label="view switcher">
               <button
-                className="btn btn-outline-light btn-sm"
-                type="button"
-                onClick={() => void auth.logout()}
+                className={`btn btn-${viewMode === 'gallery' ? 'primary' : 'outline-light'}`}
+                onClick={() => setViewMode('gallery')}
               >
-                Logout
+                Gallery
+              </button>
+              <button
+                className={`btn btn-${viewMode === 'duplicates' ? 'primary' : 'outline-light'}`}
+                onClick={() => setViewMode('duplicates')}
+              >
+                Duplicates
+              </button>
+              <button
+                className={`btn btn-${viewMode === 'folders' ? 'primary' : 'outline-light'}`}
+                onClick={() => setViewMode('folders')}
+              >
+                Settings
               </button>
             </div>
-          </div>
 
-          <div className="btn-group mb-6" role="group" aria-label="view switcher">
-            <button
-              className={`btn btn-${viewMode === 'gallery' ? 'primary' : 'outline-light'}`}
-              onClick={() => setViewMode('gallery')}
-            >
-              Gallery
-            </button>
-            <button
-              className={`btn btn-${viewMode === 'duplicates' ? 'primary' : 'outline-light'}`}
-              onClick={() => setViewMode('duplicates')}
-            >
-              Duplicates
-            </button>
-            <button
-              className={`btn btn-${viewMode === 'folders' ? 'primary' : 'outline-light'}`}
-              onClick={() => setViewMode('folders')}
-            >
-              Settings
-            </button>
+            {galleryCtl.manualOrderState.error ? (
+              <div className="text-destructive mb-4">
+                Manual order: {galleryCtl.manualOrderState.error}
+              </div>
+            ) : null}
+            {galleryCtl.manualOrderState.loading ? (
+              <div className="text-muted-foreground text-sm mb-4">
+                Saving manual order…
+              </div>
+            ) : null}
           </div>
-
-          {galleryCtl.manualOrderState.error ? (
-            <div className="text-destructive mb-4">
-              Manual order: {galleryCtl.manualOrderState.error}
-            </div>
-          ) : null}
-          {galleryCtl.manualOrderState.loading ? (
-            <div className="text-muted-foreground text-sm mb-4">
-              Saving manual order…
-            </div>
-          ) : null}
 
           <div className={`row ${viewMode === 'folders' ? 'g-0 settings-sections' : 'g-4'}`}>
             {viewMode === 'folders' ? (

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -322,7 +322,13 @@
     @apply inline-flex items-center gap-1;
   }
   .dropdown-menu {
-    @apply absolute z-50 min-w-[10rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md;
+    @apply hidden absolute z-50 min-w-[10rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md;
+  }
+  .dropdown-menu.show {
+    @apply block;
+  }
+  .dropdown-backdrop {
+    @apply fixed inset-0 z-40 cursor-default bg-transparent border-0 p-0;
   }
   .dropdown-item {
     @apply block w-full select-none rounded-sm px-2 py-1.5 text-sm outline-none
@@ -336,7 +342,13 @@
 }
 
 .page-shell {
+  width: 100%;
+  max-width: none;
   padding: 0.5rem 0.75rem 1rem;
+}
+
+.page-chrome {
+  @apply px-4;
 }
 
 .gallery-item-manual {
@@ -360,6 +372,12 @@
 .gallery-card {
   content-visibility: auto;
   contain-intrinsic-size: 260px 220px;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(theme(spacing.40), 1fr));
+  @apply gap-4;
 }
 
 .gallery-load-sentinel {
@@ -602,7 +620,9 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.6rem 0;
+  width: 100%;
+  max-width: none;
+  @apply px-6 py-2;
 }
 
 .file-detail-back-btn {
@@ -767,8 +787,9 @@
 }
 
 .file-detail-body {
-  padding-top: 1rem;
-  padding-bottom: 2rem;
+  width: 100%;
+  max-width: none;
+  @apply px-6 pt-4 pb-8;
 }
 
 .file-detail-section-head {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -322,7 +322,7 @@
     @apply inline-flex items-center gap-1;
   }
   .dropdown-menu {
-    @apply hidden absolute z-50 min-w-[10rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md;
+    @apply hidden absolute z-50 min-w-40 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md;
   }
   .dropdown-menu.show {
     @apply block;
@@ -344,7 +344,7 @@
 .page-shell {
   width: 100%;
   max-width: none;
-  padding: 0.5rem 0.75rem 1rem;
+  @apply px-3 pt-2 pb-4;
 }
 
 .page-chrome {
@@ -619,10 +619,9 @@
 .file-detail-back-bar {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
   width: 100%;
   max-width: none;
-  @apply px-6 py-2;
+  @apply gap-3 px-6 py-2;
 }
 
 .file-detail-back-btn {

--- a/frontend/src/features/file-detail/useFileDetailController.ts
+++ b/frontend/src/features/file-detail/useFileDetailController.ts
@@ -664,7 +664,6 @@ export function useFileDetailController(
           }
         }
         setDeleteState({ loading: false, error: warning });
-        if (warning) window.alert(warning);
       } catch (err) {
         setDeleteState({ loading: false, error: (err as Error).message });
       }

--- a/frontend/src/features/file-detail/useFileDetailController.ts
+++ b/frontend/src/features/file-detail/useFileDetailController.ts
@@ -195,6 +195,7 @@ export function useFileDetailController(
   const removeManualTagMutation = useRemoveManualTag();
   const refreshFileTagsMutation = useRefreshFileTags();
   const removeTopMatchMutation = useRemoveTopMatch();
+  const refreshFileTags = refreshFileTagsMutation.mutateAsync;
 
   // --- core state ----------------------------------------------------------
   const [selectedFile, setSelectedFile] = useState<FileItem | null>(null);
@@ -525,7 +526,7 @@ export function useFileDetailController(
         });
         if (resp.tags.length === 0 && !tagRefreshRef.current.has(fileId)) {
           tagRefreshRef.current.add(fileId);
-          const refreshed = await refreshFileTagsMutation.mutateAsync(fileId);
+          const refreshed = await refreshFileTags(fileId);
           setFileTags(refreshed.tags);
         } else {
           setFileTags(resp.tags);
@@ -536,7 +537,7 @@ export function useFileDetailController(
         setTagState({ loading: false, error: (err as Error).message });
       }
     },
-    [queryClient, refreshFileTagsMutation],
+    [queryClient, refreshFileTags],
   );
 
   // ---------------------------------------------------------------------------
@@ -549,10 +550,10 @@ export function useFileDetailController(
       void loadTags(selectedFile.id);
       setMatchRemoveState({ loading: false, error: null });
     } else {
-      setProviderInfo([]);
-      setFileTags([]);
+      setProviderInfo((prev) => (prev.length ? [] : prev));
+      setFileTags((prev) => (prev.length ? [] : prev));
     }
-  }, [selectedFile, loadTags, loadProviders]);
+  }, [selectedFile?.id, loadTags, loadProviders]);
 
   // ---------------------------------------------------------------------------
   // Effects: scroll restore
@@ -651,7 +652,10 @@ export function useFileDetailController(
           : null;
       setDeleteState({ loading: true, error: null });
       try {
-        await deleteFileMutation.mutateAsync(fileId);
+        const result = await deleteFileMutation.mutateAsync(fileId);
+        const warning = result.errors?.length
+          ? `Deleted local file, but remote favorite update failed: ${result.errors.join('; ')}`
+          : null;
         if (selectedFile?.id === fileId) {
           if (nextFile) {
             setSelectedFile(nextFile);
@@ -659,7 +663,8 @@ export function useFileDetailController(
             closeFile();
           }
         }
-        setDeleteState({ loading: false, error: null });
+        setDeleteState({ loading: false, error: warning });
+        if (warning) window.alert(warning);
       } catch (err) {
         setDeleteState({ loading: false, error: (err as Error).message });
       }
@@ -924,14 +929,14 @@ export function useFileDetailController(
     if (!selectedFile) return;
     setTagState({ loading: true, error: null });
     try {
-      const refreshed = await refreshFileTagsMutation.mutateAsync(selectedFile.id);
+      const refreshed = await refreshFileTags(selectedFile.id);
       setFileTags(refreshed.tags);
       tagRefreshRef.current.add(selectedFile.id);
       setTagState({ loading: false, error: null });
     } catch (err) {
       setTagState({ loading: false, error: (err as Error).message });
     }
-  }, [selectedFile, refreshFileTagsMutation]);
+  }, [selectedFile, refreshFileTags]);
 
   const addManualTag = useCallback(async () => {
     if (!selectedFile) return;

--- a/frontend/src/features/library/GalleryView.tsx
+++ b/frontend/src/features/library/GalleryView.tsx
@@ -182,7 +182,7 @@ export function GalleryView({
                     type="button"
                     className="dropdown-backdrop"
                     aria-label="Close filters"
-                    onPointerDown={onFilterOpenToggle}
+                    onClick={onFilterOpenToggle}
                   />
                 ) : null}
                 <div className={`dropdown-menu dropdown-menu-dark p-4${isGalleryFilterOpen ? ' show' : ''}`}>

--- a/frontend/src/features/library/GalleryView.tsx
+++ b/frontend/src/features/library/GalleryView.tsx
@@ -35,6 +35,7 @@ export interface GalleryViewProps {
   onTagInputChange: (value: string) => void;
   onTagQueryClear: () => void;
   onFilterChange: (patch: Partial<{ photos: boolean; videos: boolean; favorites: boolean }>) => void;
+  onFilterClose: () => void;
   onFilterOpenToggle: () => void;
   onSortChange: (sort: GallerySort) => void;
   onFileOpen: (file: FileItem) => void;
@@ -68,6 +69,7 @@ export function GalleryView({
   onTagInputChange,
   onTagQueryClear,
   onFilterChange,
+  onFilterClose,
   onFilterOpenToggle,
   onSortChange,
   onFileOpen,
@@ -77,7 +79,15 @@ export function GalleryView({
   onDragOverChange,
 }: GalleryViewProps) {
   return (
-    <div className="col-12">
+    <div
+      className="col-12"
+      onPointerDownCapture={(event) => {
+        if (!isGalleryFilterOpen) return;
+        const target = event.target as Node;
+        if (galleryFilterRef.current?.contains(target)) return;
+        onFilterClose();
+      }}
+    >
       <div className="card bg-transparent text-foreground border-0 h-full content-shell-card">
         <div className="card-body">
           {/* Controls row */}
@@ -167,6 +177,14 @@ export function GalleryView({
                 >
                   {galleryFilterLabel}
                 </button>
+                {isGalleryFilterOpen ? (
+                  <button
+                    type="button"
+                    className="dropdown-backdrop"
+                    aria-label="Close filters"
+                    onPointerDown={onFilterOpenToggle}
+                  />
+                ) : null}
                 <div className={`dropdown-menu dropdown-menu-dark p-4${isGalleryFilterOpen ? ' show' : ''}`}>
                   <div className="form-check mb-2">
                     <input
@@ -230,9 +248,9 @@ export function GalleryView({
             </p>
           ) : (
             <>
-              <div className="row row-cols-2 row-cols-md-4 g-3">
+              <div className="gallery-grid">
                 {galleryFiles.map((file) => (
-                  <div key={file.id} className="col">
+                  <div key={file.id} className="min-w-0">
                     <div
                       className={`gallery-card h-full${gallerySort === 'manual' ? ' gallery-item-manual' : ''}${
                         draggingId === file.id ? ' gallery-item-dragging' : ''

--- a/frontend/src/features/library/useGalleryController.ts
+++ b/frontend/src/features/library/useGalleryController.ts
@@ -374,10 +374,10 @@ export function useGalleryController(
     return () => window.clearTimeout(handle);
   }, [galleryTagInput]);
 
-  // Click-outside / Escape to close filter popover (verbatim)
+  // Click-outside / Escape to close filter popover
   useEffect(() => {
     if (!isGalleryFilterOpen) return;
-    const handleClick = (event: MouseEvent) => {
+    const handlePointerDown = (event: PointerEvent) => {
       const target = event.target as Node | null;
       if (target && galleryFilterRef.current?.contains(target)) return;
       setIsGalleryFilterOpen(false);
@@ -387,10 +387,10 @@ export function useGalleryController(
         setIsGalleryFilterOpen(false);
       }
     };
-    window.addEventListener('mousedown', handleClick);
+    document.addEventListener('pointerdown', handlePointerDown, true);
     window.addEventListener('keydown', handleKey);
     return () => {
-      window.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('pointerdown', handlePointerDown, true);
       window.removeEventListener('keydown', handleKey);
     };
   }, [isGalleryFilterOpen]);
@@ -675,6 +675,7 @@ export function useGalleryController(
     onTagQueryClear: () => setGalleryTagQuery(''),
     onFilterChange: (patch) =>
       setGalleryFilters((prev) => ({ ...prev, ...patch })),
+    onFilterClose: () => setIsGalleryFilterOpen(false),
     onFilterOpenToggle: () => setIsGalleryFilterOpen((prev) => !prev),
     onSortChange: applyGallerySort,
     onFileOpen: openFile,


### PR DESCRIPTION
## Summary

- reverse-sync custom Gelbooru favorites when deleting local files
- detect Rule34/Gelbooru redirect responses so remote-delete failures are visible
- fix gallery spacing, filter popup dismissal, and detail-page alignment
- throttle stale local-folder watcher warnings and clean up stale DB paths locally

## Tests

- `npm test` in `backend` (170/170)
- `npm run build` in `backend`
- `npm run build` in `frontend`
- `git diff --check`

Fixes #142
Follow-up: #144
