### PR TITLE
refactor: modernize forms and e2e coverage

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "imagesearch-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.4.0",
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/react-query": "^5.100.14",
         "@tanstack/react-query-devtools": "^5.100.14",
@@ -19,10 +20,12 @@
         "radix-ui": "^1.4.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.6",
+        "react-hook-form": "^7.76.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.0",
         "tw-animate-css": "^1.4.0",
+        "zod": "^4.4.3",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -104,6 +107,18 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -1930,6 +1945,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -3224,6 +3245,22 @@
         "react": "^19.2.6"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.76.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.76.1.tgz",
+      "integrity": "sha512-rYM7tPiWlu3nZchkR/ex7piyzui2vFPyaLnXnI/RnblB/L4qfMmyses8llJVtF1NpE9WBBsJlGtcSZzPCXW1qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
@@ -3767,6 +3804,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.4.0",
     "@tailwindcss/vite": "^4.3.0",
     "@tanstack/react-query": "^5.100.14",
     "@tanstack/react-query-devtools": "^5.100.14",
@@ -22,10 +23,12 @@
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.6",
+    "react-hook-form": "^7.76.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/frontend/src/BooruSitesPanel.tsx
+++ b/frontend/src/BooruSitesPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from 'react';
+import { useState } from 'react';
 
 import {
   useBooruEngineCatalog,
@@ -12,90 +12,17 @@ import {
 } from '@/hooks/booru-sites';
 
 import {
-  api,
   type BooruCredentialSchema,
-  type BooruDetectionResult,
   type BooruEngineCatalog,
-  type BooruEngineType,
   type BooruSite
 } from './api';
-import { ensureHttps } from './urlUtils';
-
-const ENGINE_LABELS: Record<BooruEngineType, string> = {
-  danbooru: 'Danbooru',
-  e621: 'e621',
-  moebooru: 'Moebooru (yande.re / konachan)',
-  gelbooru: 'Gelbooru',
-  sankaku: 'Sankaku',
-  philomena: 'Philomena (Derpibooru)',
-  shimmie: 'Shimmie2',
-  szurubooru: 'Szurubooru'
-};
-
-type CapabilityKey = 'capFavorites' | 'capTags' | 'capSourceMatch';
-
-const CAPABILITY_LABELS: Record<CapabilityKey, string> = {
-  capFavorites: 'Sync favorites',
-  capTags: 'Tag fetch',
-  capSourceMatch: 'Source URL match'
-};
-
-type CredentialsState = {
-  username: string;
-  apiKey: string;
-};
-
-type AddFormState = {
-  name: string;
-  baseUrl: string;
-  detection: BooruDetectionResult | null;
-  detecting: boolean;
-  detectError: string | null;
-  username: string;
-  apiKey: string;
-  capabilities: Record<CapabilityKey, boolean>;
-};
-
-const defaultCaps: Record<CapabilityKey, boolean> = {
-  capFavorites: false,
-  capTags: true,
-  capSourceMatch: true
-};
-
-const initialAddForm = (): AddFormState => ({
-  name: '',
-  baseUrl: '',
-  detection: null,
-  detecting: false,
-  detectError: null,
-  username: '',
-  apiKey: '',
-  capabilities: { ...defaultCaps }
-});
-
-const credentialFieldsForSchema = (schema: BooruCredentialSchema) => {
-  switch (schema) {
-    case 'username+apikey':
-      return { username: true, usernameLabel: 'Username', apiKey: true, apiKeyLabel: 'API key' };
-    case 'userid+apikey':
-      return { username: true, usernameLabel: 'User ID', apiKey: true, apiKeyLabel: 'API key' };
-    case 'apikey-only':
-      return { username: false, usernameLabel: '', apiKey: true, apiKeyLabel: 'API key' };
-    case 'token':
-      return { username: false, usernameLabel: '', apiKey: true, apiKeyLabel: 'Token' };
-    case 'none':
-    default:
-      return { username: false, usernameLabel: '', apiKey: false, apiKeyLabel: '' };
-  }
-};
-
-const debounce = <T extends (...args: never[]) => void>(fn: T, delay: number) => {
-  let timer: ReturnType<typeof setTimeout> | null = null;
-  return (...args: Parameters<T>) => {
-    if (timer) clearTimeout(timer);
-    timer = setTimeout(() => fn(...args), delay);
-  };
-};
+import { AddBooruSiteForm, BooruSiteCredentialForm } from '@/features/booru-sites/BooruSiteForms';
+import {
+  CAPABILITY_LABELS,
+  type CapabilityKey,
+  ENGINE_LABELS,
+  credentialFieldsForSchema,
+} from '@/features/booru-sites/shared';
 
 type Props = {
   className?: string;
@@ -125,107 +52,12 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
     (sitesQuery.error as Error | null)?.message ??
     (catalogQuery.error as Error | null)?.message ??
     null;
-  const [addForm, setAddForm] = useState<AddFormState>(initialAddForm());
-  const [addingBusy, setAddingBusy] = useState(false);
   const [testingId, setTestingId] = useState<string | null>(null);
   const [testResults, setTestResults] = useState<Record<string, { ok: boolean; message: string }>>({});
-  const [editCredentials, setEditCredentials] = useState<Record<string, CredentialsState>>({});
-
-  useEffect(() => {
-    if (!sitesQuery.data) return;
-    setEditCredentials((prev) => {
-      const merged: Record<string, CredentialsState> = {};
-      sitesQuery.data.forEach((site) => {
-        const existing = prev[site.id];
-        merged[site.id] = {
-          username: existing?.username ?? site.username ?? '',
-          apiKey: existing?.apiKey ?? ''
-        };
-      });
-      return merged;
-    });
-  }, [sitesQuery.data]);
 
   const reload = async () => {
     setLocalError(null);
     await Promise.all([sitesQuery.refetch(), catalogQuery.refetch()]);
-  };
-
-  const detectedEngine: BooruEngineType | null = useMemo(() => {
-    if (addForm.detection && 'engine' in addForm.detection) return addForm.detection.engine;
-    return null;
-  }, [addForm.detection]);
-
-  const detectedSchema: BooruCredentialSchema = useMemo(() => {
-    if (addForm.detection && 'engine' in addForm.detection) {
-      return addForm.detection.credentialSchema;
-    }
-    return 'none';
-  }, [addForm.detection]);
-
-  const runDetect = useMemo(
-    () =>
-      debounce(async (url: string) => {
-        const normalized = ensureHttps(url);
-        if (!normalized) {
-          setAddForm((prev) => ({ ...prev, detection: null, detecting: false, detectError: null }));
-          return;
-        }
-        setAddForm((prev) => ({ ...prev, detecting: true, detectError: null }));
-        try {
-          const result = await detectEngineMutation.mutateAsync(normalized);
-          setAddForm((prev) => ({
-            ...prev,
-            detection: result,
-            detecting: false,
-            detectError: null,
-            capabilities:
-              'engine' in result && result.defaultCapabilities
-                ? {
-                    capFavorites: result.defaultCapabilities.favorites,
-                    capTags: result.defaultCapabilities.tags,
-                    capSourceMatch: result.defaultCapabilities.sourceMatch
-                  }
-                : prev.capabilities
-          }));
-        } catch (err) {
-          setAddForm((prev) => ({ ...prev, detecting: false, detectError: (err as Error).message }));
-        }
-      }, 600),
-    []
-  );
-
-  const onUrlChange = (value: string) => {
-    setAddForm((prev) => ({ ...prev, baseUrl: value, detection: null }));
-    runDetect(value);
-  };
-
-  const submitNewSite = async (event: FormEvent) => {
-    event.preventDefault();
-    if (!detectedEngine) {
-      setAddForm((prev) => ({ ...prev, detectError: 'No engine selected. Wait for detection or choose manually.' }));
-      return;
-    }
-    setAddingBusy(true);
-    try {
-      await createSiteMutation.mutateAsync({
-        name: addForm.name.trim(),
-        engine: detectedEngine,
-        baseUrl: ensureHttps(addForm.baseUrl),
-        username: addForm.username.trim() || null,
-        apiKey: addForm.apiKey.trim() || null,
-        capFavorites: addForm.capabilities.capFavorites,
-        capTags: addForm.capabilities.capTags,
-        capSourceMatch: addForm.capabilities.capSourceMatch,
-        enabled: true
-      });
-      setAddForm(initialAddForm());
-      await reload();
-    } catch (err) {
-      setLocalError((err as Error).message);
-    } finally {
-      setAddingBusy(false);
-    }
   };
 
   const toggleCapability = async (site: BooruSite, capability: CapabilityKey) => {
@@ -250,23 +82,15 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
     }
   };
 
-  const saveCredentials = async (site: BooruSite) => {
-    const input = editCredentials[site.id];
-    if (!input) return;
+  const saveCredentials = async (
+    site: BooruSite,
+    payload: { username: string | null; apiKey: string | null },
+  ) => {
     try {
-      const updated = await updateSiteMutation.mutateAsync({
-        id: site.id,
-        payload: {
-          username: input.username.trim() || null,
-          apiKey: input.apiKey.trim() || null
-        }
-      });
-      setEditCredentials((prev) => ({
-        ...prev,
-        [site.id]: { username: updated.username ?? '', apiKey: '' }
-      }));
+      return await updateSiteMutation.mutateAsync({ id: site.id, payload });
     } catch (err) {
       setLocalError((err as Error).message);
+      throw err;
     }
   };
 
@@ -341,7 +165,6 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
               const schema = credentialSchemaFor(site);
               const fields = credentialFieldsForSchema(schema);
               const test = testResults[site.id];
-              const edit = editCredentials[site.id] ?? { username: '', apiKey: '' };
               return (
                 <div key={site.id} className="border border-secondary rounded p-2 text-foreground">
                   <div className="flex items-center gap-2">
@@ -402,61 +225,14 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
                   </div>
 
                   {(fields.username || fields.apiKey) ? (
-                    <div className="row g-2 mt-2">
-                      {fields.username ? (
-                        <div className="col-md-4">
-                          <label className="form-label text-sm mb-1 text-muted-foreground">{fields.usernameLabel}</label>
-                          <input
-                            type="text"
-                            className="form-control form-control-sm bg-background text-foreground border-secondary"
-                            value={edit.username}
-                            onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                              setEditCredentials((prev) => ({
-                                ...prev,
-                                [site.id]: { ...edit, username: e.target.value }
-                              }))
-                            }
-                          />
-                        </div>
-                      ) : null}
-                      {fields.apiKey ? (
-                        <div className="col-md-4">
-                          <label className="form-label text-sm mb-1 text-muted-foreground">
-                            {fields.apiKeyLabel}
-                            {site.hasApiKey ? <span className="text-muted-foreground"> · saved</span> : null}
-                          </label>
-                          <input
-                            type="password"
-                            className="form-control form-control-sm bg-background text-foreground border-secondary"
-                            placeholder={site.hasApiKey ? '••••••••' : ''}
-                            value={edit.apiKey}
-                            onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                              setEditCredentials((prev) => ({
-                                ...prev,
-                                [site.id]: { ...edit, apiKey: e.target.value }
-                              }))
-                            }
-                          />
-                        </div>
-                      ) : null}
-                      <div className="col-md-4 flex items-end gap-2">
-                        <button
-                          type="button"
-                          className="btn btn-sm btn-outline-light"
-                          onClick={() => saveCredentials(site)}
-                        >
-                          Save credentials
-                        </button>
-                        <button
-                          type="button"
-                          className="btn btn-sm btn-outline-light"
-                          onClick={() => testSite(site)}
-                          disabled={testingId === site.id}
-                        >
-                          {testingId === site.id ? 'Testing…' : 'Test'}
-                        </button>
-                      </div>
-                    </div>
+                    <BooruSiteCredentialForm
+                      site={site}
+                      schema={schema}
+                      loading={updateSiteMutation.isPending}
+                      testing={testingId === site.id}
+                      onSave={(payload) => saveCredentials(site, payload)}
+                      onTest={() => testSite(site)}
+                    />
                   ) : (
                     <div className="mt-2">
                       <button
@@ -490,206 +266,14 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
       )}
 
       <h5 className="mt-6 text-foreground">Add custom booru site</h5>
-      <form onSubmit={submitNewSite} className="row g-2">
-        <div className="col-md-6">
-          <label htmlFor="booru-name" className="form-label text-sm mb-1 text-muted-foreground">
-            Name
-          </label>
-          <input
-            id="booru-name"
-            type="text"
-            className="form-control form-control-sm bg-background text-foreground border-secondary"
-            value={addForm.name}
-            onChange={(e) => setAddForm((prev) => ({ ...prev, name: e.target.value }))}
-            placeholder="My booru"
-            required
-          />
-        </div>
-        <div className="col-md-6">
-          <label htmlFor="booru-url" className="form-label text-sm mb-1 text-muted-foreground">
-            Base URL
-          </label>
-          {/* type=text (not url) so the browser accepts "gelbooru.com" while
-              the user is mid-typing; ensureHttps normalizes on blur/submit.
-              Pattern requires at least one dot OR an explicit scheme so the
-              field still flags obvious junk ("foo", "asdf"). */}
-          <input
-            id="booru-url"
-            type="text"
-            className="form-control form-control-sm bg-background text-foreground border-secondary"
-            value={addForm.baseUrl}
-            onChange={(e) => onUrlChange(e.target.value)}
-            onBlur={(e) => {
-              const normalized = ensureHttps(e.target.value);
-              if (normalized !== addForm.baseUrl) {
-                setAddForm((prev) => ({ ...prev, baseUrl: normalized }));
-              }
-            }}
-            pattern="(https?://.+|[^\s/]+\.[^\s/]+.*)"
-            placeholder="example.com"
-            required
-          />
-        </div>
-
-        {addForm.detecting ? (
-          <div className="col-12 text-muted-foreground text-sm">Detecting engine…</div>
-        ) : null}
-
-        {addForm.detection && 'engine' in addForm.detection ? (
-          <div className="col-12">
-            <div className="flex items-center gap-2 flex-wrap">
-              <span className="badge text-bg-success">
-                Detected: {ENGINE_LABELS[addForm.detection.engine]}
-              </span>
-              {devOptions ? (
-                <span className="text-muted-foreground text-sm">
-                  via {addForm.detection.confidence === 'hostname' ? 'known hostname' : 'API probe'}
-                </span>
-              ) : null}
-            </div>
-            {addForm.detection.sample?.thumbUrl ? (
-              <div className="mt-2 flex items-start gap-2">
-                <a
-                  href={addForm.detection.sample.postUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  title={`Sample post #${addForm.detection.sample.postId}`}
-                >
-                  <img
-                    src={addForm.detection.sample.thumbUrl}
-                    alt={`Sample post #${addForm.detection.sample.postId}`}
-                    style={{ maxWidth: 96, maxHeight: 96 }}
-                    className="border border-secondary rounded"
-                    loading="lazy"
-                  />
-                </a>
-              </div>
-            ) : null}
-          </div>
-        ) : null}
-
-        {addForm.detection && 'error' in addForm.detection ? (
-          <div className="col-12">
-            <div className="alert alert-warning py-2 text-sm mb-2">
-              {addForm.detection.error === 'unreachable'
-                ? `Site unreachable. ${addForm.detection.message}`
-                : 'Could not identify the engine for this site. It may run an unsupported booru engine, require login, or sit behind a CAPTCHA/anti-bot wall. Only recognized engines can be added.'}
-            </div>
-            {devOptions && addForm.detection.attempts?.length ? (
-              <details className="mb-2" open>
-                <summary className="text-muted-foreground text-sm">
-                  Probe attempts ({addForm.detection.attempts.length})
-                </summary>
-                <table className="table table-sm table-dark table-borderless mt-2 mb-0 text-sm">
-                  <thead>
-                    <tr className="text-muted-foreground">
-                      <th scope="col">Engine</th>
-                      <th scope="col">Status</th>
-                      <th scope="col">HTTP</th>
-                      <th scope="col">Detail</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {addForm.detection.attempts.map((attempt) => (
-                      <tr key={attempt.engine}>
-                        <td>{ENGINE_LABELS[attempt.engine]}</td>
-                        <td>
-                          <span
-                            className={
-                              attempt.status === 'matched'
-                                ? 'text-success'
-                                : attempt.status === 'no-match'
-                                  ? 'text-muted-foreground'
-                                  : 'text-warning'
-                            }
-                          >
-                            {attempt.status}
-                          </span>
-                        </td>
-                        <td>{attempt.httpStatus ?? '—'}</td>
-                        <td className="text-muted-foreground">{attempt.error ?? ''}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </details>
-            ) : null}
-          </div>
-        ) : null}
-
-        {detectedEngine ? (
-          <>
-            {credentialFieldsForSchema(detectedSchema).username ? (
-              <div className="col-md-6">
-                <label className="form-label text-sm mb-1">
-                  {credentialFieldsForSchema(detectedSchema).usernameLabel}
-                </label>
-                <input
-                  type="text"
-                  className="form-control form-control-sm bg-background text-foreground border-secondary"
-                  value={addForm.username}
-                  onChange={(e) => setAddForm((prev) => ({ ...prev, username: e.target.value }))}
-                />
-              </div>
-            ) : null}
-            {credentialFieldsForSchema(detectedSchema).apiKey ? (
-              <div className="col-md-6">
-                <label className="form-label text-sm mb-1">
-                  {credentialFieldsForSchema(detectedSchema).apiKeyLabel}
-                </label>
-                <input
-                  type="password"
-                  className="form-control form-control-sm bg-background text-foreground border-secondary"
-                  value={addForm.apiKey}
-                  onChange={(e) => setAddForm((prev) => ({ ...prev, apiKey: e.target.value }))}
-                />
-              </div>
-            ) : null}
-
-            <div className="col-12 mt-2">
-              <span className="text-muted-foreground text-sm block mb-1">Capabilities</span>
-              <div className="row g-2">
-                {(Object.keys(CAPABILITY_LABELS) as CapabilityKey[]).map((cap) => (
-                  <div key={cap} className="col-6 col-md-3">
-                    <div className="form-check">
-                      <input
-                        className="form-check-input"
-                        type="checkbox"
-                        id={`new-${cap}`}
-                        checked={addForm.capabilities[cap]}
-                        onChange={() =>
-                          setAddForm((prev) => ({
-                            ...prev,
-                            capabilities: { ...prev.capabilities, [cap]: !prev.capabilities[cap] }
-                          }))
-                        }
-                      />
-                      <label className="form-check-label text-muted-foreground text-sm" htmlFor={`new-${cap}`}>
-                        {CAPABILITY_LABELS[cap]}
-                      </label>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </>
-        ) : null}
-
-        {addForm.detectError ? <div className="col-12 text-destructive text-sm">{addForm.detectError}</div> : null}
-
-        <div className="col-12 flex gap-2 mt-2">
-          <button type="submit" className="btn btn-sm btn-outline-light" disabled={addingBusy || !detectedEngine}>
-            {addingBusy ? 'Adding…' : 'Add site'}
-          </button>
-          <button
-            type="button"
-            className="btn btn-sm btn-outline-light"
-            onClick={() => setAddForm(initialAddForm())}
-          >
-            Reset
-          </button>
-        </div>
-      </form>
+      <AddBooruSiteForm
+        devOptions={devOptions}
+        onDetect={(baseUrl) => detectEngineMutation.mutateAsync(baseUrl)}
+        onCreate={async (payload) => {
+          await createSiteMutation.mutateAsync(payload);
+          await reload();
+        }}
+      />
     </div>
   );
 };

--- a/frontend/src/features/auth/AuthForm.tsx
+++ b/frontend/src/features/auth/AuthForm.tsx
@@ -1,4 +1,8 @@
-import type { ChangeEvent, FormEvent } from 'react';
+import { useEffect, useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { buildAuthFormSchema } from './authSchemas';
 
 export type AuthMode = 'login' | 'register';
 
@@ -10,23 +14,36 @@ export type AuthFormValues = {
 
 type Props = {
   mode: AuthMode;
-  values: AuthFormValues;
   loading: boolean;
   error: string | null;
   onModeChange: (mode: AuthMode) => void;
-  onChange: (next: AuthFormValues) => void;
-  onSubmit: () => void;
+  onSubmit: (values: AuthFormValues) => Promise<void>;
 };
 
-export function AuthForm({ mode, values, loading, error, onModeChange, onChange, onSubmit }: Props) {
-  const updateField = (event: ChangeEvent<HTMLInputElement>) => {
-    onChange({ ...values, [event.target.name === 'confirm-password' ? 'confirmPassword' : event.target.name]: event.target.value });
-  };
+export function AuthForm({ mode, loading, error, onModeChange, onSubmit }: Props) {
+  const schema = useMemo(() => buildAuthFormSchema(mode), [mode]);
+  const form = useForm<AuthFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      username: '',
+      password: '',
+      confirmPassword: '',
+    },
+  });
+  const {
+    register,
+    reset,
+    formState: { errors },
+    handleSubmit,
+  } = form;
 
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault();
-    onSubmit();
-  };
+  useEffect(() => {
+    reset({
+      username: '',
+      password: '',
+      confirmPassword: '',
+    });
+  }, [mode, reset]);
 
   return (
     <div className="bg-background text-foreground min-h-screen flex items-center justify-center px-4">
@@ -54,7 +71,16 @@ export function AuthForm({ mode, values, loading, error, onModeChange, onChange,
               </button>
             </div>
           </div>
-          <form onSubmit={handleSubmit}>
+          <form
+            onSubmit={handleSubmit(async (values) => {
+              await onSubmit(values);
+              reset({
+                username: '',
+                password: '',
+                confirmPassword: '',
+              });
+            })}
+          >
             <div className="mb-4">
               <label className="form-label" htmlFor="auth-username">Username</label>
               <input
@@ -62,10 +88,12 @@ export function AuthForm({ mode, values, loading, error, onModeChange, onChange,
                 name="username"
                 type="text"
                 className="form-control bg-background text-foreground border-secondary"
-                value={values.username}
-                onChange={updateField}
+                {...register('username')}
                 autoComplete="username"
               />
+              {errors.username ? (
+                <div className="text-destructive text-sm mt-1">{errors.username.message}</div>
+              ) : null}
             </div>
             <div className="mb-4">
               <label className="form-label" htmlFor="auth-password">Password</label>
@@ -74,10 +102,12 @@ export function AuthForm({ mode, values, loading, error, onModeChange, onChange,
                 name="password"
                 className="form-control bg-background text-foreground border-secondary"
                 type="password"
-                value={values.password}
-                onChange={updateField}
+                {...register('password')}
                 autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
               />
+              {errors.password ? (
+                <div className="text-destructive text-sm mt-1">{errors.password.message}</div>
+              ) : null}
             </div>
             {mode === 'register' ? (
               <div className="mb-4">
@@ -87,10 +117,14 @@ export function AuthForm({ mode, values, loading, error, onModeChange, onChange,
                   name="confirm-password"
                   className="form-control bg-background text-foreground border-secondary"
                   type="password"
-                  value={values.confirmPassword}
-                  onChange={updateField}
+                  {...register('confirmPassword')}
                   autoComplete="new-password"
                 />
+                {errors.confirmPassword ? (
+                  <div className="text-destructive text-sm mt-1">
+                    {errors.confirmPassword.message}
+                  </div>
+                ) : null}
               </div>
             ) : null}
             {error ? <div className="alert alert-danger py-2">{error}</div> : null}

--- a/frontend/src/features/auth/authSchemas.ts
+++ b/frontend/src/features/auth/authSchemas.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+
+import type { AuthMode, AuthFormValues } from './AuthForm';
+
+const authUsernameRegex = /^[a-zA-Z0-9_-]+$/;
+
+const usernameSchema = z
+  .string()
+  .trim()
+  .min(3, 'Username must be at least 3 characters')
+  .max(32, 'Username must be at most 32 characters')
+  .regex(authUsernameRegex, 'Username can only contain letters, numbers, _ and -');
+
+const passwordSchema = z
+  .string()
+  .min(8, 'Password must be at least 8 characters')
+  .max(128, 'Password must be at most 128 characters');
+
+export const buildAuthFormSchema = (mode: AuthMode) =>
+  z
+    .object({
+      username: usernameSchema,
+      password: passwordSchema,
+      confirmPassword: z.string(),
+    })
+    .superRefine((value, ctx) => {
+      if (mode === 'register' && value.password !== value.confirmPassword) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Passwords do not match',
+          path: ['confirmPassword'],
+        });
+      }
+    });
+
+export const toAuthSubmitPayload = (values: AuthFormValues) => ({
+  username: values.username.trim(),
+  password: values.password,
+});

--- a/frontend/src/features/auth/useAuthController.ts
+++ b/frontend/src/features/auth/useAuthController.ts
@@ -1,7 +1,7 @@
 /**
  * useAuthController
  *
- * Owns auth state, mutations, form values, and the form-submission logic.
+ * Owns auth state and mutation side effects for the auth screen.
  * Returns formProps shaped to match AuthForm's Props interface.
  *
  * NOT owned here (stays in App.tsx):
@@ -18,9 +18,8 @@ import { useState } from 'react';
 
 import { useCurrentUser, useLogin, useLogout, useRegister } from '@/hooks/auth';
 import type { AuthUser } from '@/api';
-import type { AuthMode, AuthFormValues } from '@/features/auth/AuthForm';
-
-const authUsernameRegex = /^[a-zA-Z0-9_-]+$/;
+import type { AuthMode } from '@/features/auth/AuthForm';
+import { toAuthSubmitPayload } from '@/features/auth/authSchemas';
 
 export type AuthControllerResult = {
   authUser: AuthUser | null;
@@ -28,12 +27,14 @@ export type AuthControllerResult = {
   authLoading: boolean;
   formProps: {
     mode: AuthMode;
-    values: AuthFormValues;
     loading: boolean;
     error: string | null;
     onModeChange: (next: AuthMode) => void;
-    onChange: (next: AuthFormValues) => void;
-    onSubmit: () => void;
+    onSubmit: (values: {
+      username: string;
+      password: string;
+      confirmPassword: string;
+    }) => Promise<void>;
   };
   logout: () => Promise<void>;
 };
@@ -61,70 +62,27 @@ export function useAuthController(options?: {
     logoutMutation.isPending;
 
   const [authMode, setAuthMode] = useState<AuthMode>('login');
-  const [authForm, setAuthForm] = useState<AuthFormValues>({
-    username: '',
-    password: '',
-    confirmPassword: ''
-  });
-  const [authLocalError, setAuthLocalError] = useState<string | null>(null);
-
-  const error = authLocalError ?? authMutationError;
+  const error = authMutationError;
 
   const onModeChange = (next: AuthMode) => {
     setAuthMode(next);
-    setAuthLocalError(null);
   };
 
-  const onSubmit = () => {
-    const username = authForm.username.trim();
-    const password = authForm.password;
-
-    if (!username || !password) {
-      setAuthLocalError('Username and password are required');
-      return;
+  const onSubmit = async (values: {
+    username: string;
+    password: string;
+    confirmPassword: string;
+  }) => {
+    const payload = toAuthSubmitPayload(values);
+    if (authMode === 'register') {
+      await registerMutation.mutateAsync(payload);
+    } else {
+      await loginMutation.mutateAsync(payload);
     }
-    if (username.length < 3) {
-      setAuthLocalError('Username must be at least 3 characters');
-      return;
-    }
-    if (username.length > 32) {
-      setAuthLocalError('Username must be at most 32 characters');
-      return;
-    }
-    if (!authUsernameRegex.test(username)) {
-      setAuthLocalError('Username can only contain letters, numbers, _ and -');
-      return;
-    }
-    if (password.length < 8) {
-      setAuthLocalError('Password must be at least 8 characters');
-      return;
-    }
-    if (authMode === 'register' && password !== authForm.confirmPassword) {
-      setAuthLocalError('Passwords do not match');
-      return;
-    }
-
-    setAuthLocalError(null);
-
-    const run = async () => {
-      try {
-        if (authMode === 'register') {
-          await registerMutation.mutateAsync({ username, password });
-        } else {
-          await loginMutation.mutateAsync({ username, password });
-        }
-        options?.onLoginSuccess?.();
-        setAuthForm({ username: '', password: '', confirmPassword: '' });
-      } catch {
-        // Mutation error surfaces via authMutationError derived above.
-      }
-    };
-
-    void run();
+    options?.onLoginSuccess?.();
   };
 
   const logout = async () => {
-    setAuthLocalError(null);
     try {
       await logoutMutation.mutateAsync();
     } catch (err) {
@@ -142,11 +100,9 @@ export function useAuthController(options?: {
     authLoading: currentUserQuery.isLoading,
     formProps: {
       mode: authMode,
-      values: authForm,
       loading: authPending,
       error,
       onModeChange,
-      onChange: setAuthForm,
       onSubmit
     },
     logout

--- a/frontend/src/features/booru-sites/BooruSiteForms.tsx
+++ b/frontend/src/features/booru-sites/BooruSiteForms.tsx
@@ -1,0 +1,423 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import type {
+  BooruCredentialSchema,
+  BooruDetectionResult,
+  BooruEngineType,
+  BooruSite,
+} from '@/api';
+import { ensureHttps } from '@/urlUtils';
+
+import {
+  type BooruCredentialFormValues,
+  type BooruSiteAddFormValues,
+  booruSiteAddSchema,
+  createBooruCredentialSchema,
+  toBooruCredentialUpdatePayload,
+  toBooruSiteCreatePayload,
+} from './formSchemas';
+import {
+  CAPABILITY_LABELS,
+  ENGINE_LABELS,
+  credentialFieldsForSchema,
+} from './shared';
+
+type AddBooruSiteFormProps = {
+  devOptions: boolean;
+  onCreate: (payload: ReturnType<typeof toBooruSiteCreatePayload>) => Promise<void>;
+  onDetect: (baseUrl: string) => Promise<BooruDetectionResult>;
+};
+
+export function AddBooruSiteForm({ devOptions, onCreate, onDetect }: AddBooruSiteFormProps) {
+  const [detection, setDetection] = useState<BooruDetectionResult | null>(null);
+  const [detecting, setDetecting] = useState(false);
+  const [detectError, setDetectError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [addingBusy, setAddingBusy] = useState(false);
+  const form = useForm<BooruSiteAddFormValues>({
+    resolver: zodResolver(booruSiteAddSchema),
+    defaultValues: {
+      name: '',
+      baseUrl: '',
+      username: '',
+      apiKey: '',
+      capabilities: {
+        capFavorites: false,
+        capTags: true,
+        capSourceMatch: true,
+      },
+    },
+  });
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setValue,
+    watch,
+    formState: { errors },
+  } = form;
+  const baseUrl = watch('baseUrl');
+  const detectedEngine = useMemo(() => {
+    if (detection && 'engine' in detection) {
+      return detection.engine;
+    }
+    return null;
+  }, [detection]);
+  const detectedSchema: BooruCredentialSchema = useMemo(() => {
+    if (detection && 'engine' in detection) {
+      return detection.credentialSchema;
+    }
+    return 'none';
+  }, [detection]);
+  const detectedFields = useMemo(
+    () => credentialFieldsForSchema(detectedSchema),
+    [detectedSchema],
+  );
+  const addUsernameId = 'booru-detected-username';
+  const addApiKeyId = 'booru-detected-api-key';
+
+  useEffect(() => {
+    const normalized = ensureHttps(baseUrl);
+    if (!normalized) {
+      setDetection(null);
+      setDetecting(false);
+      setDetectError(null);
+      return;
+    }
+    const timeoutId = window.setTimeout(async () => {
+      setDetecting(true);
+      setDetectError(null);
+      try {
+        const nextDetection = await onDetect(normalized);
+        setDetection(nextDetection);
+        if ('engine' in nextDetection && nextDetection.defaultCapabilities) {
+          setValue('capabilities.capFavorites', nextDetection.defaultCapabilities.favorites);
+          setValue('capabilities.capTags', nextDetection.defaultCapabilities.tags);
+          setValue('capabilities.capSourceMatch', nextDetection.defaultCapabilities.sourceMatch);
+        }
+      } catch (error) {
+        setDetection(null);
+        setDetectError((error as Error).message);
+      } finally {
+        setDetecting(false);
+      }
+    }, 600);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [baseUrl, onDetect, setValue]);
+
+  return (
+    <form
+      onSubmit={handleSubmit(async (values) => {
+        if (!detectedEngine) {
+          setSubmitError('No engine selected. Wait for detection or choose manually.');
+          return;
+        }
+        setAddingBusy(true);
+        setSubmitError(null);
+        try {
+          await onCreate(toBooruSiteCreatePayload(values, detectedEngine as BooruEngineType));
+          reset();
+          setDetection(null);
+          setDetectError(null);
+        } catch (error) {
+          setSubmitError((error as Error).message);
+        } finally {
+          setAddingBusy(false);
+        }
+      })}
+      className="row g-2"
+    >
+      <div className="col-md-6">
+        <label htmlFor="booru-name" className="form-label text-sm mb-1 text-muted-foreground">
+          Name
+        </label>
+        <input
+          id="booru-name"
+          type="text"
+          className="form-control form-control-sm bg-background text-foreground border-secondary"
+          placeholder="My booru"
+          {...register('name')}
+        />
+        {errors.name ? (
+          <div className="text-destructive text-sm mt-1">{errors.name.message}</div>
+        ) : null}
+      </div>
+      <div className="col-md-6">
+        <label htmlFor="booru-url" className="form-label text-sm mb-1 text-muted-foreground">
+          Base URL
+        </label>
+        <input
+          id="booru-url"
+          type="text"
+          className="form-control form-control-sm bg-background text-foreground border-secondary"
+          placeholder="example.com"
+          {...register('baseUrl')}
+          onBlur={(event) => {
+            const normalized = ensureHttps(event.target.value);
+            setValue('baseUrl', normalized, { shouldValidate: true });
+          }}
+        />
+        {errors.baseUrl ? (
+          <div className="text-destructive text-sm mt-1">{errors.baseUrl.message}</div>
+        ) : null}
+      </div>
+
+      {detecting ? <div className="col-12 text-muted-foreground text-sm">Detecting engine…</div> : null}
+
+      {detection && 'engine' in detection ? (
+        <div className="col-12">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="badge text-bg-success">
+              Detected: {ENGINE_LABELS[detection.engine]}
+            </span>
+            {devOptions ? (
+              <span className="text-muted-foreground text-sm">
+                via {detection.confidence === 'hostname' ? 'known hostname' : 'API probe'}
+              </span>
+            ) : null}
+          </div>
+          {detection.sample?.thumbUrl ? (
+            <div className="mt-2 flex items-start gap-2">
+              <a
+                href={detection.sample.postUrl}
+                target="_blank"
+                rel="noreferrer"
+                title={`Sample post #${detection.sample.postId}`}
+              >
+                <img
+                  src={detection.sample.thumbUrl}
+                  alt={`Sample post #${detection.sample.postId}`}
+                  style={{ maxWidth: 96, maxHeight: 96 }}
+                  className="border border-secondary rounded"
+                  loading="lazy"
+                />
+              </a>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {detection && 'error' in detection ? (
+        <div className="col-12">
+          <div className="alert alert-warning py-2 text-sm mb-2">
+            {detection.error === 'unreachable'
+              ? `Site unreachable. ${detection.message}`
+              : 'Could not identify the engine for this site. It may run an unsupported booru engine, require login, or sit behind a CAPTCHA/anti-bot wall. Only recognized engines can be added.'}
+          </div>
+          {devOptions && detection.attempts?.length ? (
+            <details className="mb-2" open>
+              <summary className="text-muted-foreground text-sm">
+                Probe attempts ({detection.attempts.length})
+              </summary>
+              <table className="table table-sm table-dark table-borderless mt-2 mb-0 text-sm">
+                <thead>
+                  <tr className="text-muted-foreground">
+                    <th scope="col">Engine</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">HTTP</th>
+                    <th scope="col">Detail</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {detection.attempts.map((attempt) => (
+                    <tr key={attempt.engine}>
+                      <td>{ENGINE_LABELS[attempt.engine]}</td>
+                      <td>
+                        <span
+                          className={
+                            attempt.status === 'matched'
+                              ? 'text-success'
+                              : attempt.status === 'no-match'
+                                ? 'text-muted-foreground'
+                                : 'text-warning'
+                          }
+                        >
+                          {attempt.status}
+                        </span>
+                      </td>
+                      <td>{attempt.httpStatus ?? '—'}</td>
+                      <td className="text-muted-foreground">{attempt.error ?? ''}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </details>
+          ) : null}
+        </div>
+      ) : null}
+
+      {detectedEngine ? (
+        <>
+          {detectedFields.username ? (
+            <div className="col-md-6">
+              <label className="form-label text-sm mb-1" htmlFor={addUsernameId}>
+                {detectedFields.usernameLabel}
+              </label>
+              <input
+                id={addUsernameId}
+                type="text"
+                className="form-control form-control-sm bg-background text-foreground border-secondary"
+                {...register('username')}
+              />
+            </div>
+          ) : null}
+          {detectedFields.apiKey ? (
+            <div className="col-md-6">
+              <label className="form-label text-sm mb-1" htmlFor={addApiKeyId}>
+                {detectedFields.apiKeyLabel}
+              </label>
+              <input
+                id={addApiKeyId}
+                type="password"
+                className="form-control form-control-sm bg-background text-foreground border-secondary"
+                {...register('apiKey')}
+              />
+            </div>
+          ) : null}
+          <div className="col-12 mt-2">
+            <span className="text-muted-foreground text-sm block mb-1">Capabilities</span>
+            <div className="row g-2">
+              {Object.entries(CAPABILITY_LABELS).map(([key, label]) => (
+                <div key={key} className="col-6 col-md-3">
+                  <div className="form-check">
+                    <input
+                      className="form-check-input"
+                      type="checkbox"
+                      id={`new-${key}`}
+                      {...register(`capabilities.${key as keyof BooruSiteAddFormValues['capabilities']}`)}
+                    />
+                    <label className="form-check-label text-muted-foreground text-sm" htmlFor={`new-${key}`}>
+                      {label}
+                    </label>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      ) : null}
+
+      {detectError ? <div className="col-12 text-destructive text-sm">{detectError}</div> : null}
+      {submitError ? <div className="col-12 text-destructive text-sm">{submitError}</div> : null}
+
+      <div className="col-12 flex gap-2 mt-2">
+        <button type="submit" className="btn btn-sm btn-outline-light" disabled={addingBusy || !detectedEngine}>
+          {addingBusy ? 'Adding…' : 'Add site'}
+        </button>
+        <button
+          type="button"
+          className="btn btn-sm btn-outline-light"
+          onClick={() => {
+            reset();
+            setDetection(null);
+            setDetectError(null);
+            setSubmitError(null);
+          }}
+        >
+          Reset
+        </button>
+      </div>
+    </form>
+  );
+}
+
+type BooruSiteCredentialFormProps = {
+  site: BooruSite;
+  schema: BooruCredentialSchema;
+  loading: boolean;
+  testing: boolean;
+  onSave: (
+    payload: ReturnType<typeof toBooruCredentialUpdatePayload>,
+  ) => Promise<BooruSite>;
+  onTest: () => Promise<void>;
+};
+
+export function BooruSiteCredentialForm({
+  site,
+  schema,
+  loading,
+  testing,
+  onSave,
+  onTest,
+}: BooruSiteCredentialFormProps) {
+  const fields = useMemo(() => credentialFieldsForSchema(schema), [schema]);
+  const formSchema = useMemo(() => createBooruCredentialSchema(schema), [schema]);
+  const usernameId = `site-${site.id}-username`;
+  const apiKeyId = `site-${site.id}-api-key`;
+  const {
+    register,
+    reset,
+    handleSubmit,
+  } = useForm<BooruCredentialFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      username: site.username ?? '',
+      apiKey: '',
+    },
+  });
+
+  useEffect(() => {
+    reset({
+      username: site.username ?? '',
+      apiKey: '',
+    });
+  }, [reset, site.id, site.username]);
+
+  return (
+    <form
+      onSubmit={handleSubmit(async (values) => {
+        const updated = await onSave(toBooruCredentialUpdatePayload(values));
+        reset({
+          username: updated.username ?? '',
+          apiKey: '',
+        });
+      })}
+      className="row g-2 mt-2"
+    >
+      {fields.username ? (
+        <div className="col-md-4">
+          <label className="form-label text-sm mb-1 text-muted-foreground" htmlFor={usernameId}>
+            {fields.usernameLabel}
+          </label>
+          <input
+            id={usernameId}
+            type="text"
+            className="form-control form-control-sm bg-background text-foreground border-secondary"
+            {...register('username')}
+          />
+        </div>
+      ) : null}
+      {fields.apiKey ? (
+        <div className="col-md-4">
+          <label className="form-label text-sm mb-1 text-muted-foreground" htmlFor={apiKeyId}>
+            {fields.apiKeyLabel}
+            {site.hasApiKey ? <span className="text-muted-foreground"> · saved</span> : null}
+          </label>
+          <input
+            id={apiKeyId}
+            type="password"
+            className="form-control form-control-sm bg-background text-foreground border-secondary"
+            placeholder={site.hasApiKey ? '••••••••' : ''}
+            {...register('apiKey')}
+          />
+        </div>
+      ) : null}
+      <div className="col-md-4 flex items-end gap-2">
+        <button type="submit" className="btn btn-sm btn-outline-light" disabled={loading}>
+          Save credentials
+        </button>
+        <button
+          type="button"
+          className="btn btn-sm btn-outline-light"
+          onClick={() => void onTest()}
+          disabled={testing}
+        >
+          {testing ? 'Testing…' : 'Test'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/booru-sites/formSchemas.ts
+++ b/frontend/src/features/booru-sites/formSchemas.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+
+import type { BooruEngineType } from '@/api';
+import { ensureHttps } from '../../urlUtils';
+
+const capabilitiesSchema = z.object({
+  capFavorites: z.boolean(),
+  capTags: z.boolean(),
+  capSourceMatch: z.boolean(),
+});
+
+const normalizedUrlSchema = z
+  .string()
+  .trim()
+  .min(1, 'Base URL is required')
+  .transform((value) => ensureHttps(value))
+  .pipe(z.string().url('Base URL must be a valid URL'));
+
+const trimStringSchema = z.string().transform((value) => value.trim());
+
+export const booruSiteAddSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, 'Name is required')
+    .max(100, 'Name must be at most 100 characters'),
+  baseUrl: normalizedUrlSchema,
+  username: trimStringSchema,
+  apiKey: trimStringSchema,
+  capabilities: capabilitiesSchema,
+});
+
+export type BooruSiteAddFormValues = z.infer<typeof booruSiteAddSchema>;
+
+export const createBooruCredentialSchema = (credentialSchema: string) =>
+  z.object({
+    username:
+      credentialSchema === 'username+apikey' || credentialSchema === 'userid+apikey'
+        ? trimStringSchema
+        : z.string().default(''),
+    apiKey: trimStringSchema,
+  });
+
+export type BooruCredentialFormValues = z.infer<
+  ReturnType<typeof createBooruCredentialSchema>
+>;
+
+const toNullableTrimmed = (value: string): string | null => {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+export const toBooruSiteCreatePayload = (
+  values: BooruSiteAddFormValues,
+  engine: BooruEngineType,
+) => ({
+  name: values.name.trim(),
+  engine,
+  baseUrl: ensureHttps(values.baseUrl),
+  username: toNullableTrimmed(values.username),
+  apiKey: toNullableTrimmed(values.apiKey),
+  capFavorites: values.capabilities.capFavorites,
+  capTags: values.capabilities.capTags,
+  capSourceMatch: values.capabilities.capSourceMatch,
+  enabled: true,
+});
+
+export const toBooruCredentialUpdatePayload = (values: BooruCredentialFormValues) => ({
+  username: toNullableTrimmed(values.username),
+  apiKey: toNullableTrimmed(values.apiKey),
+});

--- a/frontend/src/features/booru-sites/shared.ts
+++ b/frontend/src/features/booru-sites/shared.ts
@@ -1,0 +1,42 @@
+import type { BooruCredentialSchema, BooruEngineType } from '@/api';
+
+export const ENGINE_LABELS: Record<BooruEngineType, string> = {
+  danbooru: 'Danbooru',
+  e621: 'e621',
+  moebooru: 'Moebooru (yande.re / konachan)',
+  gelbooru: 'Gelbooru',
+  sankaku: 'Sankaku',
+  philomena: 'Philomena (Derpibooru)',
+  shimmie: 'Shimmie2',
+  szurubooru: 'Szurubooru',
+};
+
+export type CapabilityKey = 'capFavorites' | 'capTags' | 'capSourceMatch';
+
+export const CAPABILITY_LABELS: Record<CapabilityKey, string> = {
+  capFavorites: 'Sync favorites',
+  capTags: 'Tag fetch',
+  capSourceMatch: 'Source URL match',
+};
+
+export const defaultCapabilities: Record<CapabilityKey, boolean> = {
+  capFavorites: false,
+  capTags: true,
+  capSourceMatch: true,
+};
+
+export const credentialFieldsForSchema = (schema: BooruCredentialSchema) => {
+  switch (schema) {
+    case 'username+apikey':
+      return { username: true, usernameLabel: 'Username', apiKey: true, apiKeyLabel: 'API key' };
+    case 'userid+apikey':
+      return { username: true, usernameLabel: 'User ID', apiKey: true, apiKeyLabel: 'API key' };
+    case 'apikey-only':
+      return { username: false, usernameLabel: '', apiKey: true, apiKeyLabel: 'API key' };
+    case 'token':
+      return { username: false, usernameLabel: '', apiKey: true, apiKeyLabel: 'Token' };
+    case 'none':
+    default:
+      return { username: false, usernameLabel: '', apiKey: false, apiKeyLabel: '' };
+  }
+};

--- a/frontend/test/formSchemas.test.ts
+++ b/frontend/test/formSchemas.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAuthFormSchema, toAuthSubmitPayload } from '../src/features/auth/authSchemas';
+import {
+  booruSiteAddSchema,
+  createBooruCredentialSchema,
+  toBooruCredentialUpdatePayload,
+  toBooruSiteCreatePayload,
+} from '../src/features/booru-sites/formSchemas';
+
+describe('authSchemas', () => {
+  it('rejects invalid register input with backend-matching messages', () => {
+    const result = buildAuthFormSchema('register').safeParse({
+      username: 'a',
+      password: 'short',
+      confirmPassword: 'different',
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    const messages = result.error.issues.map((issue) => issue.message);
+    expect(messages).toContain('Username must be at least 3 characters');
+    expect(messages).toContain('Password must be at least 8 characters');
+    expect(messages).toContain('Passwords do not match');
+  });
+
+  it('trims auth payloads before submit', () => {
+    expect(
+      toAuthSubmitPayload({
+        username: '  smoke-user  ',
+        password: 'Password123',
+        confirmPassword: '',
+      }),
+    ).toEqual({
+      username: 'smoke-user',
+      password: 'Password123',
+    });
+  });
+});
+
+describe('booru form schemas', () => {
+  it('rejects add-site input without a valid normalized URL', () => {
+    const result = booruSiteAddSchema.safeParse({
+      name: '',
+      baseUrl: 'not a url',
+      username: '',
+      apiKey: '',
+      capabilities: {
+        capFavorites: false,
+        capTags: true,
+        capSourceMatch: true,
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    const messages = result.error.issues.map((issue) => issue.message);
+    expect(messages).toContain('Name is required');
+    expect(messages).toContain('Base URL must be a valid URL');
+  });
+
+  it('shapes add-site payloads like the current mutation path', () => {
+    expect(
+      toBooruSiteCreatePayload(
+        {
+          name: '  My booru  ',
+          baseUrl: 'gelbooru.com/',
+          username: '  user  ',
+          apiKey: '  secret  ',
+          capabilities: {
+            capFavorites: true,
+            capTags: false,
+            capSourceMatch: true,
+          },
+        },
+        'gelbooru',
+      ),
+    ).toEqual({
+      name: 'My booru',
+      engine: 'gelbooru',
+      baseUrl: 'https://gelbooru.com/',
+      username: 'user',
+      apiKey: 'secret',
+      capFavorites: true,
+      capTags: false,
+      capSourceMatch: true,
+      enabled: true,
+    });
+  });
+
+  it('keeps credential-row fields optional but trims saved values', () => {
+    const result = createBooruCredentialSchema('username+apikey').safeParse({
+      username: '  demo  ',
+      apiKey: '  token  ',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+
+    expect(toBooruCredentialUpdatePayload(result.data)).toEqual({
+      username: 'demo',
+      apiKey: 'token',
+    });
+  });
+});

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -1,31 +1,30 @@
 import { expect, test } from '@playwright/test';
 
-import { e2eUser, loginUi } from './helpers';
+import { loginWithUi, registerWithUi } from './helpers';
 
-test('register → login → me → logout round-trips via the SPA + API', async ({ page, request }) => {
-  // `smoke` user is seeded by `webServer.command`; we register an
-  // additional one here to exercise the full client flow.
-  const username = `pw_${Date.now()}`;
-  const reg = await request.post('/auth/register', {
-    data: { username, password: 'Password123' }
-  });
-  expect(reg.ok(), `register: ${reg.status()}`).toBeTruthy();
+test('register → login → me → logout round-trips via the SPA + API', async ({ page }) => {
+  const user = {
+    username: `pw_${Date.now()}`,
+    password: 'Password123',
+  };
 
-  // Login via the UI with the pre-seeded smoke user.
-  await loginUi(page);
-  // After successful login the protected route shell shows the user header.
-  await expect(page.getByText(`Signed in as ${e2eUser.username}`)).toBeVisible();
+  await registerWithUi(page, user);
+  await expect(page.getByText(`Signed in as ${user.username}`)).toBeVisible();
 
-  // The cookie should now satisfy /auth/me.
+  await page.getByRole('button', { name: 'Logout' }).click();
+  await expect(page.locator('input[autocomplete="username"]')).toBeVisible();
+  await expect(page).toHaveURL(/\/login/);
+
+  await loginWithUi(page, user);
+  await expect(page.getByText(`Signed in as ${user.username}`)).toBeVisible();
+
   const me = await page.request.get('/auth/me');
   expect(me.ok(), `/auth/me: ${me.status()}`).toBeTruthy();
   const body = (await me.json()) as { user: { username: string } };
-  expect(body.user.username).toBe(e2eUser.username);
+  expect(body.user.username).toBe(user.username);
 
-  // Logout button is in the page header — click it and assert we are
-  // back on the auth screen.
   await page.getByRole('button', { name: 'Logout' }).click();
-  await expect(page.locator('input[autocomplete="username"]')).toBeVisible();
+  await expect(page).toHaveURL(/\/login/);
 });
 
 test('protected /folders endpoint refuses an unauthenticated SPA fetch', async ({ page }) => {
@@ -34,9 +33,11 @@ test('protected /folders endpoint refuses an unauthenticated SPA fetch', async (
   expect(res.status()).toBe(401);
 });
 
-test('unauthenticated /app/gallery redirects to /login', async ({ page }) => {
+test('unauthenticated app routes redirect to /login', async ({ page }) => {
   await page.context().clearCookies();
-  await page.goto('/app/gallery');
-  await expect(page.locator('input[autocomplete="username"]')).toBeVisible();
-  await expect(page).toHaveURL(/\/login/);
+  for (const route of ['/app/gallery', '/app/folders', '/app/duplicates']) {
+    await page.goto(route);
+    await expect(page.locator('input[autocomplete="username"]')).toBeVisible();
+    await expect(page).toHaveURL(/\/login/);
+  }
 });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -35,14 +35,37 @@ export const loginApi = async (
 };
 
 export const loginUi = async (page: Page) => {
+  await loginWithUi(page, e2eUser);
+};
+
+export const loginWithUi = async (
+  page: Page,
+  overrides: Partial<typeof e2eUser> = {},
+) => {
+  const payload = { ...e2eUser, ...overrides };
   await page.context().clearCookies();
   await page.goto('/');
   // App.tsx labels aren't htmlFor-linked to the inputs (#TODO §15), so we
   // select by the autocomplete attribute that *is* set on the inputs.
-  await page.locator('input[autocomplete="username"]').fill(e2eUser.username);
-  await page.locator('input[autocomplete="current-password"]').fill(e2eUser.password);
+  await page.locator('input[autocomplete="username"]').fill(payload.username);
+  await page.locator('input[autocomplete="current-password"]').fill(payload.password);
   // Two "Login" buttons exist (the mode toggle + the form submit); the
   // submit one is the only one of type="submit".
+  await page.locator('form button[type="submit"]').click();
+  await expect(page).toHaveURL(/\/app\/gallery$/);
+};
+
+export const registerWithUi = async (
+  page: Page,
+  overrides: Partial<typeof e2eUser> = {},
+) => {
+  const payload = { ...e2eUser, ...overrides };
+  await page.context().clearCookies();
+  await page.goto('/login');
+  await page.getByRole('button', { name: 'Register' }).click();
+  await page.locator('input[autocomplete="username"]').fill(payload.username);
+  await page.locator('input[autocomplete="new-password"]').first().fill(payload.password);
+  await page.locator('input[autocomplete="new-password"]').nth(1).fill(payload.password);
   await page.locator('form button[type="submit"]').click();
   await expect(page).toHaveURL(/\/app\/gallery$/);
 };
@@ -68,4 +91,26 @@ export const uploadSampleImage = async (
   });
   await expect(page.getByText('Uploaded 1 file.')).toBeVisible();
   return fileName;
+};
+
+export const uploadSampleImages = async (
+  page: Page,
+  fileNames: string[],
+) => {
+  const chooserPromise = page.waitForEvent('filechooser');
+  await page.goto('/app/folders');
+  await expect(page).toHaveURL(/\/app\/folders$/);
+  await page.getByRole('button', { name: 'Upload files' }).first().click();
+  const chooser = await chooserPromise;
+  await chooser.setFiles(
+    fileNames.map((name) => ({
+      name,
+      mimeType: 'image/png',
+      buffer: Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAukB9pX6lz4AAAAASUVORK5CYII=',
+        'base64',
+      ),
+    })),
+  );
+  await expect(page.getByText(`Uploaded ${fileNames.length} file`)).toBeVisible();
 };

--- a/tests/library-empty.spec.ts
+++ b/tests/library-empty.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { loginUi, uploadSampleImage } from './helpers';
+import { loginUi, uploadSampleImage, uploadSampleImages } from './helpers';
 
 test('a freshly-seeded user lands on the gallery view with no files', async ({ page }) => {
   await loginUi(page);
@@ -10,13 +10,16 @@ test('a freshly-seeded user lands on the gallery view with no files', async ({ p
   expect(await tiles.count()).toBe(0);
 });
 
-test('switching to Duplicates view does not error out on an empty library', async ({ page }) => {
+test('navigation roundtrip covers gallery, settings, and duplicates routes', async ({ page }) => {
   await loginUi(page);
+  await page.getByRole('link', { name: 'Settings' }).click();
+  await expect(page).toHaveURL(/\/app\/folders$/);
+  await expect(page.getByText('Configured booru sources')).toBeVisible();
   await page.getByRole('link', { name: 'Duplicates' }).click();
-  // No alerts, no console errors past this point. Playwright's default
-  // page error handler will fail the test if the React tree throws.
   await expect(page).toHaveURL(/\/app\/duplicates$/);
   await expect(page.getByRole('link', { name: 'Duplicates' })).toBeVisible();
+  await page.getByRole('link', { name: 'Gallery' }).click();
+  await expect(page).toHaveURL(/\/app\/gallery$/);
 });
 
 test('gallery file detail deep-link survives reload', async ({ page }) => {
@@ -40,4 +43,36 @@ test('gallery file detail deep-link survives reload', async ({ page }) => {
   expect(fileId).toBeTruthy();
   const del = await page.request.delete(`/files/${fileId}`);
   expect(del.ok(), `delete file: ${del.status()}`).toBeTruthy();
+});
+
+test('upload and duplicate scan flow works across routes', async ({ page }) => {
+  await loginUi(page);
+  const fileNames = [`dup-a-${Date.now()}.png`, `dup-b-${Date.now()}.png`];
+  await uploadSampleImages(page, fileNames);
+  await expect(page.getByText(/Uploaded 2 file/)).toBeVisible();
+
+  await page.getByRole('link', { name: 'Gallery' }).click();
+  await expect(page).toHaveURL(/\/app\/gallery$/);
+  await expect(page.locator('[data-test-id="file-card"]')).toHaveCount(2);
+
+  await page.getByRole('link', { name: 'Duplicates' }).click();
+  await expect(page).toHaveURL(/\/app\/duplicates$/);
+  await page.getByRole('button', { name: 'Run scan' }).click();
+  await expect(page.getByText(/Eligible: 2\/2/)).toBeVisible();
+  await expect(page.getByText('No duplicates found.')).toBeVisible();
+});
+
+test('booru site add form submits after engine detection', async ({ page }) => {
+  await loginUi(page);
+  await page.getByRole('link', { name: 'Settings' }).click();
+  await expect(page).toHaveURL(/\/app\/folders$/);
+
+  const siteName = `Playwright ${Date.now()}`;
+  await page.locator('#booru-name').fill(siteName);
+  await page.locator('#booru-url').fill('e621.net');
+  await expect(page.getByText(/Detected: e621/i)).toBeVisible({ timeout: 15000 });
+
+  await page.getByRole('button', { name: 'Add site' }).click();
+  await expect(page.getByText(siteName)).toBeVisible();
+  await expect(page.getByText(/e621\.net/)).toBeVisible();
 });


### PR DESCRIPTION
## Summary\n- convert the auth flow and booru-site add/edit credential forms to React Hook Form + Zod\n- replace hand-rolled frontend validation with shared schema helpers and payload shapers\n- expand Playwright to cover UI register/login/logout, route roundtrips, upload+duplicate scan, and booru-site submission\n\n## Testing\n- npm test --prefix frontend\n- npm run build --prefix frontend\n- npm run test:e2e\n\nFixes #103