### PR TITLE
fix: align backend native deps with runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,5 +203,8 @@ jobs:
       - name: Build app image
         run: docker build --file backend/Dockerfile --tag gooncave-app:ci .
 
+      - name: Smoke test native runtime modules
+        run: docker run --rm --entrypoint node gooncave-app:ci -e "require('better-sqlite3'); console.log('better-sqlite3:ok')"
+
       - name: Build tagger image
         run: docker build --file tagger/Dockerfile --tag gooncave-tagger:ci tagger

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,7 +17,7 @@ COPY backend/scripts ./scripts
 COPY backend/src ./src
 RUN bun run build
 
-FROM ${BUN_IMAGE} AS backend-prod-deps
+FROM ${NODE_DEBIAN_IMAGE} AS backend-prod-deps
 
 WORKDIR /app
 
@@ -25,8 +25,8 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends python3 make g++ \
   && rm -rf /var/lib/apt/lists/*
 
-COPY backend/package.json backend/bun.lock ./
-RUN bun install --frozen-lockfile --production
+COPY backend/package.json ./
+RUN npm install --omit=dev
 
 FROM ${BUN_IMAGE} AS frontend-build
 


### PR DESCRIPTION
## Summary
- build backend production dependencies in the Node runtime image instead of Bun image
- ensure native modules (`better-sqlite3`) compile/load against runtime ABI and libc
- add CI docker smoke step that executes `require('better-sqlite3')` inside built app image

## Why
Production entered restart loop because native addon was built in a different environment than runtime. Build-only CI did not execute module load path, so breakage escaped.

## Validation
- reproduced restart loop on host (`gooncave-api-1`)
- rebuilt with fix and confirmed `gooncave-api-1` healthy with restart count `0`
- `http://127.0.0.1:4100/health` returned `{"status":"ok"...}` on host

## Notes
- full local CI suite not rerun in this branch; runtime behavior verified on target host
