### PR TITLE
feat: add dedicated favorites accounts page

### DIFF
--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -8,6 +8,7 @@
         "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^11.2.0",
         "@fastify/multipart": "^10.0.0",
+        "@fastify/rate-limit": "^10.3.0",
         "@fastify/static": "^9.1.3",
         "argon2": "^0.44.0",
         "better-sqlite3": "^12.10.0",
@@ -147,6 +148,8 @@
     "@fastify/multipart": ["@fastify/multipart@10.0.0", "", { "dependencies": { "@fastify/busboy": "^3.0.0", "@fastify/deepmerge": "^3.0.0", "@fastify/error": "^4.0.0", "fastify-plugin": "^5.0.0", "secure-json-parse": "^4.0.0" } }, "sha512-pUx3Z1QStY7E7kwvDTIvB6P+rF5lzP+iqPgZyJyG3yBJVPvQaZxzDHYbQD89rbY0ciXrMOyGi8ezHDVexLvJDA=="],
 
     "@fastify/proxy-addr": ["@fastify/proxy-addr@5.1.0", "", { "dependencies": { "@fastify/forwarded": "^3.0.0", "ipaddr.js": "^2.1.0" } }, "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw=="],
+
+    "@fastify/rate-limit": ["@fastify/rate-limit@10.3.0", "", { "dependencies": { "@lukeed/ms": "^2.0.2", "fastify-plugin": "^5.0.0", "toad-cache": "^3.7.0" } }, "sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q=="],
 
     "@fastify/send": ["@fastify/send@4.1.0", "", { "dependencies": { "@lukeed/ms": "^2.0.2", "escape-html": "~1.0.3", "fast-decode-uri-component": "^1.0.1", "http-errors": "^2.0.0", "mime": "^3" } }, "sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw=="],
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.2.0",
     "@fastify/multipart": "^10.0.0",
+    "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.1.3",
     "argon2": "^0.44.0",
     "better-sqlite3": "^12.10.0",

--- a/backend/src/db/migrations/0001_per_site_favorites_settings.sql
+++ b/backend/src/db/migrations/0001_per_site_favorites_settings.sql
@@ -1,0 +1,41 @@
+ALTER TABLE user_booru_sites
+  ADD COLUMN site_auto_sync_midnight INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE user_booru_sites
+  ADD COLUMN site_reverse_sync_enabled INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE user_booru_sites
+  ADD COLUMN site_auto_fav_enabled INTEGER NOT NULL DEFAULT 0;
+
+UPDATE user_booru_sites
+SET
+  site_auto_sync_midnight = CASE
+    WHEN (
+      SELECT us.value
+      FROM user_settings us
+      WHERE us.user_id = user_booru_sites.user_id
+        AND us.key = 'favorites_auto_sync_midnight'
+      LIMIT 1
+    ) = 'false' THEN 0
+    ELSE 1
+  END,
+  site_reverse_sync_enabled = CASE
+    WHEN (
+      SELECT us.value
+      FROM user_settings us
+      WHERE us.user_id = user_booru_sites.user_id
+        AND us.key = 'favorites_reverse_sync'
+      LIMIT 1
+    ) = 'true' THEN 1
+    ELSE 0
+  END,
+  site_auto_fav_enabled = CASE
+    WHEN (
+      SELECT us.value
+      FROM user_settings us
+      WHERE us.user_id = user_booru_sites.user_id
+        AND us.key = 'favorites_auto_fav'
+      LIMIT 1
+    ) = 'true' THEN 1
+    ELSE 0
+  END;

--- a/backend/src/db/repos/booruSitesRepo.ts
+++ b/backend/src/db/repos/booruSitesRepo.ts
@@ -18,6 +18,9 @@ type BooruSiteRow = {
   cap_tags: number;
   cap_source_match: number;
   cap_search: number;
+  site_auto_sync_midnight: number;
+  site_reverse_sync_enabled: number;
+  site_auto_fav_enabled: number;
   sort_order: number;
   created_at: string;
   updated_at: string;
@@ -38,6 +41,9 @@ const mapBooruSiteRow = (row: BooruSiteRow): BooruSiteRecord => ({
   capTags: row.cap_tags === 1,
   capSourceMatch: row.cap_source_match === 1,
   capSearch: row.cap_search === 1,
+  siteAutoSyncMidnight: row.site_auto_sync_midnight === 1,
+  siteReverseSyncEnabled: row.site_reverse_sync_enabled === 1,
+  siteAutoFavEnabled: row.site_auto_fav_enabled === 1,
   sortOrder: row.sort_order,
   createdAt: row.created_at,
   updatedAt: row.updated_at
@@ -46,29 +52,47 @@ const mapBooruSiteRow = (row: BooruSiteRow): BooruSiteRecord => ({
 export const booruSitesRepo = {
   async listBooruSites(userId: string): Promise<BooruSiteRecord[]> {
     const rows = sqlite
-      .prepare('SELECT * FROM user_booru_sites WHERE user_id = ? ORDER BY sort_order ASC, created_at ASC')
+      .prepare(
+        'SELECT * FROM user_booru_sites WHERE user_id = ? ORDER BY sort_order ASC, created_at ASC'
+      )
       .all(userId) as BooruSiteRow[];
     return rows.map(mapBooruSiteRow);
   },
-  async getBooruSite(id: string, userId: string): Promise<BooruSiteRecord | null> {
+  async getBooruSite(
+    id: string,
+    userId: string
+  ): Promise<BooruSiteRecord | null> {
     const row = sqlite
       .prepare('SELECT * FROM user_booru_sites WHERE id = ? AND user_id = ?')
       .get(id, userId) as BooruSiteRow | undefined;
     return row ? mapBooruSiteRow(row) : null;
   },
-  async findBooruSiteByPresetKey(presetKey: string, userId: string): Promise<BooruSiteRecord | null> {
+  async findBooruSiteByPresetKey(
+    presetKey: string,
+    userId: string
+  ): Promise<BooruSiteRecord | null> {
     const row = sqlite
-      .prepare('SELECT * FROM user_booru_sites WHERE preset_key = ? AND user_id = ?')
+      .prepare(
+        'SELECT * FROM user_booru_sites WHERE preset_key = ? AND user_id = ?'
+      )
       .get(presetKey, userId) as BooruSiteRow | undefined;
     return row ? mapBooruSiteRow(row) : null;
   },
-  async findBooruSiteByBaseUrl(baseUrl: string, userId: string): Promise<BooruSiteRecord | null> {
+  async findBooruSiteByBaseUrl(
+    baseUrl: string,
+    userId: string
+  ): Promise<BooruSiteRecord | null> {
     const row = sqlite
-      .prepare('SELECT * FROM user_booru_sites WHERE base_url = ? AND user_id = ?')
+      .prepare(
+        'SELECT * FROM user_booru_sites WHERE base_url = ? AND user_id = ?'
+      )
       .get(baseUrl, userId) as BooruSiteRow | undefined;
     return row ? mapBooruSiteRow(row) : null;
   },
-  async insertBooruSite(input: BooruSiteInput, userId: string): Promise<BooruSiteRecord> {
+  async insertBooruSite(
+    input: BooruSiteInput,
+    userId: string
+  ): Promise<BooruSiteRecord> {
     const id = randomUUID();
     const now = new Date().toISOString();
     const insertTx = sqlite.transaction(() => {
@@ -76,41 +100,55 @@ export const booruSitesRepo = {
         input.sortOrder ??
         (
           sqlite
-            .prepare('SELECT COALESCE(MAX(sort_order), -1) + 1 AS next FROM user_booru_sites WHERE user_id = ?')
+            .prepare(
+              'SELECT COALESCE(MAX(sort_order), -1) + 1 AS next FROM user_booru_sites WHERE user_id = ?'
+            )
             .get(userId) as { next: number }
         ).next;
-      sqlite.prepare(
-        `INSERT INTO user_booru_sites
+      sqlite
+        .prepare(
+          `INSERT INTO user_booru_sites
            (id, user_id, name, engine, base_url, username, api_key,
             is_preset, preset_key, enabled,
             cap_favorites, cap_tags, cap_source_match, cap_search,
+            site_auto_sync_midnight, site_reverse_sync_enabled, site_auto_fav_enabled,
             sort_order, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-      ).run(
-        id,
-        userId,
-        input.name,
-        input.engine,
-        input.baseUrl,
-        input.username ?? null,
-        input.apiKey ?? null,
-        input.isPreset ? 1 : 0,
-        input.presetKey ?? null,
-        input.enabled === false ? 0 : 1,
-        input.capFavorites ? 1 : 0,
-        input.capTags ? 1 : 0,
-        input.capSourceMatch ? 1 : 0,
-        input.capSearch ? 1 : 0,
-        nextSortOrder,
-        now,
-        now
-      );
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          id,
+          userId,
+          input.name,
+          input.engine,
+          input.baseUrl,
+          input.username ?? null,
+          input.apiKey ?? null,
+          input.isPreset ? 1 : 0,
+          input.presetKey ?? null,
+          input.enabled === false ? 0 : 1,
+          input.capFavorites ? 1 : 0,
+          input.capTags ? 1 : 0,
+          input.capSourceMatch ? 1 : 0,
+          input.capSearch ? 1 : 0,
+          input.siteAutoSyncMidnight ? 1 : 0,
+          input.siteReverseSyncEnabled ? 1 : 0,
+          input.siteAutoFavEnabled ? 1 : 0,
+          nextSortOrder,
+          now,
+          now
+        );
     });
     insertTx();
-    const row = sqlite.prepare('SELECT * FROM user_booru_sites WHERE id = ?').get(id) as BooruSiteRow;
+    const row = sqlite
+      .prepare('SELECT * FROM user_booru_sites WHERE id = ?')
+      .get(id) as BooruSiteRow;
     return mapBooruSiteRow(row);
   },
-  async updateBooruSite(id: string, updates: Partial<BooruSiteInput>, userId: string): Promise<BooruSiteRecord | null> {
+  async updateBooruSite(
+    id: string,
+    updates: Partial<BooruSiteInput>,
+    userId: string
+  ): Promise<BooruSiteRecord | null> {
     const existing = sqlite
       .prepare('SELECT * FROM user_booru_sites WHERE id = ? AND user_id = ?')
       .get(id, userId) as BooruSiteRow | undefined;
@@ -120,52 +158,146 @@ export const booruSitesRepo = {
       name: updates.name ?? existing.name,
       engine: updates.engine ?? existing.engine,
       base_url: updates.baseUrl ?? existing.base_url,
-      username: updates.username !== undefined ? updates.username : existing.username,
+      username:
+        updates.username !== undefined ? updates.username : existing.username,
       api_key: updates.apiKey !== undefined ? updates.apiKey : existing.api_key,
-      is_preset: updates.isPreset !== undefined ? (updates.isPreset ? 1 : 0) : existing.is_preset,
-      preset_key: updates.presetKey !== undefined ? updates.presetKey : existing.preset_key,
-      enabled: updates.enabled !== undefined ? (updates.enabled ? 1 : 0) : existing.enabled,
-      cap_favorites: updates.capFavorites !== undefined ? (updates.capFavorites ? 1 : 0) : existing.cap_favorites,
-      cap_tags: updates.capTags !== undefined ? (updates.capTags ? 1 : 0) : existing.cap_tags,
+      is_preset:
+        updates.isPreset !== undefined
+          ? updates.isPreset
+            ? 1
+            : 0
+          : existing.is_preset,
+      preset_key:
+        updates.presetKey !== undefined
+          ? updates.presetKey
+          : existing.preset_key,
+      enabled:
+        updates.enabled !== undefined
+          ? updates.enabled
+            ? 1
+            : 0
+          : existing.enabled,
+      cap_favorites:
+        updates.capFavorites !== undefined
+          ? updates.capFavorites
+            ? 1
+            : 0
+          : existing.cap_favorites,
+      cap_tags:
+        updates.capTags !== undefined
+          ? updates.capTags
+            ? 1
+            : 0
+          : existing.cap_tags,
       cap_source_match:
-        updates.capSourceMatch !== undefined ? (updates.capSourceMatch ? 1 : 0) : existing.cap_source_match,
-      cap_search: updates.capSearch !== undefined ? (updates.capSearch ? 1 : 0) : existing.cap_search,
+        updates.capSourceMatch !== undefined
+          ? updates.capSourceMatch
+            ? 1
+            : 0
+          : existing.cap_source_match,
+      cap_search:
+        updates.capSearch !== undefined
+          ? updates.capSearch
+            ? 1
+            : 0
+          : existing.cap_search,
+      site_auto_sync_midnight:
+        updates.siteAutoSyncMidnight !== undefined
+          ? updates.siteAutoSyncMidnight
+            ? 1
+            : 0
+          : existing.site_auto_sync_midnight,
+      site_reverse_sync_enabled:
+        updates.siteReverseSyncEnabled !== undefined
+          ? updates.siteReverseSyncEnabled
+            ? 1
+            : 0
+          : existing.site_reverse_sync_enabled,
+      site_auto_fav_enabled:
+        updates.siteAutoFavEnabled !== undefined
+          ? updates.siteAutoFavEnabled
+            ? 1
+            : 0
+          : existing.site_auto_fav_enabled,
       sort_order: updates.sortOrder ?? existing.sort_order,
       updated_at: new Date().toISOString()
     };
-    sqlite.prepare(
-      `UPDATE user_booru_sites
+    sqlite
+      .prepare(
+        `UPDATE user_booru_sites
        SET name = ?, engine = ?, base_url = ?, username = ?, api_key = ?, is_preset = ?, preset_key = ?,
            enabled = ?, cap_favorites = ?, cap_tags = ?, cap_source_match = ?, cap_search = ?,
+           site_auto_sync_midnight = ?, site_reverse_sync_enabled = ?, site_auto_fav_enabled = ?,
            sort_order = ?, updated_at = ?
        WHERE id = ? AND user_id = ?`
-    ).run(
-      merged.name,
-      merged.engine,
-      merged.base_url,
-      merged.username ?? null,
-      merged.api_key ?? null,
-      merged.is_preset,
-      merged.preset_key ?? null,
-      merged.enabled,
-      merged.cap_favorites,
-      merged.cap_tags,
-      merged.cap_source_match,
-      merged.cap_search,
-      merged.sort_order,
-      merged.updated_at,
-      id,
-      userId
-    );
+      )
+      .run(
+        merged.name,
+        merged.engine,
+        merged.base_url,
+        merged.username ?? null,
+        merged.api_key ?? null,
+        merged.is_preset,
+        merged.preset_key ?? null,
+        merged.enabled,
+        merged.cap_favorites,
+        merged.cap_tags,
+        merged.cap_source_match,
+        merged.cap_search,
+        merged.site_auto_sync_midnight,
+        merged.site_reverse_sync_enabled,
+        merged.site_auto_fav_enabled,
+        merged.sort_order,
+        merged.updated_at,
+        id,
+        userId
+      );
     return mapBooruSiteRow(merged);
+  },
+  async listUsersWithAutoSyncFavorites(): Promise<string[]> {
+    const rows = sqlite
+      .prepare(
+        `SELECT DISTINCT user_id
+         FROM user_booru_sites
+         WHERE enabled = 1
+           AND cap_favorites = 1
+           AND username IS NOT NULL
+           AND TRIM(username) <> ''
+           AND api_key IS NOT NULL
+           AND TRIM(api_key) <> ''
+           AND site_auto_sync_midnight = 1
+         ORDER BY user_id ASC`
+      )
+      .all() as Array<{ user_id: string }>;
+    return rows.map((row) => row.user_id);
   },
   async deleteBooruSite(id: string, userId: string): Promise<boolean> {
     const tx = sqlite.transaction(() => {
+      const existing = sqlite
+        .prepare('SELECT * FROM user_booru_sites WHERE id = ? AND user_id = ?')
+        .get(id, userId) as BooruSiteRow | undefined;
+      if (!existing) return false;
       const result = sqlite
-        .prepare('DELETE FROM user_booru_sites WHERE id = ? AND user_id = ? AND is_preset = 0')
+        .prepare('DELETE FROM user_booru_sites WHERE id = ? AND user_id = ?')
         .run(id, userId);
       if ((result.changes ?? 0) === 0) return false;
-      sqlite.prepare('DELETE FROM favorite_items WHERE provider = ? AND user_id = ?').run(id, userId);
+      sqlite
+        .prepare(
+          'DELETE FROM favorite_items WHERE provider = ? AND user_id = ?'
+        )
+        .run(id, userId);
+      if (existing.preset_key) {
+        sqlite
+          .prepare(
+            'DELETE FROM favorite_items WHERE provider = ? AND user_id = ?'
+          )
+          .run(existing.preset_key, userId);
+        sqlite
+          .prepare(
+            'DELETE FROM provider_credentials WHERE provider = ? AND user_id = ?'
+          )
+          .run(existing.preset_key, userId);
+      }
       return true;
     });
     return tx() as boolean;

--- a/backend/src/db/repos/favoritesRepo.ts
+++ b/backend/src/db/repos/favoritesRepo.ts
@@ -1,5 +1,10 @@
 import { config } from '../../config';
-import type { DuplicateSettings, FavoriteItemRecord, FavoriteProvider, FavoritesSettings } from '../../db/types';
+import type {
+  DuplicateSettings,
+  FavoriteItemRecord,
+  FavoriteProvider,
+  FavoritesSettings
+} from '../../db/types';
 import { sqlite } from '../client';
 
 type FavoriteItemRow = {
@@ -23,32 +28,51 @@ const mapFavoriteRow = (row: FavoriteItemRow): FavoriteItemRecord => ({
 });
 
 const getUserSetting = (userId: string, key: string) => {
-  const row = sqlite.prepare('SELECT value FROM user_settings WHERE user_id = ? AND key = ?').get(userId, key) as
-    | { value: string }
-    | undefined;
+  const row = sqlite
+    .prepare('SELECT value FROM user_settings WHERE user_id = ? AND key = ?')
+    .get(userId, key) as { value: string } | undefined;
   return row?.value ?? null;
 };
 
 const setUserSetting = (userId: string, key: string, value: string) => {
-  sqlite.prepare('INSERT OR REPLACE INTO user_settings (user_id, key, value) VALUES (?, ?, ?)').run(userId, key, value);
+  sqlite
+    .prepare(
+      'INSERT OR REPLACE INTO user_settings (user_id, key, value) VALUES (?, ?, ?)'
+    )
+    .run(userId, key, value);
 };
 
 const deleteUserSetting = (userId: string, key: string) => {
-  sqlite.prepare('DELETE FROM user_settings WHERE user_id = ? AND key = ?').run(userId, key);
+  sqlite
+    .prepare('DELETE FROM user_settings WHERE user_id = ? AND key = ?')
+    .run(userId, key);
 };
 
-const readUserSettingJson = <T>(userId: string, key: string, fallback: T): T => {
+const readUserSettingJson = <T>(
+  userId: string,
+  key: string,
+  fallback: T
+): T => {
   const raw = getUserSetting(userId, key);
   if (!raw) return fallback;
   try {
     return JSON.parse(raw) as T;
   } catch (error) {
-    console.error('[favorites] failed to parse user setting json', { userId, key, raw, error });
+    console.error('[favorites] failed to parse user setting json', {
+      userId,
+      key,
+      raw,
+      error
+    });
     throw error;
   }
 };
 
-const readUserSettingBool = (userId: string, key: string, fallback: boolean) => {
+const readUserSettingBool = (
+  userId: string,
+  key: string,
+  fallback: boolean
+) => {
   const raw = getUserSetting(userId, key);
   if (raw === null) return fallback;
   return raw === 'true';
@@ -67,42 +91,70 @@ const writeUserSettingJson = (userId: string, key: string, value: unknown) => {
 
 const normalizeKeyList = (value: string[] | undefined) => {
   if (!Array.isArray(value)) return [];
-  const cleaned = value.map((entry) => entry.trim().toLowerCase()).filter(Boolean);
+  const cleaned = value
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
   return Array.from(new Set(cleaned));
 };
 
 export const favoritesRepo = {
-  async listFavoriteItems(provider: FavoriteProvider | undefined, userId: string) {
+  async listFavoriteItems(
+    provider: FavoriteProvider | undefined,
+    userId: string
+  ) {
     const rows = provider
       ? (sqlite
-          .prepare('SELECT * FROM favorite_items WHERE provider = ? AND user_id = ? ORDER BY updated_at DESC')
+          .prepare(
+            'SELECT * FROM favorite_items WHERE provider = ? AND user_id = ? ORDER BY updated_at DESC'
+          )
           .all(provider, userId) as FavoriteItemRow[])
-      : (sqlite.prepare('SELECT * FROM favorite_items WHERE user_id = ? ORDER BY updated_at DESC').all(userId) as FavoriteItemRow[]);
+      : (sqlite
+          .prepare(
+            'SELECT * FROM favorite_items WHERE user_id = ? ORDER BY updated_at DESC'
+          )
+          .all(userId) as FavoriteItemRow[]);
     return rows.map(mapFavoriteRow);
   },
   async listFavoriteItemsByPath(filePath: string, userId: string) {
     const rows = sqlite
-      .prepare('SELECT * FROM favorite_items WHERE file_path = ? AND user_id = ? ORDER BY updated_at DESC')
+      .prepare(
+        'SELECT * FROM favorite_items WHERE file_path = ? AND user_id = ? ORDER BY updated_at DESC'
+      )
       .all(filePath, userId) as FavoriteItemRow[];
     return rows.map(mapFavoriteRow);
   },
-  async upsertFavoriteItem(item: {
-    provider: FavoriteProvider;
-    remoteId: string;
-    filePath: string;
-    sourceUrl?: string | null;
-    fileUrl?: string | null;
-  }, userId: string) {
+  async upsertFavoriteItem(
+    item: {
+      provider: FavoriteProvider;
+      remoteId: string;
+      filePath: string;
+      sourceUrl?: string | null;
+      fileUrl?: string | null;
+    },
+    userId: string
+  ) {
     const now = new Date().toISOString();
     const existing = sqlite
-      .prepare('SELECT * FROM favorite_items WHERE provider = ? AND remote_id = ? AND user_id = ?')
+      .prepare(
+        'SELECT * FROM favorite_items WHERE provider = ? AND remote_id = ? AND user_id = ?'
+      )
       .get(item.provider, item.remoteId, userId) as FavoriteItemRow | undefined;
     if (existing) {
-      sqlite.prepare(
-        `UPDATE favorite_items
+      sqlite
+        .prepare(
+          `UPDATE favorite_items
          SET file_path = ?, source_url = ?, file_url = ?, updated_at = ?
          WHERE provider = ? AND remote_id = ? AND user_id = ?`
-      ).run(item.filePath, item.sourceUrl ?? null, item.fileUrl ?? null, now, item.provider, item.remoteId, userId);
+        )
+        .run(
+          item.filePath,
+          item.sourceUrl ?? null,
+          item.fileUrl ?? null,
+          now,
+          item.provider,
+          item.remoteId,
+          userId
+        );
       return {
         ...mapFavoriteRow(existing),
         filePath: item.filePath,
@@ -111,10 +163,21 @@ export const favoritesRepo = {
         updatedAt: now
       };
     }
-    sqlite.prepare(
-      `INSERT INTO favorite_items (user_id, provider, remote_id, file_path, source_url, file_url, created_at, updated_at)
+    sqlite
+      .prepare(
+        `INSERT INTO favorite_items (user_id, provider, remote_id, file_path, source_url, file_url, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(userId, item.provider, item.remoteId, item.filePath, item.sourceUrl ?? null, item.fileUrl ?? null, now, now);
+      )
+      .run(
+        userId,
+        item.provider,
+        item.remoteId,
+        item.filePath,
+        item.sourceUrl ?? null,
+        item.fileUrl ?? null,
+        now,
+        now
+      );
     return {
       provider: item.provider,
       remoteId: item.remoteId,
@@ -125,103 +188,145 @@ export const favoritesRepo = {
       updatedAt: now
     } as FavoriteItemRecord;
   },
-  async deleteFavoriteItem(provider: FavoriteProvider, remoteId: string, userId: string) {
-    sqlite.prepare('DELETE FROM favorite_items WHERE provider = ? AND remote_id = ? AND user_id = ?').run(provider, remoteId, userId);
+  async deleteFavoriteItem(
+    provider: FavoriteProvider,
+    remoteId: string,
+    userId: string
+  ) {
+    sqlite
+      .prepare(
+        'DELETE FROM favorite_items WHERE provider = ? AND remote_id = ? AND user_id = ?'
+      )
+      .run(provider, remoteId, userId);
   },
   async getFavoritesSettings(userId: string): Promise<FavoritesSettings> {
-    const autoSyncDefault = config.favorites.syncIntervalMs > 0;
     return {
-      reverseSyncEnabled: readUserSettingBool(userId, 'favorites_reverse_sync', false),
-      autoSyncMidnight: readUserSettingBool(userId, 'favorites_auto_sync_midnight', autoSyncDefault),
-      autoFavEnabled: readUserSettingBool(userId, 'favorites_auto_fav', false),
       favoritesRootId: readUserSettingString(userId, 'favorites_root_id')
     };
   },
-  async getFavoritesSettingsBatch(userIds: string[]): Promise<Map<string, FavoritesSettings>> {
-    if (userIds.length === 0) return new Map();
-    const autoSyncDefault = config.favorites.syncIntervalMs > 0;
-    const placeholders = userIds.map(() => '?').join(',');
-    const keys = ['favorites_reverse_sync', 'favorites_auto_sync_midnight', 'favorites_auto_fav', 'favorites_root_id'];
-    const keyPlaceholders = keys.map(() => '?').join(',');
-    const rows = sqlite
-      .prepare(`SELECT user_id, key, value FROM user_settings WHERE user_id IN (${placeholders}) AND key IN (${keyPlaceholders})`)
-      .all(...userIds, ...keys) as { user_id: string; key: string; value: string }[];
-    const settingsByUser = new Map<string, Map<string, string>>();
-    for (const row of rows) {
-      if (!settingsByUser.has(row.user_id)) settingsByUser.set(row.user_id, new Map());
-      settingsByUser.get(row.user_id)!.set(row.key, row.value);
-    }
-    const result = new Map<string, FavoritesSettings>();
-    for (const userId of userIds) {
-      const settings = settingsByUser.get(userId) || new Map();
-      result.set(userId, {
-        reverseSyncEnabled: settings.get('favorites_reverse_sync') === 'true',
-        autoSyncMidnight: settings.has('favorites_auto_sync_midnight')
-          ? settings.get('favorites_auto_sync_midnight') === 'true'
-          : autoSyncDefault,
-        autoFavEnabled: settings.get('favorites_auto_fav') === 'true',
-        favoritesRootId: settings.get('favorites_root_id') || null
-      });
-    }
-    return result;
-  },
-  async saveFavoritesSettings(input: Partial<FavoritesSettings>, userId: string): Promise<FavoritesSettings> {
+  async saveFavoritesSettings(
+    input: Partial<FavoritesSettings>,
+    userId: string
+  ): Promise<FavoritesSettings> {
     const current = await this.getFavoritesSettings(userId);
-    const reverseSyncEnabled =
-      input.reverseSyncEnabled !== undefined ? input.reverseSyncEnabled : current.reverseSyncEnabled;
-    const autoSyncMidnight =
-      input.autoSyncMidnight !== undefined ? input.autoSyncMidnight : current.autoSyncMidnight;
-    const autoFavEnabled = input.autoFavEnabled !== undefined ? input.autoFavEnabled : current.autoFavEnabled;
-    const favoritesRootId = input.favoritesRootId !== undefined ? input.favoritesRootId : current.favoritesRootId;
-    setUserSetting(userId, 'favorites_reverse_sync', reverseSyncEnabled ? 'true' : 'false');
-    setUserSetting(userId, 'favorites_auto_sync_midnight', autoSyncMidnight ? 'true' : 'false');
-    setUserSetting(userId, 'favorites_auto_fav', autoFavEnabled ? 'true' : 'false');
+    const favoritesRootId =
+      input.favoritesRootId !== undefined
+        ? input.favoritesRootId
+        : current.favoritesRootId;
     if (favoritesRootId) {
       setUserSetting(userId, 'favorites_root_id', favoritesRootId);
     } else {
       deleteUserSetting(userId, 'favorites_root_id');
     }
-    return { reverseSyncEnabled, autoSyncMidnight, autoFavEnabled, favoritesRootId: favoritesRootId ?? null };
+    return { favoritesRootId: favoritesRootId ?? null };
+  },
+  async getLegacyPerSiteFavoritesDefaults(userId: string): Promise<{
+    siteAutoSyncMidnight: boolean;
+    siteReverseSyncEnabled: boolean;
+    siteAutoFavEnabled: boolean;
+  }> {
+    const autoSyncDefault = config.favorites.syncIntervalMs > 0;
+    return {
+      siteAutoSyncMidnight: readUserSettingBool(
+        userId,
+        'favorites_auto_sync_midnight',
+        autoSyncDefault
+      ),
+      siteReverseSyncEnabled: readUserSettingBool(
+        userId,
+        'favorites_reverse_sync',
+        false
+      ),
+      siteAutoFavEnabled: readUserSettingBool(
+        userId,
+        'favorites_auto_fav',
+        false
+      )
+    };
   },
   async getDuplicateSettings(userId: string): Promise<DuplicateSettings> {
-    return { autoResolve: readUserSettingBool(userId, 'duplicates_auto_resolve', false) };
+    return {
+      autoResolve: readUserSettingBool(userId, 'duplicates_auto_resolve', false)
+    };
   },
-  async saveDuplicateSettings(input: Partial<DuplicateSettings>, userId: string): Promise<DuplicateSettings> {
+  async saveDuplicateSettings(
+    input: Partial<DuplicateSettings>,
+    userId: string
+  ): Promise<DuplicateSettings> {
     const current = await this.getDuplicateSettings(userId);
-    const autoResolve = input.autoResolve !== undefined ? input.autoResolve : current.autoResolve;
-    setUserSetting(userId, 'duplicates_auto_resolve', autoResolve ? 'true' : 'false');
+    const autoResolve =
+      input.autoResolve !== undefined ? input.autoResolve : current.autoResolve;
+    setUserSetting(
+      userId,
+      'duplicates_auto_resolve',
+      autoResolve ? 'true' : 'false'
+    );
     return { autoResolve };
   },
   async getSauceSettings(userId: string) {
     const display = readUserSettingJson<string[]>(userId, 'sauce_display', []);
     const targets = readUserSettingJson<string[]>(userId, 'sauce_targets', []);
-    const displayInitialized = readUserSettingBool(userId, 'sauce_display_initialized', display.length > 0);
+    const displayInitialized = readUserSettingBool(
+      userId,
+      'sauce_display_initialized',
+      display.length > 0
+    );
     return { display, targets, displayInitialized };
   },
-  async saveSauceSettings(input: { display?: string[]; targets?: string[]; displayInitialized?: boolean }, userId: string) {
+  async saveSauceSettings(
+    input: {
+      display?: string[];
+      targets?: string[];
+      displayInitialized?: boolean;
+    },
+    userId: string
+  ) {
     const current = await this.getSauceSettings(userId);
     const display = normalizeKeyList(input.display ?? current.display);
     const targets = normalizeKeyList(input.targets ?? current.targets);
-    const displayInitialized = input.displayInitialized ?? current.displayInitialized;
+    const displayInitialized =
+      input.displayInitialized ?? current.displayInitialized;
     writeUserSettingJson(userId, 'sauce_display', display);
     writeUserSettingJson(userId, 'sauce_targets', targets);
-    setUserSetting(userId, 'sauce_display_initialized', displayInitialized ? 'true' : 'false');
+    setUserSetting(
+      userId,
+      'sauce_display_initialized',
+      displayInitialized ? 'true' : 'false'
+    );
     return { display, targets, displayInitialized };
   },
   async getSauceSettingsBatch(userIds: string[]) {
-    if (userIds.length === 0) return new Map<string, Awaited<ReturnType<typeof this.getSauceSettings>>>();
+    if (userIds.length === 0)
+      return new Map<
+        string,
+        Awaited<ReturnType<typeof this.getSauceSettings>>
+      >();
     const placeholders = userIds.map(() => '?').join(',');
-    const keys = ['sauce_display', 'sauce_targets', 'sauce_display_initialized'];
+    const keys = [
+      'sauce_display',
+      'sauce_targets',
+      'sauce_display_initialized'
+    ];
     const keyPlaceholders = keys.map(() => '?').join(',');
     const rows = sqlite
-      .prepare(`SELECT user_id, key, value FROM user_settings WHERE user_id IN (${placeholders}) AND key IN (${keyPlaceholders})`)
-      .all(...userIds, ...keys) as { user_id: string; key: string; value: string }[];
+      .prepare(
+        `SELECT user_id, key, value FROM user_settings WHERE user_id IN (${placeholders}) AND key IN (${keyPlaceholders})`
+      )
+      .all(...userIds, ...keys) as {
+      user_id: string;
+      key: string;
+      value: string;
+    }[];
     const settingsByUser = new Map<string, Map<string, string>>();
     for (const row of rows) {
-      if (!settingsByUser.has(row.user_id)) settingsByUser.set(row.user_id, new Map());
+      if (!settingsByUser.has(row.user_id))
+        settingsByUser.set(row.user_id, new Map());
       settingsByUser.get(row.user_id)!.set(row.key, row.value);
     }
-    const result = new Map<string, { display: string[]; targets: string[]; displayInitialized: boolean }>();
+    const result = new Map<
+      string,
+      { display: string[]; targets: string[]; displayInitialized: boolean }
+    >();
     for (const userId of userIds) {
       const settings = settingsByUser.get(userId);
       const displayRaw = settings?.get('sauce_display');

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -161,7 +161,10 @@ export const providerRuns = sqliteTable(
       table.completedAt,
       table.createdAt
     ),
-    providerFileIdx: index('idx_provider_runs_provider_file_id').on(table.provider, table.fileId),
+    providerFileIdx: index('idx_provider_runs_provider_file_id').on(
+      table.provider,
+      table.fileId
+    ),
     providerCreatedHitIdx: index('idx_provider_runs_provider_created_hit').on(
       table.provider,
       table.createdAt,
@@ -220,7 +223,10 @@ export const favoriteItems = sqliteTable(
   },
   (table) => ({
     pk: primaryKey({ columns: [table.userId, table.provider, table.remoteId] }),
-    userProviderIdx: index('idx_favorite_items_user_id_provider').on(table.userId, table.provider),
+    userProviderIdx: index('idx_favorite_items_user_id_provider').on(
+      table.userId,
+      table.provider
+    ),
     providerIdx: index('idx_favorite_items_provider').on(table.provider),
     filePathIdx: index('idx_favorite_items_file_path').on(table.filePath)
   })
@@ -260,21 +266,41 @@ export const userBooruSites = sqliteTable(
     capTags: integer('cap_tags').notNull(),
     capSourceMatch: integer('cap_source_match').notNull(),
     capSearch: integer('cap_search').notNull(),
+    siteAutoSyncMidnight: integer('site_auto_sync_midnight').notNull(),
+    siteReverseSyncEnabled: integer('site_reverse_sync_enabled').notNull(),
+    siteAutoFavEnabled: integer('site_auto_fav_enabled').notNull(),
     sortOrder: integer('sort_order').notNull(),
     createdAt: text('created_at').notNull(),
     updatedAt: text('updated_at').notNull()
   },
   (table) => ({
-    userSortIdx: index('idx_user_booru_sites_user_sort').on(table.userId, table.sortOrder),
-    userFavIdx: index('idx_user_booru_sites_user_fav').on(table.userId, table.enabled, table.capFavorites),
-    userTagsIdx: index('idx_user_booru_sites_user_tags').on(table.userId, table.enabled, table.capTags),
+    userSortIdx: index('idx_user_booru_sites_user_sort').on(
+      table.userId,
+      table.sortOrder
+    ),
+    userFavIdx: index('idx_user_booru_sites_user_fav').on(
+      table.userId,
+      table.enabled,
+      table.capFavorites
+    ),
+    userTagsIdx: index('idx_user_booru_sites_user_tags').on(
+      table.userId,
+      table.enabled,
+      table.capTags
+    ),
     userMatchIdx: index('idx_user_booru_sites_user_match').on(
       table.userId,
       table.enabled,
       table.capSourceMatch
     ),
-    userPresetUnique: uniqueIndex('user_booru_sites_user_preset_unique').on(table.userId, table.presetKey),
-    userBaseUrlUnique: uniqueIndex('user_booru_sites_user_base_url_unique').on(table.userId, table.baseUrl)
+    userPresetUnique: uniqueIndex('user_booru_sites_user_preset_unique').on(
+      table.userId,
+      table.presetKey
+    ),
+    userBaseUrlUnique: uniqueIndex('user_booru_sites_user_base_url_unique').on(
+      table.userId,
+      table.baseUrl
+    )
   })
 );
 
@@ -305,6 +331,9 @@ export const fileSignatures = sqliteTable(
     createdAt: text('created_at').notNull()
   },
   (table) => ({
-    sampleSizeIdx: index('idx_file_signatures_sample_size_file_id').on(table.sampleSize, table.fileId)
+    sampleSizeIdx: index('idx_file_signatures_sample_size_file_id').on(
+      table.sampleSize,
+      table.fileId
+    )
   })
 );

--- a/backend/src/db/types.ts
+++ b/backend/src/db/types.ts
@@ -105,6 +105,9 @@ export type BooruSiteRecord = {
   capTags: boolean;
   capSourceMatch: boolean;
   capSearch: boolean;
+  siteAutoSyncMidnight: boolean;
+  siteReverseSyncEnabled: boolean;
+  siteAutoFavEnabled: boolean;
   sortOrder: number;
   createdAt: string;
   updatedAt: string;
@@ -123,6 +126,9 @@ export type BooruSiteInput = {
   capTags?: boolean;
   capSourceMatch?: boolean;
   capSearch?: boolean;
+  siteAutoSyncMidnight?: boolean;
+  siteReverseSyncEnabled?: boolean;
+  siteAutoFavEnabled?: boolean;
   sortOrder?: number;
 };
 
@@ -134,9 +140,6 @@ export type CredentialRecord = {
 };
 
 export type FavoritesSettings = {
-  reverseSyncEnabled: boolean;
-  autoSyncMidnight: boolean;
-  autoFavEnabled: boolean;
   favoritesRootId: string | null;
 };
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,6 +8,7 @@ import fastifyStaticPlugin from '@fastify/static';
 import Fastify from 'fastify';
 
 import { config } from './config';
+import { runMigrations } from './db/migrate';
 import { seedBooruSitesFromLegacyCredentials } from './lib/booruSitesSeed';
 import { registerAdminRoutes } from './routes/admin';
 import { registerAuthRoutes } from './routes/auth';
@@ -21,16 +22,30 @@ import { registerHealthRoutes } from './routes/health';
 import { registerSauceRoutes } from './routes/sauces';
 import { clearSessionCookie, getUserFromSessionToken } from './services/auth';
 
-const protectedRoutePrefixes = ['/folders', '/files', '/sauces', '/duplicates', '/favorites', '/credentials', '/booru-sites', '/scans', '/thumbnails'];
+const protectedRoutePrefixes = [
+  '/folders',
+  '/files',
+  '/sauces',
+  '/duplicates',
+  '/favorites',
+  '/credentials',
+  '/booru-sites',
+  '/scans',
+  '/thumbnails'
+];
 const spaRoutePrefixes = ['/login', '/app'];
 
 const isProtectedPath = (url: string) => {
   const pathname = new URL(url, 'http://x').pathname;
-  return protectedRoutePrefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+  return protectedRoutePrefixes.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  );
 };
 
 const isSpaRoutePath = (pathname: string) =>
-  spaRoutePrefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+  spaRoutePrefixes.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  );
 
 export const createServer = (options?: { frontendDir?: string | null }) => {
   const app = Fastify({
@@ -46,7 +61,9 @@ export const createServer = (options?: { frontendDir?: string | null }) => {
   });
 
   if (config.allowedOrigins.length === 0) {
-    app.log.warn('ALLOWED_ORIGINS is empty; cross-origin requests will be rejected');
+    app.log.warn(
+      'ALLOWED_ORIGINS is empty; cross-origin requests will be rejected'
+    );
   }
   app.register(cors, {
     origin: config.allowedOrigins.length ? config.allowedOrigins : false,
@@ -95,7 +112,9 @@ export const createServer = (options?: { frontendDir?: string | null }) => {
     app.log.warn(`Thumbnails directory not found: ${thumbnailsRoot}`);
   }
   const frontendRootSource = options?.frontendDir ?? config.frontendDir;
-  const frontendRoot = frontendRootSource ? path.resolve(frontendRootSource) : null;
+  const frontendRoot = frontendRootSource
+    ? path.resolve(frontendRootSource)
+    : null;
   if (frontendRoot && fs.existsSync(frontendRoot)) {
     app.register(fastifyStaticPlugin, {
       root: frontendRoot,
@@ -119,8 +138,10 @@ export const createServer = (options?: { frontendDir?: string | null }) => {
   if (frontendRoot && fs.existsSync(frontendRoot)) {
     app.setNotFoundHandler(async (request, reply) => {
       const pathname = new URL(request.url, 'http://x').pathname;
-      const acceptsHtml = request.headers.accept?.includes('text/html') ?? false;
-      const isHtmlNavigation = request.method === 'GET' && acceptsHtml && !path.extname(pathname);
+      const acceptsHtml =
+        request.headers.accept?.includes('text/html') ?? false;
+      const isHtmlNavigation =
+        request.method === 'GET' && acceptsHtml && !path.extname(pathname);
       if (isHtmlNavigation && isSpaRoutePath(pathname)) {
         return reply.type('text/html').sendFile('index.html');
       }
@@ -128,7 +149,7 @@ export const createServer = (options?: { frontendDir?: string | null }) => {
       return reply.send({
         message: `Route ${request.method}:${pathname} not found`,
         error: 'Not Found',
-        statusCode: 404,
+        statusCode: 404
       });
     });
   }
@@ -139,6 +160,7 @@ export const createServer = (options?: { frontendDir?: string | null }) => {
 const start = async () => {
   const app = createServer();
   try {
+    runMigrations();
     const seedResult = await seedBooruSitesFromLegacyCredentials();
     if (seedResult.insertedRows > 0) {
       app.log.info(
@@ -148,6 +170,9 @@ const start = async () => {
     }
     await app.listen({ port: config.port, host: config.host });
     app.log.info(`Server listening on ${config.host}:${config.port}`);
+    if (process.env.API_EXIT_AFTER_BOOT === 'true') {
+      await app.close();
+    }
   } catch (err) {
     app.log.error(err);
     process.exit(1);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import cookie from '@fastify/cookie';
 import cors from '@fastify/cors';
 import multipart from '@fastify/multipart';
+import rateLimit from '@fastify/rate-limit';
 import fastifyStaticPlugin from '@fastify/static';
 import Fastify from 'fastify';
 
@@ -72,6 +73,7 @@ export const createServer = (options?: { frontendDir?: string | null }) => {
   });
 
   app.register(cookie);
+  app.register(rateLimit, { global: false });
   app.decorateRequest('currentUser', null);
   app.decorateRequest('sessionToken', null);
 

--- a/backend/src/lib/booruSitesSeed.ts
+++ b/backend/src/lib/booruSitesSeed.ts
@@ -1,5 +1,6 @@
 import { authRepo } from '../db/repos/authRepo';
 import { booruSitesRepo } from '../db/repos/booruSitesRepo';
+import { favoritesRepo } from '../db/repos/favoritesRepo';
 
 import { BOORU_PRESETS } from './booruEngines/presets';
 
@@ -27,6 +28,9 @@ export const seedBooruSitesFromLegacyCredentials = async (): Promise<{
     if (!PRESETS_WITH_LEGACY_CREDS.has(credential.provider)) continue;
     const preset = BOORU_PRESETS.find((p) => p.key === credential.provider);
     if (!preset) continue;
+    const siteDefaults = await favoritesRepo.getLegacyPerSiteFavoritesDefaults(
+      credential.userId
+    );
     await booruSitesRepo.insertBooruSite(
       {
         name: preset.name,
@@ -40,7 +44,10 @@ export const seedBooruSitesFromLegacyCredentials = async (): Promise<{
         capFavorites: preset.defaultCapabilities.favorites,
         capTags: preset.defaultCapabilities.tags,
         capSourceMatch: preset.defaultCapabilities.sourceMatch,
-        capSearch: preset.defaultCapabilities.search
+        capSearch: preset.defaultCapabilities.search,
+        siteAutoSyncMidnight: siteDefaults.siteAutoSyncMidnight,
+        siteReverseSyncEnabled: siteDefaults.siteReverseSyncEnabled,
+        siteAutoFavEnabled: siteDefaults.siteAutoFavEnabled
       },
       credential.userId
     );

--- a/backend/src/lib/booruSitesStore.test.ts
+++ b/backend/src/lib/booruSitesStore.test.ts
@@ -41,17 +41,26 @@ test('deleteBooruSite purges favorite_items rows owned by the deleted custom sit
     },
     seeded.user.id
   );
-  assert.equal((await favoritesRepo.listFavoriteItems(site.id, seeded.user.id)).length, 1);
+  assert.equal(
+    (await favoritesRepo.listFavoriteItems(site.id, seeded.user.id)).length,
+    1
+  );
 
   const removed = await booruSitesRepo.deleteBooruSite(site.id, seeded.user.id);
   assert.equal(removed, true);
 
   // Site gone AND its favorites gone — no orphans.
-  assert.equal(await booruSitesRepo.getBooruSite(site.id, seeded.user.id), null);
-  assert.equal((await favoritesRepo.listFavoriteItems(site.id, seeded.user.id)).length, 0);
+  assert.equal(
+    await booruSitesRepo.getBooruSite(site.id, seeded.user.id),
+    null
+  );
+  assert.equal(
+    (await favoritesRepo.listFavoriteItems(site.id, seeded.user.id)).length,
+    0
+  );
 });
 
-test('deleteBooruSite refuses to delete preset rows and leaves them intact', async () => {
+test('deleteBooruSite deletes preset row and purges preset-key favorites', async () => {
   const seeded = await seedUser({ username: 'delete-preset' });
   const preset = await booruSitesRepo.insertBooruSite(
     {
@@ -68,9 +77,29 @@ test('deleteBooruSite refuses to delete preset rows and leaves them intact', asy
     },
     seeded.user.id
   );
-  const removed = await booruSitesRepo.deleteBooruSite(preset.id, seeded.user.id);
-  assert.equal(removed, false);
-  assert.ok(await booruSitesRepo.getBooruSite(preset.id, seeded.user.id));
+  await favoritesRepo.upsertFavoriteItem(
+    {
+      provider: 'E621',
+      remoteId: '123',
+      filePath: '/tmp/e621.jpg',
+      sourceUrl: 'https://e621.net/posts/123',
+      fileUrl: null
+    },
+    seeded.user.id
+  );
+  const removed = await booruSitesRepo.deleteBooruSite(
+    preset.id,
+    seeded.user.id
+  );
+  assert.equal(removed, true);
+  assert.equal(
+    await booruSitesRepo.getBooruSite(preset.id, seeded.user.id),
+    null
+  );
+  assert.equal(
+    (await favoritesRepo.listFavoriteItems('E621', seeded.user.id)).length,
+    0
+  );
 });
 
 test('updateBooruSite persists preset flags when explicitly changed', async () => {
@@ -101,18 +130,38 @@ test('updateBooruSite persists preset flags when explicitly changed', async () =
   assert.equal(updated?.presetKey, 'CUSTOM_PRESET');
 });
 
-test('deleteBooruSite does not touch another user\'s favorites that share a remote id', async () => {
+test("deleteBooruSite does not touch another user's favorites that share a remote id", async () => {
   const a = await seedUser({ username: 'cascade-user-a' });
   const b = await seedUser({ username: 'cascade-user-b' });
   const siteA = await booruSitesRepo.insertBooruSite(
-    { name: 'A', engine: 'szurubooru', baseUrl: 'https://a.example.com', isPreset: false, presetKey: null, enabled: true, capFavorites: true, capTags: true, capSourceMatch: true, capSearch: false },
+    {
+      name: 'A',
+      engine: 'szurubooru',
+      baseUrl: 'https://a.example.com',
+      isPreset: false,
+      presetKey: null,
+      enabled: true,
+      capFavorites: true,
+      capTags: true,
+      capSourceMatch: true,
+      capSearch: false
+    },
     a.user.id
   );
   // user B has a favorite under the same provider key shape site deletes use.
   await favoritesRepo.upsertFavoriteItem(
-    { provider: siteA.id, remoteId: '99', filePath: '/tmp/b.jpg', sourceUrl: null, fileUrl: null },
+    {
+      provider: siteA.id,
+      remoteId: '99',
+      filePath: '/tmp/b.jpg',
+      sourceUrl: null,
+      fileUrl: null
+    },
     b.user.id
   );
   await booruSitesRepo.deleteBooruSite(siteA.id, a.user.id);
-  assert.equal((await favoritesRepo.listFavoriteItems(siteA.id, b.user.id)).length, 1);
+  assert.equal(
+    (await favoritesRepo.listFavoriteItems(siteA.id, b.user.id)).length,
+    1
+  );
 });

--- a/backend/src/routes/booruSites.ts
+++ b/backend/src/routes/booruSites.ts
@@ -30,6 +30,9 @@ const createSchema = z.object({
   capTags: z.boolean().optional(),
   capSourceMatch: z.boolean().optional(),
   capSearch: z.boolean().optional(),
+  siteAutoSyncMidnight: z.boolean().optional(),
+  siteReverseSyncEnabled: z.boolean().optional(),
+  siteAutoFavEnabled: z.boolean().optional(),
   enabled: z.boolean().optional()
 });
 
@@ -42,6 +45,9 @@ const updateSchema = z.object({
   capTags: z.boolean().optional(),
   capSourceMatch: z.boolean().optional(),
   capSearch: z.boolean().optional(),
+  siteAutoSyncMidnight: z.boolean().optional(),
+  siteReverseSyncEnabled: z.boolean().optional(),
+  siteAutoFavEnabled: z.boolean().optional(),
   // Only honoured for non-preset rows; presets ignore engine/baseUrl edits to
   // keep historical favorite_items rows pointing at the right canonical site.
   engine: engineEnum.optional(),
@@ -53,10 +59,12 @@ const detectSchema = z.object({
 });
 
 const reorderSchema = z.object({
-  orderedIds: z.array(z.string()).min(1).refine(
-    (ids) => new Set(ids).size === ids.length,
-    { message: 'orderedIds must not contain duplicates' }
-  )
+  orderedIds: z
+    .array(z.string())
+    .min(1)
+    .refine((ids) => new Set(ids).size === ids.length, {
+      message: 'orderedIds must not contain duplicates'
+    })
 });
 
 const toPublic = (site: BooruSiteRecord) => ({
@@ -73,13 +81,18 @@ const toPublic = (site: BooruSiteRecord) => ({
   capTags: site.capTags,
   capSourceMatch: site.capSourceMatch,
   capSearch: site.capSearch,
+  siteAutoSyncMidnight: site.siteAutoSyncMidnight,
+  siteReverseSyncEnabled: site.siteReverseSyncEnabled,
+  siteAutoFavEnabled: site.siteAutoFavEnabled,
   sortOrder: site.sortOrder,
   createdAt: site.createdAt,
   updatedAt: site.updatedAt,
   engineCredentialSchema: getEngine(site.engine)?.credentialSchema ?? 'none'
 });
 
-const trimOrUndefined = (value: string | null | undefined): string | null | undefined => {
+const trimOrUndefined = (
+  value: string | null | undefined
+): string | null | undefined => {
   if (value === undefined) return undefined;
   if (value === null) return null;
   const trimmed = value.trim();
@@ -93,11 +106,15 @@ const probeTestConnection = async (
   if (!engine) return { ok: false, error: 'unknown engine' };
   const url = site.baseUrl.replace(/\/+$/, '') + engine.probePath;
   try {
-    const headers: Record<string, string> = { 'User-Agent': config.e621.userAgent };
+    const headers: Record<string, string> = {
+      'User-Agent': config.e621.userAgent
+    };
     let probeUrl = url;
     if (site.username && site.apiKey) {
       if (engine.credentialSchema === 'username+apikey') {
-        const token = Buffer.from(`${site.username}:${site.apiKey}`).toString('base64');
+        const token = Buffer.from(`${site.username}:${site.apiKey}`).toString(
+          'base64'
+        );
         headers.Authorization = `Basic ${token}`;
       } else if (engine.credentialSchema === 'userid+apikey') {
         probeUrl += `&user_id=${encodeURIComponent(site.username)}&api_key=${encodeURIComponent(site.apiKey)}`;
@@ -117,7 +134,11 @@ const probeTestConnection = async (
       // not JSON — keep raw text for XML engines
     }
     if (!engine.probeMatches(body)) {
-      return { ok: false, status: res.status, error: 'response does not match engine shape' };
+      return {
+        ok: false,
+        status: res.status,
+        error: 'response does not match engine shape'
+      };
     }
     return { ok: true, status: res.status };
   } catch (err) {
@@ -196,10 +217,15 @@ export const registerBooruSiteRoutes = (app: FastifyInstance) => {
       return { error: `Unknown engine: ${parsed.data.engine}` };
     }
     const baseUrl = parsed.data.baseUrl.replace(/\/+$/, '');
-    const existing = await booruSitesRepo.findBooruSiteByBaseUrl(baseUrl, userId);
+    const existing = await booruSitesRepo.findBooruSiteByBaseUrl(
+      baseUrl,
+      userId
+    );
     if (existing) {
       reply.code(409);
-      return { error: 'A site with this base URL already exists for this account' };
+      return {
+        error: 'A site with this base URL already exists for this account'
+      };
     }
     const capDefaults = engine.defaultCapabilities;
     const site = await booruSitesRepo.insertBooruSite(
@@ -215,77 +241,98 @@ export const registerBooruSiteRoutes = (app: FastifyInstance) => {
         capFavorites: parsed.data.capFavorites ?? capDefaults.favorites,
         capTags: parsed.data.capTags ?? capDefaults.tags,
         capSourceMatch: parsed.data.capSourceMatch ?? capDefaults.sourceMatch,
-        capSearch: parsed.data.capSearch ?? capDefaults.search
+        capSearch: parsed.data.capSearch ?? capDefaults.search,
+        siteAutoSyncMidnight: parsed.data.siteAutoSyncMidnight ?? false,
+        siteReverseSyncEnabled: parsed.data.siteReverseSyncEnabled ?? false,
+        siteAutoFavEnabled: parsed.data.siteAutoFavEnabled ?? false
       },
       userId
     );
     return { site: toPublic(site) };
   });
 
-  app.put<{ Params: { id: string } }>('/booru-sites/:id', async (request, reply) => {
-    const userId = request.currentUser!.id;
-    const parsed = updateSchema.safeParse(request.body ?? {});
-    if (!parsed.success) {
-      reply.code(400);
-      return { error: 'Invalid payload', issues: parsed.error.issues };
+  app.put<{ Params: { id: string } }>(
+    '/booru-sites/:id',
+    async (request, reply) => {
+      const userId = request.currentUser!.id;
+      const parsed = updateSchema.safeParse(request.body ?? {});
+      if (!parsed.success) {
+        reply.code(400);
+        return { error: 'Invalid payload', issues: parsed.error.issues };
+      }
+      const existing = await booruSitesRepo.getBooruSite(
+        request.params.id,
+        userId
+      );
+      if (!existing) {
+        reply.code(404);
+        return { error: 'Site not found' };
+      }
+      const updates = { ...parsed.data };
+      if (existing.isPreset) {
+        // Lock engine + base_url for preset rows so that historical favorite_items
+        // rows keep referring to the same canonical site (see AGENTS.md §11).
+        delete updates.engine;
+        delete updates.baseUrl;
+      } else if (updates.baseUrl) {
+        updates.baseUrl = updates.baseUrl.replace(/\/+$/, '');
+      }
+      if (updates.username !== undefined) {
+        updates.username = trimOrUndefined(updates.username);
+      }
+      if (updates.apiKey !== undefined) {
+        updates.apiKey = trimOrUndefined(updates.apiKey);
+      }
+      const site = await booruSitesRepo.updateBooruSite(
+        request.params.id,
+        updates,
+        userId
+      );
+      if (!site) {
+        reply.code(404);
+        return { error: 'Site not found' };
+      }
+      return { site: toPublic(site) };
     }
-    const existing = await booruSitesRepo.getBooruSite(request.params.id, userId);
-    if (!existing) {
-      reply.code(404);
-      return { error: 'Site not found' };
-    }
-    const updates = { ...parsed.data };
-    if (existing.isPreset) {
-      // Lock engine + base_url for preset rows so that historical favorite_items
-      // rows keep referring to the same canonical site (see AGENTS.md §11).
-      delete updates.engine;
-      delete updates.baseUrl;
-    } else if (updates.baseUrl) {
-      updates.baseUrl = updates.baseUrl.replace(/\/+$/, '');
-    }
-    if (updates.username !== undefined) {
-      updates.username = trimOrUndefined(updates.username);
-    }
-    if (updates.apiKey !== undefined) {
-      updates.apiKey = trimOrUndefined(updates.apiKey);
-    }
-    const site = await booruSitesRepo.updateBooruSite(request.params.id, updates, userId);
-    if (!site) {
-      reply.code(404);
-      return { error: 'Site not found' };
-    }
-    return { site: toPublic(site) };
-  });
+  );
 
-  app.delete<{ Params: { id: string } }>('/booru-sites/:id', async (request, reply) => {
-    const userId = request.currentUser!.id;
-    const existing = await booruSitesRepo.getBooruSite(request.params.id, userId);
-    if (!existing) {
-      reply.code(404);
-      return { error: 'Site not found' };
+  app.delete<{ Params: { id: string } }>(
+    '/booru-sites/:id',
+    async (request, reply) => {
+      const userId = request.currentUser!.id;
+      const existing = await booruSitesRepo.getBooruSite(
+        request.params.id,
+        userId
+      );
+      if (!existing) {
+        reply.code(404);
+        return { error: 'Site not found' };
+      }
+      const removed = await booruSitesRepo.deleteBooruSite(
+        request.params.id,
+        userId
+      );
+      if (!removed) {
+        reply.code(409);
+        return { error: 'Site could not be deleted' };
+      }
+      return { ok: true };
     }
-    if (existing.isPreset) {
-      reply.code(400);
-      return { error: 'Preset sites cannot be deleted. Disable the site instead.' };
-    }
-    const removed = await booruSitesRepo.deleteBooruSite(request.params.id, userId);
-    if (!removed) {
-      reply.code(409);
-      return { error: 'Site could not be deleted' };
-    }
-    return { ok: true };
-  });
+  );
 
-  app.post<{ Params: { id: string } }>('/booru-sites/:id/test', async (request, reply) => {
-    const userId = request.currentUser!.id;
-    const site = await booruSitesRepo.getBooruSite(request.params.id, userId);
-    if (!site) {
-      reply.code(404);
-      return { error: 'Site not found' };
+  app.post<{ Params: { id: string } }>(
+    '/booru-sites/:id/test',
+    async (request, reply) => {
+      const userId = request.currentUser!.id;
+      const site = await booruSitesRepo.getBooruSite(request.params.id, userId);
+      if (!site) {
+        reply.code(404);
+        return { error: 'Site not found' };
+      }
+      const result = await probeTestConnection(site);
+      return result;
     }
-    const result = await probeTestConnection(site);
-    return result;
-  });
+  );
 
   app.post('/booru-sites/reorder', async (request, reply) => {
     const parsed = reorderSchema.safeParse(request.body ?? {});
@@ -293,7 +340,10 @@ export const registerBooruSiteRoutes = (app: FastifyInstance) => {
       reply.code(400);
       return { error: 'Invalid payload', issues: parsed.error.issues };
     }
-    await booruSitesRepo.reorderBooruSites(parsed.data.orderedIds, request.currentUser!.id);
+    await booruSitesRepo.reorderBooruSites(
+      parsed.data.orderedIds,
+      request.currentUser!.id
+    );
     const sites = await booruSitesRepo.listBooruSites(request.currentUser!.id);
     return { sites: sites.map(toPublic) };
   });

--- a/backend/src/routes/favorites.ts
+++ b/backend/src/routes/favorites.ts
@@ -11,9 +11,6 @@ const syncSchema = z.object({
 });
 
 const settingsSchema = z.object({
-  reverseSyncEnabled: z.boolean().optional(),
-  autoSyncMidnight: z.boolean().optional(),
-  autoFavEnabled: z.boolean().optional(),
   favoritesRootId: z.string().nullable().optional()
 });
 
@@ -29,8 +26,14 @@ export const registerFavoritesRoutes = (app: FastifyInstance) => {
       reply.code(400);
       return { error: 'Invalid payload', issues: parsed.error.issues };
     }
-    if (parsed.data.favoritesRootId !== undefined && parsed.data.favoritesRootId !== null) {
-      const folder = await foldersRepo.findFolderById(parsed.data.favoritesRootId, userId);
+    if (
+      parsed.data.favoritesRootId !== undefined &&
+      parsed.data.favoritesRootId !== null
+    ) {
+      const folder = await foldersRepo.findFolderById(
+        parsed.data.favoritesRootId,
+        userId
+      );
       if (!folder) {
         reply.code(404);
         return { error: 'Folder not found' };
@@ -58,12 +61,15 @@ export const registerFavoritesRoutes = (app: FastifyInstance) => {
     // providers can be either a legacy preset key ('E621', 'DANBOORU', ...) or a
     // user_booru_sites.id UUID. The sync service resolves either form back to a
     // BooruSiteRecord, so we just pass strings through here without filtering.
-    const providers = parsed.data.providers?.map((value) => value.trim()).filter(Boolean);
+    const providers = parsed.data.providers
+      ?.map((value) => value.trim())
+      .filter(Boolean);
     if (parsed.data.providers && (!providers || providers.length === 0)) {
       reply.code(400);
       return { error: 'No valid providers provided.' };
     }
-    const { assertFavoritesSyncReady, startFavoritesSync } = await import('../services/favorites.js');
+    const { assertFavoritesSyncReady, startFavoritesSync } =
+      await import('../services/favorites.js');
     try {
       await assertFavoritesSyncReady(userId);
     } catch (error) {
@@ -71,12 +77,18 @@ export const registerFavoritesRoutes = (app: FastifyInstance) => {
         reply.code(409);
         return { error: error.message };
       }
-      if (error instanceof Error && /favorites root not configured/i.test(error.message)) {
+      if (
+        error instanceof Error &&
+        /favorites root not configured/i.test(error.message)
+      ) {
         reply.code(400);
         return { error: error.message };
       }
       throw error;
     }
-    return startFavoritesSync(userId, { providers, deleteMissing: parsed.data.deleteMissing });
+    return startFavoritesSync(userId, {
+      providers,
+      deleteMissing: parsed.data.deleteMissing
+    });
   });
 };

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -50,6 +50,15 @@ const favoriteSchema = z.object({
   favorite: z.boolean()
 });
 
+const fileContentRateLimit = {
+  max: 300,
+  timeWindow: '1 minute'
+};
+const fileDeleteRateLimit = {
+  max: 30,
+  timeWindow: '1 minute'
+};
+
 const removeLocalFile = async (filePath: string) => {
   const errors: string[] = [];
   const attemptDelete = async () => {
@@ -337,6 +346,11 @@ export const registerFilesRoutes = (app: FastifyInstance) => {
 
   app.get<{ Params: { id: string } }>(
     '/files/:id/content',
+    {
+      config: {
+        rateLimit: fileContentRateLimit
+      }
+    },
     async (request, reply) => {
       const userId = request.currentUser!.id;
       const file = await filesRepo.findFileById(request.params.id, userId);
@@ -481,6 +495,11 @@ export const registerFilesRoutes = (app: FastifyInstance) => {
 
   app.delete<{ Params: { id: string } }>(
     '/files/:id',
+    {
+      config: {
+        rateLimit: fileDeleteRateLimit
+      }
+    },
     async (request, reply) => {
       const userId = request.currentUser!.id;
       const file = await filesRepo.findFileById(request.params.id, userId);

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -5,6 +5,7 @@ import { FastifyInstance } from 'fastify';
 import { lookup as lookupMime } from 'mime-types';
 import { z } from 'zod';
 
+import { booruSitesRepo } from '../db/repos/booruSitesRepo';
 import { favoritesRepo } from '../db/repos/favoritesRepo';
 import { filesRepo } from '../db/repos/filesRepo';
 import { foldersRepo } from '../db/repos/foldersRepo';
@@ -136,31 +137,42 @@ export const registerFilesRoutes = (app: FastifyInstance) => {
       reply.code(400);
       return { error: 'Invalid query', issues: parsed.error.issues };
     }
-    const { folderId, sort, tags, seed, limit, offset, mediaType, favorites } = parsed.data;
+    const { folderId, sort, tags, seed, limit, offset, mediaType, favorites } =
+      parsed.data;
     const tagTerms = parseTagQuery(tags);
-    const { files, total } = await filesRepo.listFilesPage({
-      folderId,
-      tagTerms: tagTerms.length ? tagTerms : undefined,
-      mediaType,
-      favoritesOnly: favorites,
-      sort,
-      seed,
-      limit,
-      offset
-    }, userId);
-    const providerRunsByFile = await filesRepo.listProviderRunsByFileIds(files.map((file) => file.id));
+    const { files, total } = await filesRepo.listFilesPage(
+      {
+        folderId,
+        tagTerms: tagTerms.length ? tagTerms : undefined,
+        mediaType,
+        favoritesOnly: favorites,
+        sort,
+        seed,
+        limit,
+        offset
+      },
+      userId
+    );
+    const providerRunsByFile = await filesRepo.listProviderRunsByFileIds(
+      files.map((file) => file.id)
+    );
     const results = files.map((file) => {
       const runs = providerRunsByFile[file.id] ?? [];
-      const providerSummary = ['SAUCENAO', 'FLUFFLE'].reduce((acc, provider) => {
-        const latest = runs.find((run) => run.provider === provider);
-        if (latest) {
-          acc[provider] = latest;
-        }
-        return acc;
-      }, {} as Record<string, typeof runs[number]>);
+      const providerSummary = ['SAUCENAO', 'FLUFFLE'].reduce(
+        (acc, provider) => {
+          const latest = runs.find((run) => run.provider === provider);
+          if (latest) {
+            acc[provider] = latest;
+          }
+          return acc;
+        },
+        {} as Record<string, (typeof runs)[number]>
+      );
       return {
         ...file,
-        thumbUrl: file.thumbPath ? `/thumbnails/${path.basename(file.thumbPath)}` : null,
+        thumbUrl: file.thumbPath
+          ? `/thumbnails/${path.basename(file.thumbPath)}`
+          : null,
         providers: providerSummary
       };
     });
@@ -173,282 +185,378 @@ export const registerFilesRoutes = (app: FastifyInstance) => {
       reply.code(400);
       return { error: 'Invalid payload', issues: parsed.error.issues };
     }
-    const result = await filesRepo.saveManualOrder(parsed.data.order, request.currentUser!.id);
+    const result = await filesRepo.saveManualOrder(
+      parsed.data.order,
+      request.currentUser!.id
+    );
     return { status: 'ok', saved: result.saved };
   });
 
-  app.get<{ Params: { id: string } }>('/files/:id/tags', async (request, reply) => {
-    const file = await filesRepo.findFileById(request.params.id, request.currentUser!.id);
-    if (!file) {
-      reply.code(404);
-      return { error: 'File not found' };
+  app.get<{ Params: { id: string } }>(
+    '/files/:id/tags',
+    async (request, reply) => {
+      const file = await filesRepo.findFileById(
+        request.params.id,
+        request.currentUser!.id
+      );
+      if (!file) {
+        reply.code(404);
+        return { error: 'File not found' };
+      }
+      const tags = await filesRepo.listTagsForFile(file.id);
+      return { tags };
     }
-    const tags = await filesRepo.listTagsForFile(file.id);
-    return { tags };
-  });
+  );
 
-  app.delete<{ Params: { id: string } }>('/files/:id/tags', async (request, reply) => {
-    const file = await filesRepo.findFileById(request.params.id, request.currentUser!.id);
-    if (!file) {
-      reply.code(404);
-      return { error: 'File not found' };
+  app.delete<{ Params: { id: string } }>(
+    '/files/:id/tags',
+    async (request, reply) => {
+      const file = await filesRepo.findFileById(
+        request.params.id,
+        request.currentUser!.id
+      );
+      if (!file) {
+        reply.code(404);
+        return { error: 'File not found' };
+      }
+      const removed = await filesRepo.clearTagsForFile(file.id);
+      return { status: 'ok', removed };
     }
-    const removed = await filesRepo.clearTagsForFile(file.id);
-    return { status: 'ok', removed };
-  });
+  );
 
-  app.post<{ Params: { id: string } }>('/files/:id/tags/refresh', async (request, reply) => {
-    const file = await filesRepo.findFileById(request.params.id, request.currentUser!.id);
-    if (!file) {
-      reply.code(404);
-      return { error: 'File not found' };
+  app.post<{ Params: { id: string } }>(
+    '/files/:id/tags/refresh',
+    async (request, reply) => {
+      const file = await filesRepo.findFileById(
+        request.params.id,
+        request.currentUser!.id
+      );
+      if (!file) {
+        reply.code(404);
+        return { error: 'File not found' };
+      }
+      const { refreshTagsForFile } = await import('../services/tagging.js');
+      await refreshTagsForFile(file);
+      const tags = await filesRepo.listTagsForFile(file.id);
+      return { tags };
     }
-    const { refreshTagsForFile } = await import('../services/tagging.js');
-    await refreshTagsForFile(file);
-    const tags = await filesRepo.listTagsForFile(file.id);
-    return { tags };
-  });
+  );
 
-  app.post<{ Params: { id: string } }>('/files/:id/matches/remove', async (request, reply) => {
-    const file = await filesRepo.findFileById(request.params.id, request.currentUser!.id);
-    if (!file) {
-      reply.code(404);
-      return { error: 'File not found' };
+  app.post<{ Params: { id: string } }>(
+    '/files/:id/matches/remove',
+    async (request, reply) => {
+      const file = await filesRepo.findFileById(
+        request.params.id,
+        request.currentUser!.id
+      );
+      if (!file) {
+        reply.code(404);
+        return { error: 'File not found' };
+      }
+      const parsed = matchRemoveSchema.safeParse(request.body);
+      if (!parsed.success) {
+        reply.code(400);
+        return { error: 'Invalid payload', issues: parsed.error.issues };
+      }
+      const sourceUrl = parsed.data.sourceUrl.trim();
+      await filesRepo.removeTagsBySourceUrl(file.id, sourceUrl);
+      await filesRepo.removeProviderRunResultForFile(file.id, sourceUrl);
+      const { refreshTagsForFile } = await import('../services/tagging.js');
+      await refreshTagsForFile(file);
+      const tags = await filesRepo.listTagsForFile(file.id);
+      const providers = await filesRepo.listProviderRuns(file.id);
+      return { status: 'ok', tags, providers };
     }
-    const parsed = matchRemoveSchema.safeParse(request.body);
-    if (!parsed.success) {
-      reply.code(400);
-      return { error: 'Invalid payload', issues: parsed.error.issues };
-    }
-    const sourceUrl = parsed.data.sourceUrl.trim();
-    await filesRepo.removeTagsBySourceUrl(file.id, sourceUrl);
-    await filesRepo.removeProviderRunResultForFile(file.id, sourceUrl);
-    const { refreshTagsForFile } = await import('../services/tagging.js');
-    await refreshTagsForFile(file);
-    const tags = await filesRepo.listTagsForFile(file.id);
-    const providers = await filesRepo.listProviderRuns(file.id);
-    return { status: 'ok', tags, providers };
-  });
+  );
 
-  app.post<{ Params: { id: string } }>('/files/:id/tags/manual', async (request, reply) => {
-    const file = await filesRepo.findFileById(request.params.id, request.currentUser!.id);
-    if (!file) {
-      reply.code(404);
-      return { error: 'File not found' };
+  app.post<{ Params: { id: string } }>(
+    '/files/:id/tags/manual',
+    async (request, reply) => {
+      const file = await filesRepo.findFileById(
+        request.params.id,
+        request.currentUser!.id
+      );
+      if (!file) {
+        reply.code(404);
+        return { error: 'File not found' };
+      }
+      const parsed = manualTagSchema.safeParse(request.body);
+      if (!parsed.success) {
+        reply.code(400);
+        return { error: 'Invalid payload', issues: parsed.error.issues };
+      }
+      const tag = parsed.data.tag.trim().replace(/\s+/g, '_').toLowerCase();
+      const category = (parsed.data.category ?? 'general').trim().toLowerCase();
+      await filesRepo.addManualTag(file.id, tag, category);
+      return { status: 'ok' };
     }
-    const parsed = manualTagSchema.safeParse(request.body);
-    if (!parsed.success) {
-      reply.code(400);
-      return { error: 'Invalid payload', issues: parsed.error.issues };
-    }
-    const tag = parsed.data.tag.trim().replace(/\s+/g, '_').toLowerCase();
-    const category = (parsed.data.category ?? 'general').trim().toLowerCase();
-    await filesRepo.addManualTag(file.id, tag, category);
-    return { status: 'ok' };
-  });
+  );
 
-  app.delete<{ Params: { id: string } }>('/files/:id/tags/manual', async (request, reply) => {
-    const file = await filesRepo.findFileById(request.params.id, request.currentUser!.id);
-    if (!file) {
-      reply.code(404);
-      return { error: 'File not found' };
+  app.delete<{ Params: { id: string } }>(
+    '/files/:id/tags/manual',
+    async (request, reply) => {
+      const file = await filesRepo.findFileById(
+        request.params.id,
+        request.currentUser!.id
+      );
+      if (!file) {
+        reply.code(404);
+        return { error: 'File not found' };
+      }
+      const parsed = manualTagSchema.safeParse(request.body);
+      if (!parsed.success) {
+        reply.code(400);
+        return { error: 'Invalid payload', issues: parsed.error.issues };
+      }
+      const tag = parsed.data.tag.trim().replace(/\s+/g, '_').toLowerCase();
+      await filesRepo.removeManualTag(file.id, tag);
+      return { status: 'ok' };
     }
-    const parsed = manualTagSchema.safeParse(request.body);
-    if (!parsed.success) {
-      reply.code(400);
-      return { error: 'Invalid payload', issues: parsed.error.issues };
-    }
-    const tag = parsed.data.tag.trim().replace(/\s+/g, '_').toLowerCase();
-    await filesRepo.removeManualTag(file.id, tag);
-    return { status: 'ok' };
-  });
+  );
 
-  app.put<{ Params: { id: string } }>('/files/:id/favorite', async (request, reply) => {
-    const parsed = favoriteSchema.safeParse(request.body ?? {});
-    if (!parsed.success) {
-      reply.code(400);
-      return { error: 'Invalid payload', issues: parsed.error.issues };
+  app.put<{ Params: { id: string } }>(
+    '/files/:id/favorite',
+    async (request, reply) => {
+      const parsed = favoriteSchema.safeParse(request.body ?? {});
+      if (!parsed.success) {
+        reply.code(400);
+        return { error: 'Invalid payload', issues: parsed.error.issues };
+      }
+      const file = await filesRepo.findFileById(
+        request.params.id,
+        request.currentUser!.id
+      );
+      if (!file) {
+        reply.code(404);
+        return { error: 'File not found' };
+      }
+      await filesRepo.setFileFavorite(file.id, parsed.data.favorite);
+      return { status: 'ok', isFavorite: parsed.data.favorite };
     }
-    const file = await filesRepo.findFileById(request.params.id, request.currentUser!.id);
-    if (!file) {
-      reply.code(404);
-      return { error: 'File not found' };
-    }
-    await filesRepo.setFileFavorite(file.id, parsed.data.favorite);
-    return { status: 'ok', isFavorite: parsed.data.favorite };
-  });
+  );
 
-  app.get<{ Params: { id: string } }>('/files/:id/content', async (request, reply) => {
-    const userId = request.currentUser!.id;
-    const file = await filesRepo.findFileById(request.params.id, userId);
-    if (!file) {
-      reply.code(404);
-      return { error: 'File not found' };
-    }
-    const folder = await foldersRepo.findFolderById(file.folderId, userId);
-    if (!folder) {
-      reply.code(404);
-      return { error: 'Folder not found' };
-    }
-    let safeLocalPath: string | null = null;
-    if (folder.type === 'LOCAL') {
+  app.get<{ Params: { id: string } }>(
+    '/files/:id/content',
+    async (request, reply) => {
+      const userId = request.currentUser!.id;
+      const file = await filesRepo.findFileById(request.params.id, userId);
+      if (!file) {
+        reply.code(404);
+        return { error: 'File not found' };
+      }
+      const folder = await foldersRepo.findFolderById(file.folderId, userId);
+      if (!folder) {
+        reply.code(404);
+        return { error: 'Folder not found' };
+      }
+      let safeLocalPath: string | null = null;
+      if (folder.type === 'LOCAL') {
+        try {
+          safeLocalPath = resolveSafeLocalPath(folder.path, file.path);
+        } catch (err) {
+          reply.code(400);
+          return { error: (err as Error).message };
+        }
+      }
+
+      const query = (request.query ?? {}) as { download?: string };
+
       try {
-        safeLocalPath = resolveSafeLocalPath(folder.path, file.path);
+        const localPath = safeLocalPath ?? file.path;
+        const stat = await fs.promises.stat(localPath);
+        const fileSize = stat.size;
+        const range = request.headers.range;
+        const contentType = lookupMime(file.path) || 'application/octet-stream';
+        reply.type(contentType);
+        reply.header('X-Content-Type-Options', 'nosniff');
+        if (query.download === '1') {
+          reply.header(
+            'Content-Disposition',
+            encodeDownloadFilename(file.path)
+          );
+        }
+        reply.header('Accept-Ranges', 'bytes');
+
+        if (range) {
+          const match = /^bytes=(\d*)-(\d*)$/.exec(range);
+          if (!match || (!match[1] && !match[2])) {
+            reply.code(416).header('Content-Range', `bytes */${fileSize}`);
+            return reply.send();
+          }
+
+          let start: number;
+          let end: number;
+          if (!match[1] && match[2]) {
+            const suffixLength = Number.parseInt(match[2], 10);
+            if (Number.isNaN(suffixLength)) {
+              reply.code(416).header('Content-Range', `bytes */${fileSize}`);
+              return reply.send();
+            }
+            start = Math.max(fileSize - suffixLength, 0);
+            end = fileSize - 1;
+          } else {
+            start = match[1] ? Number.parseInt(match[1], 10) : 0;
+            end = match[2] ? Number.parseInt(match[2], 10) : fileSize - 1;
+          }
+
+          if (
+            Number.isNaN(start) ||
+            Number.isNaN(end) ||
+            start > end ||
+            start >= fileSize
+          ) {
+            reply.code(416).header('Content-Range', `bytes */${fileSize}`);
+            return reply.send();
+          }
+
+          if (end >= fileSize) end = fileSize - 1;
+          reply
+            .code(206)
+            .header('Content-Range', `bytes ${start}-${end}/${fileSize}`)
+            .header('Content-Length', end - start + 1);
+          const stream = fs.createReadStream(localPath, { start, end });
+          stream.on('error', (err) => {
+            if (!reply.sent) {
+              reply.code(500).send({ error: err.message });
+            }
+          });
+          return reply.send(stream);
+        }
+
+        reply.header('Content-Length', fileSize);
+        const stream = fs.createReadStream(localPath);
+        stream.on('error', (err) => {
+          reply.code(500).send({ error: err.message });
+        });
+        return reply.send(stream);
+      } catch (err) {
+        reply.code(500);
+        return { error: (err as Error).message };
+      }
+    }
+  );
+
+  app.get<{ Params: { id: string } }>(
+    '/files/:id/providers',
+    async (request, reply) => {
+      const file = await filesRepo.findFileById(
+        request.params.id,
+        request.currentUser!.id
+      );
+      if (!file) {
+        reply.code(404);
+        return { error: 'File not found' };
+      }
+      const runs = await filesRepo.listProviderRuns(file.id);
+      return { providers: runs };
+    }
+  );
+
+  app.post<{ Params: { id: string; provider: string } }>(
+    '/files/:id/providers/:provider',
+    async (request, reply) => {
+      const provider = request.params.provider.toUpperCase() as ProviderKind;
+      if (provider !== 'SAUCENAO' && provider !== 'FLUFFLE') {
+        reply.code(400);
+        return { error: 'Unsupported provider' };
+      }
+      const file = await filesRepo.findFileById(
+        request.params.id,
+        request.currentUser!.id
+      );
+      if (!file) {
+        reply.code(404);
+        return { error: 'File not found' };
+      }
+      const { executeProviderRun } = await import('../lib/providerRunner.js');
+      const { providerRun, error, rateLimited, retryAt } =
+        await executeProviderRun(file, provider);
+      if (error) {
+        reply.code(rateLimited ? 429 : 500);
+        return { error, retryAt };
+      }
+      return { providerRun };
+    }
+  );
+
+  app.delete<{ Params: { id: string } }>(
+    '/files/:id',
+    async (request, reply) => {
+      const userId = request.currentUser!.id;
+      const file = await filesRepo.findFileById(request.params.id, userId);
+      if (!file) {
+        reply.code(404);
+        return { error: 'File not found' };
+      }
+      const folder = await foldersRepo.findFolderById(file.folderId, userId);
+      if (!folder) {
+        reply.code(404);
+        return { error: 'Folder not found' };
+      }
+      const errors: string[] = [];
+      const favoriteItems = await favoritesRepo.listFavoriteItemsByPath(
+        file.path,
+        userId
+      );
+      let deletePath: string;
+      try {
+        deletePath = resolveSafeLocalPath(folder.path, file.path);
       } catch (err) {
         reply.code(400);
         return { error: (err as Error).message };
       }
-    }
-
-    const query = (request.query ?? {}) as { download?: string };
-
-    try {
-      const localPath = safeLocalPath ?? file.path;
-      const stat = await fs.promises.stat(localPath);
-      const fileSize = stat.size;
-      const range = request.headers.range;
-      const contentType = lookupMime(file.path) || 'application/octet-stream';
-      reply.type(contentType);
-      reply.header('X-Content-Type-Options', 'nosniff');
-      if (query.download === '1') {
-        reply.header('Content-Disposition', encodeDownloadFilename(file.path));
+      const deleteResult = await removeLocalFile(deletePath);
+      errors.push(...deleteResult.errors);
+      if (!deleteResult.deleted) {
+        console.warn(
+          `[files] delete failed for ${file.path}: ${errors.join('; ')}`
+        );
+        reply.code(500);
+        return { error: 'Failed to delete file from disk', errors };
       }
-      reply.header('Accept-Ranges', 'bytes');
-
-      if (range) {
-        const match = /^bytes=(\d*)-(\d*)$/.exec(range);
-        if (!match || (!match[1] && !match[2])) {
-          reply.code(416).header('Content-Range', `bytes */${fileSize}`);
-          return reply.send();
-        }
-
-        let start: number;
-        let end: number;
-        if (!match[1] && match[2]) {
-          const suffixLength = Number.parseInt(match[2], 10);
-          if (Number.isNaN(suffixLength)) {
-            reply.code(416).header('Content-Range', `bytes */${fileSize}`);
-            return reply.send();
+      if (favoriteItems.length > 0) {
+        for (const favoriteItem of favoriteItems) {
+          const targetSite =
+            (await booruSitesRepo.getBooruSite(
+              favoriteItem.provider,
+              userId
+            )) ??
+            (await booruSitesRepo.findBooruSiteByPresetKey(
+              favoriteItem.provider,
+              userId
+            ));
+          if (!targetSite?.siteReverseSyncEnabled) continue;
+          try {
+            const { removeFavorite } = await import('../services/favorites.js');
+            await removeFavorite(
+              userId,
+              favoriteItem.provider,
+              favoriteItem.remoteId
+            );
+          } catch (err) {
+            errors.push(
+              `Unfavorite ${favoriteItem.provider}: ${(err as Error).message}`
+            );
           }
-          start = Math.max(fileSize - suffixLength, 0);
-          end = fileSize - 1;
-        } else {
-          start = match[1] ? Number.parseInt(match[1], 10) : 0;
-          end = match[2] ? Number.parseInt(match[2], 10) : fileSize - 1;
         }
-
-        if (Number.isNaN(start) || Number.isNaN(end) || start > end || start >= fileSize) {
-          reply.code(416).header('Content-Range', `bytes */${fileSize}`);
-          return reply.send();
-        }
-
-        if (end >= fileSize) end = fileSize - 1;
-        reply
-          .code(206)
-          .header('Content-Range', `bytes ${start}-${end}/${fileSize}`)
-          .header('Content-Length', end - start + 1);
-        const stream = fs.createReadStream(localPath, { start, end });
-        stream.on('error', (err) => {
-          if (!reply.sent) {
-            reply.code(500).send({ error: err.message });
-          }
-        });
-        return reply.send(stream);
       }
-
-      reply.header('Content-Length', fileSize);
-      const stream = fs.createReadStream(localPath);
-      stream.on('error', (err) => {
-        reply.code(500).send({ error: err.message });
-      });
-      return reply.send(stream);
-    } catch (err) {
-      reply.code(500);
-      return { error: (err as Error).message };
-    }
-  });
-
-  app.get<{ Params: { id: string } }>('/files/:id/providers', async (request, reply) => {
-    const file = await filesRepo.findFileById(request.params.id, request.currentUser!.id);
-    if (!file) {
-      reply.code(404);
-      return { error: 'File not found' };
-    }
-    const runs = await filesRepo.listProviderRuns(file.id);
-    return { providers: runs };
-  });
-
-  app.post<{ Params: { id: string; provider: string } }>('/files/:id/providers/:provider', async (request, reply) => {
-    const provider = request.params.provider.toUpperCase() as ProviderKind;
-    if (provider !== 'SAUCENAO' && provider !== 'FLUFFLE') {
-      reply.code(400);
-      return { error: 'Unsupported provider' };
-    }
-    const file = await filesRepo.findFileById(request.params.id, request.currentUser!.id);
-    if (!file) {
-      reply.code(404);
-      return { error: 'File not found' };
-    }
-    const { executeProviderRun } = await import('../lib/providerRunner.js');
-    const { providerRun, error, rateLimited, retryAt } = await executeProviderRun(file, provider);
-    if (error) {
-      reply.code(rateLimited ? 429 : 500);
-      return { error, retryAt };
-    }
-    return { providerRun };
-  });
-
-  app.delete<{ Params: { id: string } }>('/files/:id', async (request, reply) => {
-    const userId = request.currentUser!.id;
-    const file = await filesRepo.findFileById(request.params.id, userId);
-    if (!file) {
-      reply.code(404);
-      return { error: 'File not found' };
-    }
-    const folder = await foldersRepo.findFolderById(file.folderId, userId);
-    if (!folder) {
-      reply.code(404);
-      return { error: 'Folder not found' };
-    }
-    const errors: string[] = [];
-    const favoritesSettings = await favoritesRepo.getFavoritesSettings(userId);
-    const favoriteItems = await favoritesRepo.listFavoriteItemsByPath(file.path, userId);
-    let deletePath: string;
-    try {
-      deletePath = resolveSafeLocalPath(folder.path, file.path);
-    } catch (err) {
-      reply.code(400);
-      return { error: (err as Error).message };
-    }
-    const deleteResult = await removeLocalFile(deletePath);
-    errors.push(...deleteResult.errors);
-    if (!deleteResult.deleted) {
-      console.warn(`[files] delete failed for ${file.path}: ${errors.join('; ')}`);
-      reply.code(500);
-      return { error: 'Failed to delete file from disk', errors };
-    }
-    if (favoritesSettings.reverseSyncEnabled && favoriteItems.length > 0) {
-      for (const favoriteItem of favoriteItems) {
+      if (file.thumbPath) {
         try {
-          const { removeFavorite } = await import('../services/favorites.js');
-          await removeFavorite(userId, favoriteItem.provider, favoriteItem.remoteId);
+          const safeThumbPath = resolveSafeAbsolutePath(file.thumbPath);
+          await fs.promises.unlink(safeThumbPath);
         } catch (err) {
-          errors.push(`Unfavorite ${favoriteItem.provider}: ${(err as Error).message}`);
+          errors.push(`Thumb delete: ${(err as Error).message}`);
         }
       }
-    }
-    if (file.thumbPath) {
-      try {
-        const safeThumbPath = resolveSafeAbsolutePath(file.thumbPath);
-        await fs.promises.unlink(safeThumbPath);
-      } catch (err) {
-        errors.push(`Thumb delete: ${(err as Error).message}`);
+      for (const favoriteItem of favoriteItems) {
+        await favoritesRepo.deleteFavoriteItem(
+          favoriteItem.provider,
+          favoriteItem.remoteId,
+          userId
+        );
       }
+      await filesRepo.deleteFile(file.id);
+      return { status: 'deleted', errors: errors.length ? errors : undefined };
     }
-    for (const favoriteItem of favoriteItems) {
-      await favoritesRepo.deleteFavoriteItem(favoriteItem.provider, favoriteItem.remoteId, userId);
-    }
-    await filesRepo.deleteFile(file.id);
-    return { status: 'deleted', errors: errors.length ? errors : undefined };
-  });
+  );
 };

--- a/backend/src/services/credentials.ts
+++ b/backend/src/services/credentials.ts
@@ -1,5 +1,6 @@
 import { authRepo } from '../db/repos/authRepo';
 import { booruSitesRepo } from '../db/repos/booruSitesRepo';
+import { favoritesRepo } from '../db/repos/favoritesRepo';
 import type { CredentialProvider } from '../db/types';
 import { BOORU_PRESETS } from '../lib/booruEngines/presets';
 
@@ -13,17 +14,32 @@ export type ResolvedCredential = {
   updatedAt: string | null;
 };
 
-const BOORU_PRESET_PROVIDERS = new Set<CredentialProvider>(['E621', 'DANBOORU']);
+const BOORU_PRESET_PROVIDERS = new Set<CredentialProvider>([
+  'E621',
+  'DANBOORU'
+]);
 
-export const resolveCredential = async (provider: CredentialProvider, userId?: string): Promise<ResolvedCredential> => {
+export const resolveCredential = async (
+  provider: CredentialProvider,
+  userId?: string
+): Promise<ResolvedCredential> => {
   if (!userId) {
-    return { provider, username: null, apiKey: null, source: 'none', updatedAt: null };
+    return {
+      provider,
+      username: null,
+      apiKey: null,
+      source: 'none',
+      updatedAt: null
+    };
   }
   // E621/DANBOORU credentials now live on user_booru_sites preset rows. Read
   // from there first; fall back to provider_credentials for legacy installs
   // where the seed migration hasn't been run yet.
   if (BOORU_PRESET_PROVIDERS.has(provider)) {
-    const site = await booruSitesRepo.findBooruSiteByPresetKey(provider, userId);
+    const site = await booruSitesRepo.findBooruSiteByPresetKey(
+      provider,
+      userId
+    );
     if (site?.username?.trim() && site.apiKey?.trim()) {
       return {
         provider,
@@ -44,11 +60,22 @@ export const resolveCredential = async (provider: CredentialProvider, userId?: s
       updatedAt: stored.updatedAt
     };
   }
-  return { provider, username: null, apiKey: null, source: 'none', updatedAt: null };
+  return {
+    provider,
+    username: null,
+    apiKey: null,
+    source: 'none',
+    updatedAt: null
+  };
 };
 
-export const resolveCredentials = async (providers: CredentialProvider[], userId?: string) => {
-  const resolved = await Promise.all(providers.map((provider) => resolveCredential(provider, userId)));
+export const resolveCredentials = async (
+  providers: CredentialProvider[],
+  userId?: string
+) => {
+  const resolved = await Promise.all(
+    providers.map((provider) => resolveCredential(provider, userId))
+  );
   return resolved;
 };
 
@@ -69,12 +96,27 @@ export const upsertCredentialCompat = async (
     await authRepo.upsertCredential(provider, updates, userId);
     return;
   }
-  const existing = await booruSitesRepo.findBooruSiteByPresetKey(provider, userId);
-  const username = updates.username !== undefined ? updates.username.trim() || null : existing?.username ?? null;
-  const apiKey = updates.apiKey !== undefined ? updates.apiKey.trim() || null : existing?.apiKey ?? null;
+  const existing = await booruSitesRepo.findBooruSiteByPresetKey(
+    provider,
+    userId
+  );
+  const username =
+    updates.username !== undefined
+      ? updates.username.trim() || null
+      : (existing?.username ?? null);
+  const apiKey =
+    updates.apiKey !== undefined
+      ? updates.apiKey.trim() || null
+      : (existing?.apiKey ?? null);
   if (existing) {
-    await booruSitesRepo.updateBooruSite(existing.id, { username, apiKey }, userId);
+    await booruSitesRepo.updateBooruSite(
+      existing.id,
+      { username, apiKey },
+      userId
+    );
   } else {
+    const siteDefaults =
+      await favoritesRepo.getLegacyPerSiteFavoritesDefaults(userId);
     await booruSitesRepo.insertBooruSite(
       {
         name: preset.name,
@@ -88,7 +130,10 @@ export const upsertCredentialCompat = async (
         capFavorites: preset.defaultCapabilities.favorites,
         capTags: preset.defaultCapabilities.tags,
         capSourceMatch: preset.defaultCapabilities.sourceMatch,
-        capSearch: preset.defaultCapabilities.search
+        capSearch: preset.defaultCapabilities.search,
+        siteAutoSyncMidnight: siteDefaults.siteAutoSyncMidnight,
+        siteReverseSyncEnabled: siteDefaults.siteReverseSyncEnabled,
+        siteAutoFavEnabled: siteDefaults.siteAutoFavEnabled
       },
       userId
     );

--- a/backend/src/services/favorites.test.ts
+++ b/backend/src/services/favorites.test.ts
@@ -65,14 +65,48 @@ test('autoFavoriteFromSauce skips when file has no owner', async () => {
   }
 });
 
-test('autoFavoriteFromSauce skips when auto-fav setting is disabled', async () => {
+test('autoFavoriteFromSauce skips when matched site has auto-fav disabled', async () => {
   const app = await buildTestApp();
   try {
     const seeded = await seedUser({ username: 'autofav_disabled' });
-    const filePath = writeFixtureFile(seeded.libraryRoot, 'sample.png', Buffer.from('x'));
+    await booruSitesRepo.insertBooruSite(
+      {
+        name: 'e621',
+        engine: 'e621',
+        baseUrl: 'https://e621.net',
+        isPreset: true,
+        presetKey: 'E621',
+        enabled: true,
+        capFavorites: true,
+        capTags: true,
+        capSourceMatch: true,
+        capSearch: false,
+        siteAutoFavEnabled: false
+      },
+      seeded.user.id
+    );
+    const filePath = writeFixtureFile(
+      seeded.libraryRoot,
+      'sample.png',
+      Buffer.from('x')
+    );
     const folders = await foldersRepo.listFolders(seeded.user.id);
     const file = await registerFixtureFile(folders[0].id, filePath);
-    // Default: autoFavEnabled=false in favoritesRepo.
+    const run = await filesRepo.createProviderRun(file.id, 'SAUCENAO');
+    await filesRepo.updateProviderRun(run.id, {
+      status: 'COMPLETED',
+      score: 99,
+      sourceUrl: 'https://e621.net/posts/777',
+      results: [
+        {
+          sourceUrl: 'https://e621.net/posts/777',
+          score: 99,
+          sourceName: 'e621',
+          thumbUrl: null
+        }
+      ],
+      completedAt: new Date().toISOString()
+    });
     const result = await autoFavoriteFromSauce(file);
     assert.equal(result.status, 'skipped');
     if (result.status === 'skipped') assert.equal(result.reason, 'disabled');
@@ -85,13 +119,17 @@ test('autoFavoriteFromSauce skips when no provider run yields a supported-provid
   const app = await buildTestApp();
   try {
     const seeded = await seedUser({ username: 'autofav_no_match' });
-    await favoritesRepo.saveFavoritesSettings({ autoFavEnabled: true }, seeded.user.id);
-    const filePath = writeFixtureFile(seeded.libraryRoot, 'sample.png', Buffer.from('x'));
+    const filePath = writeFixtureFile(
+      seeded.libraryRoot,
+      'sample.png',
+      Buffer.from('x')
+    );
     const folders = await foldersRepo.listFolders(seeded.user.id);
     const file = await registerFixtureFile(folders[0].id, filePath);
     const result = await autoFavoriteFromSauce(file);
     assert.equal(result.status, 'skipped');
-    if (result.status === 'skipped') assert.equal(result.reason, 'no-supported-match');
+    if (result.status === 'skipped')
+      assert.equal(result.reason, 'no-supported-match');
   } finally {
     await app.close();
   }
@@ -101,7 +139,6 @@ test('autoFavoriteFromSauce skips and does NOT touch network when already marked
   const app = await buildTestApp();
   try {
     const seeded = await seedUser({ username: 'autofav_already' });
-    await favoritesRepo.saveFavoritesSettings({ autoFavEnabled: true }, seeded.user.id);
 
     // The URL matcher consults user_booru_sites rows now — seed the E621
     // preset so the e621.net source URL resolves to a known site. No
@@ -118,12 +155,17 @@ test('autoFavoriteFromSauce skips and does NOT touch network when already marked
         capFavorites: true,
         capTags: true,
         capSourceMatch: true,
-        capSearch: false
+        capSearch: false,
+        siteAutoFavEnabled: false
       },
       seeded.user.id
     );
 
-    const filePath = writeFixtureFile(seeded.libraryRoot, 'already.png', Buffer.from('x'));
+    const filePath = writeFixtureFile(
+      seeded.libraryRoot,
+      'already.png',
+      Buffer.from('x')
+    );
     const folders = await foldersRepo.listFolders(seeded.user.id);
     const file = await registerFixtureFile(folders[0].id, filePath);
 
@@ -133,7 +175,14 @@ test('autoFavoriteFromSauce skips and does NOT touch network when already marked
       status: 'COMPLETED',
       score: 99,
       sourceUrl: 'https://e621.net/posts/777',
-      results: [{ sourceUrl: 'https://e621.net/posts/777', score: 99, sourceName: 'e621', thumbUrl: null }],
+      results: [
+        {
+          sourceUrl: 'https://e621.net/posts/777',
+          score: 99,
+          sourceName: 'e621',
+          thumbUrl: null
+        }
+      ],
       completedAt: new Date().toISOString()
     });
 
@@ -155,7 +204,8 @@ test('autoFavoriteFromSauce skips and does NOT touch network when already marked
     // either hang or fail — already-marked must short-circuit before that.
     const result = await autoFavoriteFromSauce(file);
     assert.equal(result.status, 'skipped');
-    if (result.status === 'skipped') assert.equal(result.reason, 'already-marked');
+    if (result.status === 'skipped')
+      assert.equal(result.reason, 'already-marked');
   } finally {
     await app.close();
   }

--- a/backend/src/services/favorites.ts
+++ b/backend/src/services/favorites.ts
@@ -27,7 +27,8 @@ import { applyRemotePostTags } from './tagging';
 // favorite_items.provider for a given site is the preset key when the site is
 // one of the seeded presets (so legacy 'E621'/'DANBOORU' rows continue to
 // match) and the site UUID for fully-custom sites.
-const favoriteKeyForSite = (site: BooruSiteRecord): string => site.presetKey ?? site.id;
+const favoriteKeyForSite = (site: BooruSiteRecord): string =>
+  site.presetKey ?? site.id;
 
 const resolveSiteFromProvider = async (
   userId: string,
@@ -40,7 +41,9 @@ const resolveSiteFromProvider = async (
   return booruSitesRepo.findBooruSiteByPresetKey(provider, userId);
 };
 
-const loadFavoriteSyncableSites = async (userId: string): Promise<BooruSiteRecord[]> => {
+const loadFavoriteSyncableSites = async (
+  userId: string
+): Promise<BooruSiteRecord[]> => {
   const sites = await booruSitesRepo.listBooruSites(userId);
   return sites.filter(
     (site) => site.enabled && site.capFavorites && site.username && site.apiKey
@@ -68,7 +71,13 @@ type SyncOptions = {
   deleteMissing?: boolean;
 };
 
-type ProviderStage = 'idle' | 'fetching' | 'downloading' | 'deleting' | 'done' | 'error';
+type ProviderStage =
+  | 'idle'
+  | 'fetching'
+  | 'downloading'
+  | 'deleting'
+  | 'done'
+  | 'error';
 
 type FavoriteSyncProgress = {
   provider: FavoriteProvider;
@@ -116,11 +125,13 @@ const debugLog = (...args: string[]) => {
   console.log('[favorites]', ...args);
 };
 
-
 const ensureFavoritesRoot = async (userId: string) => {
   const settings = await favoritesRepo.getFavoritesSettings(userId);
   if (settings.favoritesRootId) {
-    const folder = await foldersRepo.findFolderById(settings.favoritesRootId, userId);
+    const folder = await foldersRepo.findFolderById(
+      settings.favoritesRootId,
+      userId
+    );
     if (folder?.type === 'LOCAL') {
       await ensureDirectoryWritable(folder.path, 'Favorites sync');
       return folder.path;
@@ -134,7 +145,9 @@ const ensureFavoritesRoot = async (userId: string) => {
   const folders = await foldersRepo.listFolders(userId);
   const localFolder = folders.find((folder) => folder.type === 'LOCAL');
   if (!localFolder?.path) {
-    throw new Error('Favorites root not configured. Add a local folder for this account.');
+    throw new Error(
+      'Favorites root not configured. Add a local folder for this account.'
+    );
   }
   await ensureDirectoryWritable(localFolder.path, 'Favorites sync');
   return localFolder.path;
@@ -150,13 +163,22 @@ const ensureFavoritesFolder = async (root: string, userId: string) => {
   return foldersRepo.addFolder(root, userId);
 };
 
-const scanAndUpsertFavorite = async (folderId: string, filePath: string): Promise<FileRecord | null> => {
-  const scanned = await scanLocalFile(filePath, { thumbnailsDir: config.storage.thumbnailsDir });
+const scanAndUpsertFavorite = async (
+  folderId: string,
+  filePath: string
+): Promise<FileRecord | null> => {
+  const scanned = await scanLocalFile(filePath, {
+    thumbnailsDir: config.storage.thumbnailsDir
+  });
   if (!scanned) return null;
   return filesRepo.upsertFile(folderId, scanned);
 };
 
-const findOrScanFavoriteRecord = async (folderId: string, filePath: string, userId: string): Promise<FileRecord | null> => {
+const findOrScanFavoriteRecord = async (
+  folderId: string,
+  filePath: string,
+  userId: string
+): Promise<FileRecord | null> => {
   const existing = await filesRepo.findFileByPath(filePath, userId);
   if (existing) return existing;
   return scanAndUpsertFavorite(folderId, filePath);
@@ -168,17 +190,26 @@ const favoriteSourceName = (provider: FavoriteProvider): string => {
   return provider;
 };
 
-const providerThreshold = (provider: 'SAUCENAO' | 'FLUFFLE') => (provider === 'FLUFFLE' ? 95 : 90);
+const providerThreshold = (provider: 'SAUCENAO' | 'FLUFFLE') =>
+  provider === 'FLUFFLE' ? 95 : 90;
 
 const hasHighConfidenceSource = (file: FileRecord, sourceUrl: string) => {
   return filesRepo.listProviderRuns(file.id).then((runs) =>
     runs.some((run) => {
       const threshold = providerThreshold(run.provider);
-      const results = Array.isArray(run.results) && run.results.length
-        ? run.results
-        : run.sourceUrl
-          ? [{ sourceUrl: run.sourceUrl, score: run.score, sourceName: null, thumbUrl: run.thumbUrl }]
-          : [];
+      const results =
+        Array.isArray(run.results) && run.results.length
+          ? run.results
+          : run.sourceUrl
+            ? [
+                {
+                  sourceUrl: run.sourceUrl,
+                  score: run.score,
+                  sourceName: null,
+                  thumbUrl: run.thumbUrl
+                }
+              ]
+            : [];
       return results.some(
         (result) =>
           result.sourceUrl === sourceUrl &&
@@ -190,7 +221,10 @@ const hasHighConfidenceSource = (file: FileRecord, sourceUrl: string) => {
   );
 };
 
-const ensureFavoriteSourceRun = async (file: FileRecord, item: FavoriteRemote) => {
+const ensureFavoriteSourceRun = async (
+  file: FileRecord,
+  item: FavoriteRemote
+) => {
   if (!(await hasHighConfidenceSource(file, item.sourceUrl))) {
     const run = await filesRepo.createProviderRun(file.id, 'SAUCENAO');
     await filesRepo.updateProviderRun(run.id, {
@@ -213,12 +247,18 @@ const ensureFavoriteSourceRun = async (file: FileRecord, item: FavoriteRemote) =
   }
 };
 
-const hasProviderSourceTags = async (fileId: string, provider: FavoriteProvider) => {
+const hasProviderSourceTags = async (
+  fileId: string,
+  provider: FavoriteProvider
+) => {
   const tags = await filesRepo.listTagsForFile(fileId);
   return tags.some((tag) => tag.source === provider);
 };
 
-const ensureFavoriteSourceMetadata = async (file: FileRecord, item: FavoriteRemote) => {
+const ensureFavoriteSourceMetadata = async (
+  file: FileRecord,
+  item: FavoriteRemote
+) => {
   await ensureFavoriteSourceRun(file, item);
   if (await hasProviderSourceTags(file.id, item.provider)) return;
   await applyRemotePostTags(file, item.provider, item.remoteId, item.sourceUrl);
@@ -237,7 +277,12 @@ const pickExtension = (fileUrl: string) => {
   return '.jpg';
 };
 
-const buildFavoritePath = (root: string, provider: FavoriteProvider, remoteId: string, fileUrl: string) => {
+const buildFavoritePath = (
+  root: string,
+  provider: FavoriteProvider,
+  remoteId: string,
+  fileUrl: string
+) => {
   const ext = pickExtension(fileUrl);
   const safeId = toSafeId(remoteId) || remoteId;
   const fileName = `${provider.toLowerCase()}-${safeId}${ext}`;
@@ -247,10 +292,17 @@ const buildFavoritePath = (root: string, provider: FavoriteProvider, remoteId: s
 const isPathInsideRoot = (candidatePath: string, root: string) => {
   const resolvedRoot = path.resolve(root);
   const resolvedCandidate = path.resolve(candidatePath);
-  return resolvedCandidate === resolvedRoot || resolvedCandidate.startsWith(`${resolvedRoot}${path.sep}`);
+  return (
+    resolvedCandidate === resolvedRoot ||
+    resolvedCandidate.startsWith(`${resolvedRoot}${path.sep}`)
+  );
 };
 
-const resolveFavoriteFilePath = (root: string, item: FavoriteRemote, existingPath?: string | null) => {
+const resolveFavoriteFilePath = (
+  root: string,
+  item: FavoriteRemote,
+  existingPath?: string | null
+) => {
   const normalizedExisting = existingPath ? path.resolve(existingPath) : '';
   if (!item.fileUrl) {
     if (!normalizedExisting) return '';
@@ -259,10 +311,16 @@ const resolveFavoriteFilePath = (root: string, item: FavoriteRemote, existingPat
     return fs.existsSync(candidate) ? candidate : normalizedExisting;
   }
 
-  const preferred = buildFavoritePath(root, item.provider, item.remoteId, item.fileUrl);
+  const preferred = buildFavoritePath(
+    root,
+    item.provider,
+    item.remoteId,
+    item.fileUrl
+  );
   if (!normalizedExisting) return preferred;
   if (normalizedExisting === path.resolve(preferred)) return preferred;
-  if (path.basename(normalizedExisting) === path.basename(preferred)) return preferred;
+  if (path.basename(normalizedExisting) === path.basename(preferred))
+    return preferred;
   if (isPathInsideRoot(normalizedExisting, root)) return normalizedExisting;
   // Auto-fav marker: existing row points to a real local file outside the favorites
   // root (e.g. a file the user uploaded that the sauce scanner matched on e621).
@@ -271,7 +329,11 @@ const resolveFavoriteFilePath = (root: string, item: FavoriteRemote, existingPat
   return preferred;
 };
 
-const downloadFile = async (url: string, destPath: string, headers: Record<string, string>) => {
+const downloadFile = async (
+  url: string,
+  destPath: string,
+  headers: Record<string, string>
+) => {
   await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
   const tempPath = `${destPath}.part`;
   const res = await fetch(url, { headers });
@@ -340,7 +402,9 @@ export type AutoFavoriteOutcome =
   | { status: 'favorited'; provider: FavoriteProvider; remoteId: string }
   | { status: 'error'; reason: string };
 
-const resolveFileUserIdSafe = async (file: FileRecord): Promise<string | null> => {
+const resolveFileUserIdSafe = async (
+  file: FileRecord
+): Promise<string | null> => {
   try {
     const owner = await authRepo.findUserByFileId(file.id);
     return owner?.id ?? null;
@@ -374,12 +438,27 @@ const findBestFavoritableMatch = async (
     const candidates = run.results?.length
       ? run.results
       : run.sourceUrl
-        ? [{ sourceUrl: run.sourceUrl, score: run.score, sourceName: null, thumbUrl: null }]
+        ? [
+            {
+              sourceUrl: run.sourceUrl,
+              score: run.score,
+              sourceName: null,
+              thumbUrl: null
+            }
+          ]
         : [];
     for (const candidate of candidates) {
       const score = candidate.score;
-      if (typeof score !== 'number' || !Number.isFinite(score) || score < threshold) continue;
-      const remote = extractFavoriteRemoteFromSiteList(candidate.sourceUrl, sites);
+      if (
+        typeof score !== 'number' ||
+        !Number.isFinite(score) ||
+        score < threshold
+      )
+        continue;
+      const remote = extractFavoriteRemoteFromSiteList(
+        candidate.sourceUrl,
+        sites
+      );
       if (!remote) continue;
       if (!best || score > best.score) {
         best = {
@@ -401,12 +480,11 @@ const findBestFavoritableMatch = async (
 // favorite_items row pointing at the local file path so the next sync
 // recognises it (option C of #66) and skips re-downloading the post into the
 // favorites root. Opt-in via settings.
-export const autoFavoriteFromSauce = async (file: FileRecord): Promise<AutoFavoriteOutcome> => {
+export const autoFavoriteFromSauce = async (
+  file: FileRecord
+): Promise<AutoFavoriteOutcome> => {
   const userId = await resolveFileUserIdSafe(file);
   if (!userId) return { status: 'skipped', reason: 'no-owner' };
-
-  const settings = await favoritesRepo.getFavoritesSettings(userId);
-  if (!settings.autoFavEnabled) return { status: 'skipped', reason: 'disabled' };
 
   // Match URL against every site that opted into source-match (cap_source_match).
   // Don't pre-filter by favorites capability or credentials here: the
@@ -418,13 +496,25 @@ export const autoFavoriteFromSauce = async (file: FileRecord): Promise<AutoFavor
   const remote = await findBestFavoritableMatch(file.id, matchSites);
   if (!remote) return { status: 'skipped', reason: 'no-supported-match' };
 
-  const existing = await favoritesRepo.listFavoriteItemsByPath(file.path, userId);
-  if (existing.some((item) => item.provider === remote.provider && item.remoteId === remote.remoteId)) {
+  const existing = await favoritesRepo.listFavoriteItemsByPath(
+    file.path,
+    userId
+  );
+  if (
+    existing.some(
+      (item) =>
+        item.provider === remote.provider && item.remoteId === remote.remoteId
+    )
+  ) {
     return { status: 'skipped', reason: 'already-marked' };
   }
 
   const targetSite = await resolveSiteFromProvider(userId, remote.provider);
-  if (!targetSite) return { status: 'error', reason: `unknown provider: ${remote.provider}` };
+  if (!targetSite)
+    return { status: 'error', reason: `unknown provider: ${remote.provider}` };
+  if (!targetSite.siteAutoFavEnabled) {
+    return { status: 'skipped', reason: 'disabled' };
+  }
   if (!targetSite.capFavorites) {
     return { status: 'skipped', reason: 'favorites-capability-disabled' };
   }
@@ -449,7 +539,11 @@ export const autoFavoriteFromSauce = async (file: FileRecord): Promise<AutoFavor
     userId
   );
 
-  return { status: 'favorited', provider: remote.provider, remoteId: remote.remoteId };
+  return {
+    status: 'favorited',
+    provider: remote.provider,
+    remoteId: remote.remoteId
+  };
 };
 
 const fetchSiteFavorites = async (
@@ -473,7 +567,9 @@ const fetchSiteFavorites = async (
   return { items, headers: result.downloadHeaders };
 };
 
-const initProviderProgress = (provider: FavoriteProvider): FavoriteSyncProgress => ({
+const initProviderProgress = (
+  provider: FavoriteProvider
+): FavoriteSyncProgress => ({
   provider,
   stage: 'idle',
   fetched: 0,
@@ -497,11 +593,22 @@ const syncSite = async (
   site: BooruSiteRecord,
   deleteMissing: boolean,
   root: string,
-  onProgress: (provider: FavoriteProvider, patch: Partial<FavoriteSyncProgress>, message?: string) => void
+  onProgress: (
+    provider: FavoriteProvider,
+    patch: Partial<FavoriteSyncProgress>,
+    message?: string
+  ) => void
 ): Promise<SyncResult> => {
   const provider = favoriteKeyForSite(site);
   const label = site.name;
-  const result: SyncResult = { provider, fetched: 0, added: 0, removed: 0, skipped: 0, errors: [] };
+  const result: SyncResult = {
+    provider,
+    fetched: 0,
+    added: 0,
+    removed: 0,
+    skipped: 0,
+    errors: []
+  };
   debugLog(`${label}: start`);
   onProgress(provider, { stage: 'fetching' }, `Fetching ${label} favorites…`);
   const fetched = await fetchSiteFavorites(site, (page, count) => {
@@ -515,13 +622,20 @@ const syncSite = async (
   result.fetched = remote.length;
   onProgress(
     provider,
-    { fetched: remote.length, total: remote.length, processed: 0, stage: 'downloading' },
+    {
+      fetched: remote.length,
+      total: remote.length,
+      processed: 0,
+      stage: 'downloading'
+    },
     `Downloading ${provider.toLowerCase()} favorites…`
   );
 
   const folder = await ensureFavoritesFolder(root, userId);
   const existingItems = await favoritesRepo.listFavoriteItems(provider, userId);
-  const existingById = new Map(existingItems.map((item) => [item.remoteId, item]));
+  const existingById = new Map(
+    existingItems.map((item) => [item.remoteId, item])
+  );
   const remoteIds = new Set(remote.map((item) => item.remoteId));
 
   let processed = 0;
@@ -530,15 +644,22 @@ const syncSite = async (
     const filePath = resolveFavoriteFilePath(root, item, existing?.filePath);
     const fileExists = filePath ? fs.existsSync(filePath) : false;
     if (existing && fileExists) {
-      await favoritesRepo.upsertFavoriteItem({
-        provider,
-        remoteId: item.remoteId,
-        filePath,
-        sourceUrl: item.sourceUrl,
-        fileUrl: item.fileUrl
-      }, userId);
+      await favoritesRepo.upsertFavoriteItem(
+        {
+          provider,
+          remoteId: item.remoteId,
+          filePath,
+          sourceUrl: item.sourceUrl,
+          fileUrl: item.fileUrl
+        },
+        userId
+      );
       try {
-        const record = await findOrScanFavoriteRecord(folder.id, filePath, userId);
+        const record = await findOrScanFavoriteRecord(
+          folder.id,
+          filePath,
+          userId
+        );
         if (record) {
           await ensureFavoriteSourceMetadata(record, item);
         }
@@ -557,15 +678,20 @@ const syncSite = async (
     }
     if (!item.fileUrl) {
       if (existing) {
-        await favoritesRepo.upsertFavoriteItem({
-          provider,
-          remoteId: item.remoteId,
-          filePath,
-          sourceUrl: item.sourceUrl,
-          fileUrl: null
-        }, userId);
+        await favoritesRepo.upsertFavoriteItem(
+          {
+            provider,
+            remoteId: item.remoteId,
+            filePath,
+            sourceUrl: item.sourceUrl,
+            fileUrl: null
+          },
+          userId
+        );
         try {
-          const record = filePath ? await findOrScanFavoriteRecord(folder.id, filePath, userId) : null;
+          const record = filePath
+            ? await findOrScanFavoriteRecord(folder.id, filePath, userId)
+            : null;
           if (record) {
             await ensureFavoriteSourceMetadata(record, item);
           }
@@ -585,16 +711,23 @@ const syncSite = async (
     }
     try {
       await downloadFile(item.fileUrl, filePath, headers);
-      await favoritesRepo.upsertFavoriteItem({
-        provider,
-        remoteId: item.remoteId,
-        filePath,
-        sourceUrl: item.sourceUrl,
-        fileUrl: item.fileUrl
-      }, userId);
+      await favoritesRepo.upsertFavoriteItem(
+        {
+          provider,
+          remoteId: item.remoteId,
+          filePath,
+          sourceUrl: item.sourceUrl,
+          fileUrl: item.fileUrl
+        },
+        userId
+      );
       result.added += 1;
       try {
-        const record = await findOrScanFavoriteRecord(folder.id, filePath, userId);
+        const record = await findOrScanFavoriteRecord(
+          folder.id,
+          filePath,
+          userId
+        );
         if (record) {
           await ensureFavoriteSourceMetadata(record, item);
         }
@@ -612,19 +745,34 @@ const syncSite = async (
     }
     processed += 1;
     if (processed % 10 === 0 || processed === remote.length) {
-      onProgress(provider, { processed, added: result.added, skipped: result.skipped });
+      onProgress(provider, {
+        processed,
+        added: result.added,
+        skipped: result.skipped
+      });
     }
   }
   if (processed % 10 !== 0) {
-    onProgress(provider, { processed, added: result.added, skipped: result.skipped });
+    onProgress(provider, {
+      processed,
+      added: result.added,
+      skipped: result.skipped
+    });
   }
 
   if (deleteMissing) {
-    const missing = existingItems.filter((item) => !remoteIds.has(item.remoteId));
+    const missing = existingItems.filter(
+      (item) => !remoteIds.has(item.remoteId)
+    );
     let removedProcessed = 0;
     onProgress(
       provider,
-      { stage: 'deleting', total: missing.length, processed: 0, removed: result.removed },
+      {
+        stage: 'deleting',
+        total: missing.length,
+        processed: 0,
+        removed: result.removed
+      },
       `Removing unfavorited ${provider.toLowerCase()} items…`
     );
     debugLog(`${provider}: removing ${missing.length} unfavorited items`);
@@ -634,17 +782,27 @@ const syncSite = async (
       result.removed += 1;
       removedProcessed += 1;
       if (removedProcessed % 10 === 0 || removedProcessed === missing.length) {
-        onProgress(provider, { processed: removedProcessed, removed: result.removed });
+        onProgress(provider, {
+          processed: removedProcessed,
+          removed: result.removed
+        });
       }
     }
   }
 
   onProgress(
     provider,
-    { stage: 'done', processed: result.fetched, added: result.added, removed: result.removed },
+    {
+      stage: 'done',
+      processed: result.fetched,
+      added: result.added,
+      removed: result.removed
+    },
     `${provider.toLowerCase()} favorites synced.`
   );
-  debugLog(`${provider}: done (added ${result.added}, removed ${result.removed}, skipped ${result.skipped})`);
+  debugLog(
+    `${provider}: done (added ${result.added}, removed ${result.removed}, skipped ${result.skipped})`
+  );
   return result;
 };
 
@@ -657,13 +815,21 @@ const updateSyncState = (userId: string, patch: Partial<FavoriteSyncState>) => {
   });
 };
 
-const createProgressUpdater = (userId: string, providers: FavoriteProvider[]) => {
+const createProgressUpdater = (
+  userId: string,
+  providers: FavoriteProvider[]
+) => {
   const progressMap = new Map<FavoriteProvider, FavoriteSyncProgress>(
     providers.map((provider) => [provider, initProviderProgress(provider)])
   );
   return {
-    update(provider: FavoriteProvider, patch: Partial<FavoriteSyncProgress>, message?: string) {
-      const existing = progressMap.get(provider) ?? initProviderProgress(provider);
+    update(
+      provider: FavoriteProvider,
+      patch: Partial<FavoriteSyncProgress>,
+      message?: string
+    ) {
+      const existing =
+        progressMap.get(provider) ?? initProviderProgress(provider);
       const next = { ...existing, ...patch };
       progressMap.set(provider, next);
       updateSyncState(userId, {
@@ -682,9 +848,15 @@ const runFavoritesSync = async (userId: string, options: SyncOptions) => {
   try {
     const root = await ensureFavoritesRoot(userId);
     const syncableSites = await loadFavoriteSyncableSites(userId);
-    const filterIds = options.providers?.length ? new Set(options.providers) : null;
+    const filterIds = options.providers?.length
+      ? new Set(options.providers)
+      : null;
     const sites = filterIds
-      ? syncableSites.filter((site) => filterIds.has(site.id) || (site.presetKey && filterIds.has(site.presetKey)))
+      ? syncableSites.filter(
+          (site) =>
+            filterIds.has(site.id) ||
+            (site.presetKey && filterIds.has(site.presetKey))
+        )
       : syncableSites;
     if (!sites.length) {
       updateSyncState(userId, {
@@ -697,7 +869,8 @@ const runFavoritesSync = async (userId: string, options: SyncOptions) => {
       return;
     }
     const providerKeys = sites.map((site) => favoriteKeyForSite(site));
-    const deleteMissing = options.deleteMissing ?? config.favorites.deleteMissing;
+    const deleteMissing =
+      options.deleteMissing ?? config.favorites.deleteMissing;
     const results: SyncResult[] = [];
     const progress = createProgressUpdater(userId, providerKeys);
     updateSyncState(userId, {
@@ -710,7 +883,9 @@ const runFavoritesSync = async (userId: string, options: SyncOptions) => {
     for (const site of sites) {
       const provider = favoriteKeyForSite(site);
       try {
-        results.push(await syncSite(userId, site, deleteMissing, root, progress.update));
+        results.push(
+          await syncSite(userId, site, deleteMissing, root, progress.update)
+        );
       } catch (err) {
         results.push({
           provider,
@@ -720,7 +895,10 @@ const runFavoritesSync = async (userId: string, options: SyncOptions) => {
           skipped: 0,
           errors: [(err as Error).message]
         });
-        progress.update(provider, { stage: 'error', errors: [(err as Error).message] });
+        progress.update(provider, {
+          stage: 'error',
+          errors: [(err as Error).message]
+        });
         debugLog(`${site.name}: error ${(err as Error).message}`);
       }
     }
@@ -744,7 +922,10 @@ const runFavoritesSync = async (userId: string, options: SyncOptions) => {
 
 export const getFavoritesSyncStatus = (userId: string) => getSyncState(userId);
 
-export const startFavoritesSync = (userId: string, options: SyncOptions = {}) => {
+export const startFavoritesSync = (
+  userId: string,
+  options: SyncOptions = {}
+) => {
   if (syncRunningByUser.get(userId)) {
     return { status: 'busy', state: getSyncState(userId) };
   }

--- a/backend/src/worker.test.ts
+++ b/backend/src/worker.test.ts
@@ -3,37 +3,17 @@ import '../test/helpers/setupEnv';
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { runAutoFavoritesSyncForEnabledUsers, shouldWarnMissingLocalFolder } from './worker';
+import {
+  runAutoFavoritesSyncForEnabledUsers,
+  shouldWarnMissingLocalFolder
+} from './worker';
 
 test('midnight favorites sync starts for enabled users', async () => {
   const started: string[] = [];
   const warnings: string[] = [];
 
   await runAutoFavoritesSyncForEnabledUsers({
-    listUsers: async () => [
-      { id: 'disabled-user' },
-      { id: 'enabled-user' }
-    ],
-    getFavoritesSettings: async (userId) => {
-      return {
-        reverseSyncEnabled: false,
-        autoSyncMidnight: userId === 'enabled-user',
-        autoFavEnabled: false,
-        favoritesRootId: null
-      };
-    },
-    getFavoritesSettingsBatch: async (userIds) => {
-      const map = new Map();
-      for (const userId of userIds) {
-        map.set(userId, {
-          reverseSyncEnabled: false,
-          autoSyncMidnight: userId === 'enabled-user',
-          autoFavEnabled: false,
-          favoritesRootId: null
-        });
-      }
-      return map;
-    },
+    listUsersWithAutoSyncFavorites: async () => ['enabled-user'],
     startFavoritesSync: (userId) => {
       started.push(userId);
       return { status: 'started' };
@@ -49,15 +29,9 @@ test('midnight favorites sync logs and returns when user listing fails', async (
   const warnings: string[] = [];
 
   await runAutoFavoritesSyncForEnabledUsers({
-    listUsers: async () => {
+    listUsersWithAutoSyncFavorites: async () => {
       throw new Error('db unavailable');
     },
-    getFavoritesSettings: async () => {
-      throw new Error('should not run');
-    },
-    getFavoritesSettingsBatch: async () => {
-      throw new Error('should not run');
-    },
     startFavoritesSync: () => {
       throw new Error('should not run');
     },
@@ -65,37 +39,25 @@ test('midnight favorites sync logs and returns when user listing fails', async (
   });
 
   assert.equal(warnings.length, 1);
-  assert.match(warnings[0], /list users/);
-});
-
-test('midnight favorites sync logs and returns when batch settings fetch fails', async () => {
-  const warnings: string[] = [];
-
-  await runAutoFavoritesSyncForEnabledUsers({
-    listUsers: async () => [
-      { id: 'user1' },
-      { id: 'user2' }
-    ],
-    getFavoritesSettings: async () => {
-      throw new Error('should not run');
-    },
-    getFavoritesSettingsBatch: async () => {
-      throw new Error('settings db error');
-    },
-    startFavoritesSync: () => {
-      throw new Error('should not run');
-    },
-    warn: (message) => warnings.push(message)
-  });
-
-  assert.equal(warnings.length, 1);
-  assert.match(warnings[0], /fetch settings/);
+  assert.match(warnings[0], /list eligible users/);
 });
 
 test('shouldWarnMissingLocalFolder warns once until the folder exists again', () => {
-  assert.equal(shouldWarnMissingLocalFolder('folder-a', '/missing/path', false), true);
-  assert.equal(shouldWarnMissingLocalFolder('folder-a', '/missing/path', false), false);
+  assert.equal(
+    shouldWarnMissingLocalFolder('folder-a', '/missing/path', false),
+    true
+  );
+  assert.equal(
+    shouldWarnMissingLocalFolder('folder-a', '/missing/path', false),
+    false
+  );
 
-  assert.equal(shouldWarnMissingLocalFolder('folder-a', '/missing/path', true), false);
-  assert.equal(shouldWarnMissingLocalFolder('folder-a', '/missing/path', false), true);
+  assert.equal(
+    shouldWarnMissingLocalFolder('folder-a', '/missing/path', true),
+    false
+  );
+  assert.equal(
+    shouldWarnMissingLocalFolder('folder-a', '/missing/path', false),
+    true
+  );
 });

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -5,14 +5,19 @@ import { fetch } from 'undici';
 
 import { config } from './config';
 import { authRepo } from './db/repos/authRepo';
+import { booruSitesRepo } from './db/repos/booruSitesRepo';
 import { favoritesRepo } from './db/repos/favoritesRepo';
 import { filesRepo } from './db/repos/filesRepo';
 import { foldersRepo } from './db/repos/foldersRepo';
 import { scansRepo } from './db/repos/scansRepo';
-import type { FavoritesSettings, FileRecord, FolderRecord, ProviderRunRecord, UserRecord } from './db/types';
+import type { FileRecord, FolderRecord, ProviderRunRecord } from './db/types';
 import { executeProviderRun, ProviderKind } from './lib/providerRunner';
 import { hasTargetSauce, normalizeSauceKey } from './lib/sauces';
-import { iterateLocalMediaPaths, scanLocalFile, ScannedFile } from './lib/scanner';
+import {
+  iterateLocalMediaPaths,
+  scanLocalFile,
+  ScannedFile
+} from './lib/scanner';
 import { startFavoritesSync } from './services/favorites';
 import { ensureWd14Tags } from './services/tagging';
 
@@ -27,7 +32,8 @@ const missingProviderMaxMs = 20 * 60 * 1000;
 const missingProviderCandidateLimit = 25;
 const providerRefreshMaxDays = 7;
 const favoritesSyncIntervalMs = config.favorites.syncIntervalMs;
-const wd14BackfillIntervalMs = config.wd14.backfillIntervalHours * 60 * 60 * 1000;
+const wd14BackfillIntervalMs =
+  config.wd14.backfillIntervalHours * 60 * 60 * 1000;
 const wd14BackfillBatchSize = 50;
 const folderRefreshIntervalMs = 60 * 1000;
 const localRescanIntervalMs = config.background.localRescanIntervalMs;
@@ -39,7 +45,10 @@ const scanFileRetryLimit = 2;
 
 type FolderWatcher = {
   close: () => Promise<void>;
-  on(event: 'add' | 'change' | 'unlink', listener: (filePath: string) => void): FolderWatcher;
+  on(
+    event: 'add' | 'change' | 'unlink',
+    listener: (filePath: string) => void
+  ): FolderWatcher;
   on(event: 'error', listener: (error: unknown) => void): FolderWatcher;
 };
 
@@ -60,9 +69,7 @@ let autoScannerStarted = false;
 let wd14BackfillRunning = false;
 
 type AutoFavoritesSyncDeps = {
-  listUsers: () => Promise<Pick<UserRecord, 'id'>[]>;
-  getFavoritesSettings: (userId: string) => Promise<FavoritesSettings>;
-  getFavoritesSettingsBatch: (userIds: string[]) => Promise<Map<string, FavoritesSettings>>;
+  listUsersWithAutoSyncFavorites: () => Promise<string[]>;
   startFavoritesSync: typeof startFavoritesSync;
   warn: (message: string) => void;
 };
@@ -84,21 +91,29 @@ type ScanState = {
 
 const runProviderAsync = (file: FileRecord, provider: ProviderKind) => {
   void executeProviderRun(file, provider).catch((err) => {
-    console.warn(`[provider] ${provider} failed for ${file.id}: ${(err as Error).message}`);
+    console.warn(
+      `[provider] ${provider} failed for ${file.id}: ${(err as Error).message}`
+    );
   });
 };
 
 const runWd14Async = (file: FileRecord) => {
   if (file.mediaType === 'VIDEO') {
     void ensureWd14Tags(file, true).catch((err) => {
-      console.warn(`[tags] wd14 failed for ${file.id}: ${(err as Error).message}`);
+      console.warn(
+        `[tags] wd14 failed for ${file.id}: ${(err as Error).message}`
+      );
     });
     return;
   }
   if (file.mediaType === 'IMAGE') {
-    void ensureWd14Tags(file, false, { ignoreSourceTags: true }).catch((err) => {
-      console.warn(`[tags] wd14 failed for ${file.id}: ${(err as Error).message}`);
-    });
+    void ensureWd14Tags(file, false, { ignoreSourceTags: true }).catch(
+      (err) => {
+        console.warn(
+          `[tags] wd14 failed for ${file.id}: ${(err as Error).message}`
+        );
+      }
+    );
   }
 };
 
@@ -109,7 +124,9 @@ const isProviderDue = (
   targetKeys: Set<string>
 ) => {
   const allRuns = runs ?? [];
-  if (allRuns.some((run) => run.status === 'RUNNING' || run.status === 'PENDING')) {
+  if (
+    allRuns.some((run) => run.status === 'RUNNING' || run.status === 'PENDING')
+  ) {
     return false;
   }
   if (allRuns.length === 0) return false;
@@ -161,14 +178,18 @@ const getScanState = (folderId: string): ScanState => {
 const isSameOrInsidePath = (candidatePath: string, basePath: string) => {
   const resolvedBase = path.resolve(basePath);
   const resolvedCandidate = path.resolve(candidatePath);
-  return resolvedCandidate === resolvedBase || resolvedCandidate.startsWith(`${resolvedBase}${path.sep}`);
+  return (
+    resolvedCandidate === resolvedBase ||
+    resolvedCandidate.startsWith(`${resolvedBase}${path.sep}`)
+  );
 };
 
 const listManagedChildRoots = async (folder: FolderRecord) => {
   const folders = await foldersRepo.listFolders(folder.userId ?? undefined);
   return folders
     .filter((candidate) => {
-      if (candidate.id === folder.id || candidate.type !== 'LOCAL') return false;
+      if (candidate.id === folder.id || candidate.type !== 'LOCAL')
+        return false;
       return isSameOrInsidePath(candidate.path, folder.path);
     })
     .map((candidate) => path.resolve(candidate.path))
@@ -181,7 +202,11 @@ const isManagedChildPath = (filePath: string, managedChildRoots: string[]) => {
   });
 };
 
-export const shouldWarnMissingLocalFolder = (folderId: string, folderPath: string, exists: boolean) => {
+export const shouldWarnMissingLocalFolder = (
+  folderId: string,
+  folderPath: string,
+  exists: boolean
+) => {
   const key = `${folderId}:${path.resolve(folderPath)}`;
   if (exists) {
     missingLocalFolderWarnings.delete(key);
@@ -192,7 +217,10 @@ export const shouldWarnMissingLocalFolder = (folderId: string, folderPath: strin
   return true;
 };
 
-const deleteExistingPathFromFolder = async (filePath: string, state: ScanState) => {
+const deleteExistingPathFromFolder = async (
+  filePath: string,
+  state: ScanState
+) => {
   const existing = state.existingByPath?.get(filePath);
   if (!existing) return false;
   await filesRepo.deleteFile(existing.id);
@@ -208,7 +236,11 @@ class ScanTimeoutError extends Error {
   }
 }
 
-const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> => {
+const withTimeout = async <T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string
+): Promise<T> => {
   let timer: NodeJS.Timeout | undefined;
   const timeout = new Promise<T>((_, reject) => {
     timer = setTimeout(() => reject(new ScanTimeoutError(label)), timeoutMs);
@@ -268,12 +300,17 @@ const waitForPendingOrTimeout = (state: ScanState) => {
   });
 };
 
-const handleUpsertedFile = async (folderId: string, scanned: ScannedFile, state: ScanState) => {
+const handleUpsertedFile = async (
+  folderId: string,
+  scanned: ScannedFile,
+  state: ScanState
+) => {
   const previous = state.existingByPath?.get(scanned.path);
   if (previous) {
     const sameSize = Number(previous.sizeBytes) === Number(scanned.sizeBytes);
     const sameSha = previous.sha256 === scanned.sha256;
-    const sameMtime = new Date(previous.mtime).getTime() === scanned.mtime.getTime();
+    const sameMtime =
+      new Date(previous.mtime).getTime() === scanned.mtime.getTime();
     if (sameSize && sameSha && sameMtime) {
       return;
     }
@@ -282,10 +319,15 @@ const handleUpsertedFile = async (folderId: string, scanned: ScannedFile, state:
   const saved = await filesRepo.upsertFile(folderId, scanned);
   state.existingByPath?.set(saved.path, saved);
   state.lastMutationAt = Date.now();
-  const changed = !!previous && (previous.sha256 !== saved.sha256 || previous.mtime !== saved.mtime);
+  const changed =
+    !!previous &&
+    (previous.sha256 !== saved.sha256 || previous.mtime !== saved.mtime);
   const needsProviderScan = !previous || changed;
 
-  if (needsProviderScan && state.providerRunsStarted < providerRunsPerScanLimit) {
+  if (
+    needsProviderScan &&
+    state.providerRunsStarted < providerRunsPerScanLimit
+  ) {
     for (const provider of providerKinds) {
       if (state.providerRunsStarted >= providerRunsPerScanLimit) break;
       runProviderAsync(saved, provider);
@@ -296,7 +338,11 @@ const handleUpsertedFile = async (folderId: string, scanned: ScannedFile, state:
   runWd14Async(saved);
 };
 
-const processLocalFile = async (folderId: string, filePath: string, state: ScanState) => {
+const processLocalFile = async (
+  folderId: string,
+  filePath: string,
+  state: ScanState
+) => {
   if (isManagedChildPath(filePath, state.managedChildRoots)) {
     await deleteExistingPathFromFolder(filePath, state);
     return;
@@ -317,7 +363,10 @@ const processLocalFile = async (folderId: string, filePath: string, state: ScanS
       const retries = state.retryCounts.get(filePath) ?? 0;
       if (retries < scanFileRetryLimit) {
         state.retryCounts.set(filePath, retries + 1);
-        setTimeout(() => queuePathScan(folderId, filePath, 'retry-timeout'), scanFileRetryDelayMs);
+        setTimeout(
+          () => queuePathScan(folderId, filePath, 'retry-timeout'),
+          scanFileRetryDelayMs
+        );
       } else {
         state.retryCounts.delete(filePath);
       }
@@ -369,7 +418,9 @@ const runFullLocalScan = async (folder: FolderRecord, state: ScanState) => {
 
   const allowEarlyExit = (state.existingByPath?.size ?? 0) > 0;
   let processed = 0;
-  for await (const filePath of iterateLocalMediaPaths(folder.path, { yieldEvery: 200 })) {
+  for await (const filePath of iterateLocalMediaPaths(folder.path, {
+    yieldEvery: 200
+  })) {
     await processLocalFile(folder.id, filePath, state);
     if (state.pendingDeletes.size > 0) {
       await drainPendingDeletes(folder.id, state);
@@ -377,8 +428,13 @@ const runFullLocalScan = async (folder: FolderRecord, state: ScanState) => {
     if (state.pendingPaths.size > 0) {
       await drainPendingPaths(folder.id, state);
     }
-    if (allowEarlyExit && Date.now() - state.lastMutationAt > scanIdleTimeoutMs) {
-      console.log(`[auto-scan] idle timeout during full scan for ${folder.path}`);
+    if (
+      allowEarlyExit &&
+      Date.now() - state.lastMutationAt > scanIdleTimeoutMs
+    ) {
+      console.log(
+        `[auto-scan] idle timeout during full scan for ${folder.path}`
+      );
       break;
     }
     processed += 1;
@@ -405,16 +461,23 @@ const startScanSession = async (folderId: string, reason: string) => {
     await fs.promises.mkdir(config.storage.thumbnailsDir, { recursive: true });
 
     const existingFiles = await filesRepo.listFiles(folderId);
-    state.existingByPath = new Map(existingFiles.map((file) => [file.path, file]));
-  state.managedChildRoots = await listManagedChildRoots(folder);
+    state.existingByPath = new Map(
+      existingFiles.map((file) => [file.path, file])
+    );
+    state.managedChildRoots = await listManagedChildRoots(folder);
 
     const scan = await scansRepo.createScan(folderId);
     scanId = scan.id;
     state.scanId = scanId;
     state.lastMutationAt = Date.now();
     await scansRepo.updateScan(scanId, { status: 'RUNNING', progress: 0 });
-    await foldersRepo.updateFolder(folderId, { status: 'SCANNING', lastScanAt: new Date().toISOString() });
-    console.log(`[auto-scan] started scan ${scanId} for folder ${folder.path} (${reason})`);
+    await foldersRepo.updateFolder(folderId, {
+      status: 'SCANNING',
+      lastScanAt: new Date().toISOString()
+    });
+    console.log(
+      `[auto-scan] started scan ${scanId} for folder ${folder.path} (${reason})`
+    );
 
     for (;;) {
       if (state.needsFullScan) {
@@ -424,13 +487,21 @@ const startScanSession = async (folderId: string, reason: string) => {
       await drainPendingDeletes(folderId, state);
       await drainPendingPaths(folderId, state);
 
-      if (state.needsFullScan || state.pendingDeletes.size > 0 || state.pendingPaths.size > 0) {
+      if (
+        state.needsFullScan ||
+        state.pendingDeletes.size > 0 ||
+        state.pendingPaths.size > 0
+      ) {
         continue;
       }
 
       const waitResult = await waitForPendingOrTimeout(state);
       if (waitResult === 'timeout') {
-        if (state.needsFullScan || state.pendingDeletes.size > 0 || state.pendingPaths.size > 0) {
+        if (
+          state.needsFullScan ||
+          state.pendingDeletes.size > 0 ||
+          state.pendingPaths.size > 0
+        ) {
           continue;
         }
         break;
@@ -442,11 +513,17 @@ const startScanSession = async (folderId: string, reason: string) => {
     }
   } catch (err) {
     if (scanId) {
-      await scansRepo.updateScan(scanId, { status: 'FAILED', error: (err as Error).message });
+      await scansRepo.updateScan(scanId, {
+        status: 'FAILED',
+        error: (err as Error).message
+      });
     }
   } finally {
     if (folder) {
-      await foldersRepo.updateFolder(folderId, { status: 'IDLE', lastScanAt: new Date().toISOString() });
+      await foldersRepo.updateFolder(folderId, {
+        status: 'IDLE',
+        lastScanAt: new Date().toISOString()
+      });
     }
     state.running = false;
     state.scanId = undefined;
@@ -456,7 +533,11 @@ const startScanSession = async (folderId: string, reason: string) => {
     state.providerRunsStarted = 0;
     state.retryCounts.clear();
 
-    if (state.needsFullScan || state.pendingDeletes.size > 0 || state.pendingPaths.size > 0) {
+    if (
+      state.needsFullScan ||
+      state.pendingDeletes.size > 0 ||
+      state.pendingPaths.size > 0
+    ) {
       void startScanSession(folderId, 'queued-while-closing');
     }
   }
@@ -466,7 +547,8 @@ const startFolderWatch = async (folderId: string, folderPath: string) => {
   if (watchers.has(folderId)) return false;
   const exists = fs.existsSync(folderPath);
   if (!exists) {
-    if (!shouldWarnMissingLocalFolder(folderId, folderPath, false)) return false;
+    if (!shouldWarnMissingLocalFolder(folderId, folderPath, false))
+      return false;
     console.warn(`[auto-scan] watch skipped, path not found: ${folderPath}`);
     return false;
   }
@@ -520,9 +602,14 @@ const refreshFolderWatchers = async (reason: string) => {
   const now = Date.now();
   for (const folder of folders) {
     if (folder.type === 'LOCAL') {
-      const lastScanMs = folder.lastScanAt ? new Date(folder.lastScanAt).getTime() : 0;
+      const lastScanMs = folder.lastScanAt
+        ? new Date(folder.lastScanAt).getTime()
+        : 0;
       if (watchers.has(folder.id)) {
-        if (localRescanIntervalMs > 0 && (!folder.lastScanAt || now - lastScanMs >= localRescanIntervalMs)) {
+        if (
+          localRescanIntervalMs > 0 &&
+          (!folder.lastScanAt || now - lastScanMs >= localRescanIntervalMs)
+        ) {
           queueFullScan(folder.id, 'periodic');
         }
         continue;
@@ -534,7 +621,9 @@ const refreshFolderWatchers = async (reason: string) => {
       continue;
     }
 
-    const lastScanMs = folder.lastScanAt ? new Date(folder.lastScanAt).getTime() : 0;
+    const lastScanMs = folder.lastScanAt
+      ? new Date(folder.lastScanAt).getTime()
+      : 0;
     if (!folder.lastScanAt || now - lastScanMs >= folderRefreshIntervalMs) {
       queueFullScan(folder.id, reason);
     }
@@ -555,10 +644,15 @@ const pollLocalFolderChanges = async () => {
           queueFullScan(folder.id, 'mtime-poll');
         }
       } catch (err) {
-        if ((err as NodeJS.ErrnoException).code === 'ENOENT' && !shouldWarnMissingLocalFolder(folder.id, folder.path, false)) {
+        if (
+          (err as NodeJS.ErrnoException).code === 'ENOENT' &&
+          !shouldWarnMissingLocalFolder(folder.id, folder.path, false)
+        ) {
           return;
         }
-        console.warn(`[auto-scan] mtime poll failed for ${folder.path}: ${(err as Error).message}`);
+        console.warn(
+          `[auto-scan] mtime poll failed for ${folder.path}: ${(err as Error).message}`
+        );
       }
     })
   );
@@ -578,16 +672,27 @@ const runProviderRefresh = async () => {
         after: cursor
       });
       if (batch.files.length === 0) break;
-      const ownersByFileId = await authRepo.findUsersByFileIds(batch.files.map((file) => file.id));
-      const userIds = Array.from(new Set(Array.from(ownersByFileId.values()).map((owner) => owner.id)));
-      const sauceSettingsByUser = await favoritesRepo.getSauceSettingsBatch(userIds);
+      const ownersByFileId = await authRepo.findUsersByFileIds(
+        batch.files.map((file) => file.id)
+      );
+      const userIds = Array.from(
+        new Set(Array.from(ownersByFileId.values()).map((owner) => owner.id))
+      );
+      const sauceSettingsByUser =
+        await favoritesRepo.getSauceSettingsBatch(userIds);
       const targetKeysByUser = new Map(
         userIds.map((userId) => [
           userId,
-          new Set((sauceSettingsByUser.get(userId)?.targets ?? []).map(normalizeSauceKey))
+          new Set(
+            (sauceSettingsByUser.get(userId)?.targets ?? []).map(
+              normalizeSauceKey
+            )
+          )
         ])
       );
-      const providerRunsByFile = await filesRepo.listProviderRunsByFileIds(batch.files.map((file) => file.id));
+      const providerRunsByFile = await filesRepo.listProviderRunsByFileIds(
+        batch.files.map((file) => file.id)
+      );
 
       for (const file of batch.files) {
         const owner = ownersByFileId.get(file.id);
@@ -628,17 +733,31 @@ const pickMissingProviderRun = async () => {
     const candidates: { file: FileRecord; provider: ProviderKind }[] = [];
 
     for (const provider of providerKinds) {
-      const files = filesRepo.listFilesWithoutProviderRun(provider, missingProviderCandidateLimit);
-      const ownersByFileId = await authRepo.findUsersByFileIds(files.map((file) => file.id));
-      const userIds = Array.from(new Set(Array.from(ownersByFileId.values()).map((owner) => owner.id)));
-      const sauceSettingsByUser = await favoritesRepo.getSauceSettingsBatch(userIds);
+      const files = filesRepo.listFilesWithoutProviderRun(
+        provider,
+        missingProviderCandidateLimit
+      );
+      const ownersByFileId = await authRepo.findUsersByFileIds(
+        files.map((file) => file.id)
+      );
+      const userIds = Array.from(
+        new Set(Array.from(ownersByFileId.values()).map((owner) => owner.id))
+      );
+      const sauceSettingsByUser =
+        await favoritesRepo.getSauceSettingsBatch(userIds);
       const targetKeysByUser = new Map(
         userIds.map((userId) => [
           userId,
-          new Set((sauceSettingsByUser.get(userId)?.targets ?? []).map(normalizeSauceKey))
+          new Set(
+            (sauceSettingsByUser.get(userId)?.targets ?? []).map(
+              normalizeSauceKey
+            )
+          )
         ])
       );
-      const providerRunsByFile = await filesRepo.listProviderRunsByFileIds(files.map((file) => file.id));
+      const providerRunsByFile = await filesRepo.listProviderRunsByFileIds(
+        files.map((file) => file.id)
+      );
       for (const file of files) {
         const owner = ownersByFileId.get(file.id);
         const userId = owner?.id ?? '';
@@ -660,7 +779,10 @@ const pickMissingProviderRun = async () => {
 const scheduleMissingProviderScan = () => {
   if (missingProviderTimer) clearTimeout(missingProviderTimer);
   const delay =
-    missingProviderMinMs + Math.floor(Math.random() * (missingProviderMaxMs - missingProviderMinMs + 1));
+    missingProviderMinMs +
+    Math.floor(
+      Math.random() * (missingProviderMaxMs - missingProviderMinMs + 1)
+    );
   missingProviderTimer = setTimeout(async () => {
     await pickMissingProviderRun();
     scheduleMissingProviderScan();
@@ -669,32 +791,23 @@ const scheduleMissingProviderScan = () => {
 
 export const runAutoFavoritesSyncForEnabledUsers = async (
   deps: AutoFavoritesSyncDeps = {
-    listUsers: () => authRepo.listUsers(),
-    getFavoritesSettings: (userId) => favoritesRepo.getFavoritesSettings(userId),
-    getFavoritesSettingsBatch: (userIds) => favoritesRepo.getFavoritesSettingsBatch(userIds),
+    listUsersWithAutoSyncFavorites: () =>
+      booruSitesRepo.listUsersWithAutoSyncFavorites(),
     startFavoritesSync,
     warn: (message) => console.warn(message)
   }
 ) => {
-  let users: Pick<UserRecord, 'id'>[];
+  let userIds: string[];
   try {
-    users = await deps.listUsers();
+    userIds = await deps.listUsersWithAutoSyncFavorites();
   } catch (err) {
-    deps.warn(`[favorites] auto-sync failed to list users: ${(err as Error).message}`);
+    deps.warn(
+      `[favorites] auto-sync failed to list eligible users: ${(err as Error).message}`
+    );
     return;
   }
-  const userIds = users.map((u) => u.id);
-  let settingsByUser: Map<string, FavoritesSettings>;
-  try {
-    settingsByUser = await deps.getFavoritesSettingsBatch(userIds);
-  } catch (err) {
-    deps.warn(`[favorites] auto-sync failed to fetch settings: ${(err as Error).message}`);
-    return;
-  }
-  for (const user of users) {
-    const settings = settingsByUser.get(user.id);
-    if (!settings?.autoSyncMidnight) continue;
-    deps.startFavoritesSync(user.id);
+  for (const userId of userIds) {
+    deps.startFavoritesSync(userId);
   }
 };
 
@@ -717,7 +830,9 @@ const scheduleFavoritesSync = () => {
 const isTaggerAvailable = async (): Promise<boolean> => {
   if (!config.tagger.url) return false;
   try {
-    const res = await fetch(`${config.tagger.url}/health`, { signal: AbortSignal.timeout(3000) });
+    const res = await fetch(`${config.tagger.url}/health`, {
+      signal: AbortSignal.timeout(3000)
+    });
     return res.ok;
   } catch {
     return false;
@@ -780,9 +895,13 @@ export const startAutoScanner = async () => {
   const userCount = await authRepo.countUsers();
 
   if (localRescanIntervalMs > 0) {
-    console.log(`[worker] local periodic rescan enabled (${Math.round(localRescanIntervalMs / 60000)} min)`);
+    console.log(
+      `[worker] local periodic rescan enabled (${Math.round(localRescanIntervalMs / 60000)} min)`
+    );
   } else {
-    console.log('[worker] local periodic rescan disabled; relying on watcher events and mtime polling');
+    console.log(
+      '[worker] local periodic rescan disabled; relying on watcher events and mtime polling'
+    );
   }
 
   if (userCount === 0 && config.folderPaths.length > 0) {
@@ -790,8 +909,14 @@ export const startAutoScanner = async () => {
   } else if (userCount === 0 && config.mediaPath) {
     await fs.promises.mkdir(config.mediaPath, { recursive: true });
     const existing = await foldersRepo.listFolders();
-    if (existing.length === 1 && existing[0]?.path === '/media' && config.mediaPath !== '/media') {
-      await foldersRepo.updateFolder(existing[0].id, { path: config.mediaPath });
+    if (
+      existing.length === 1 &&
+      existing[0]?.path === '/media' &&
+      config.mediaPath !== '/media'
+    ) {
+      await foldersRepo.updateFolder(existing[0].id, {
+        path: config.mediaPath
+      });
     } else if (existing.length === 0) {
       await foldersRepo.ensureFolders([config.mediaPath]);
     }

--- a/backend/test/files.test.ts
+++ b/backend/test/files.test.ts
@@ -85,12 +85,16 @@ test('GET /files rejects invalid query parameters with 400', async () => {
   assert.equal(res.statusCode, 400);
 });
 
-test('GET /files only returns the caller\'s files', async () => {
+test("GET /files only returns the caller's files", async () => {
   const alice = await seedUser({ username: 'files_iso_a' });
   const bob = await seedUser({ username: 'files_iso_b' });
   // Seed Alice with a file via the lower-level helpers.
   const aliceFolders = await foldersRepo.listFolders(alice.user.id);
-  const aliceFile = writeFixtureFile(aliceFolders[0].path, 'a.png', Buffer.from('x'));
+  const aliceFile = writeFixtureFile(
+    aliceFolders[0].path,
+    'a.png',
+    Buffer.from('x')
+  );
   await registerFixtureFile(aliceFolders[0].id, aliceFile);
 
   const bobRes = await app.inject({
@@ -105,7 +109,11 @@ test('GET /files only returns the caller\'s files', async () => {
 test('GET /files/:id/tags returns empty list for a freshly-seeded file', async () => {
   const seeded = await seedUser({ username: 'files_tags_empty' });
   const folders = await foldersRepo.listFolders(seeded.user.id);
-  const filePath = writeFixtureFile(folders[0].path, 'untagged.png', Buffer.from('x'));
+  const filePath = writeFixtureFile(
+    folders[0].path,
+    'untagged.png',
+    Buffer.from('x')
+  );
   const file = await registerFixtureFile(folders[0].id, filePath);
   const res = await app.inject({
     method: 'GET',
@@ -130,7 +138,11 @@ test('POST /files/:id/tags/manual + DELETE round-trips a tag', async () => {
   const seeded = await seedUser({ username: 'files_manual_tag' });
   const cookie = await cookieFor(seeded.user.id);
   const folders = await foldersRepo.listFolders(seeded.user.id);
-  const filePath = writeFixtureFile(folders[0].path, 'taggable.png', Buffer.from('x'));
+  const filePath = writeFixtureFile(
+    folders[0].path,
+    'taggable.png',
+    Buffer.from('x')
+  );
   const file = await registerFixtureFile(folders[0].id, filePath);
 
   const add = await app.inject({
@@ -146,8 +158,12 @@ test('POST /files/:id/tags/manual + DELETE round-trips a tag', async () => {
     url: `/files/${file.id}/tags`,
     headers: { cookie }
   });
-  const tagsAfterAdd = (afterAdd.json() as { tags: Array<{ tag: string; source: string }> }).tags;
-  assert.ok(tagsAfterAdd.some((t) => t.tag === 'sunset' && t.source === 'MANUAL'));
+  const tagsAfterAdd = (
+    afterAdd.json() as { tags: Array<{ tag: string; source: string }> }
+  ).tags;
+  assert.ok(
+    tagsAfterAdd.some((t) => t.tag === 'sunset' && t.source === 'MANUAL')
+  );
 
   const remove = await app.inject({
     method: 'DELETE',
@@ -162,15 +178,24 @@ test('POST /files/:id/tags/manual + DELETE round-trips a tag', async () => {
     url: `/files/${file.id}/tags`,
     headers: { cookie }
   });
-  const tagsAfterRemove = (afterRemove.json() as { tags: Array<{ tag: string }> }).tags;
-  assert.equal(tagsAfterRemove.some((t) => t.tag === 'sunset'), false);
+  const tagsAfterRemove = (
+    afterRemove.json() as { tags: Array<{ tag: string }> }
+  ).tags;
+  assert.equal(
+    tagsAfterRemove.some((t) => t.tag === 'sunset'),
+    false
+  );
 });
 
 test('PUT /files/:id/favorite toggles isFavorite and persists across reads', async () => {
   const seeded = await seedUser({ username: 'files_fav_toggle' });
   const cookie = await cookieFor(seeded.user.id);
   const folders = await foldersRepo.listFolders(seeded.user.id);
-  const filePath = writeFixtureFile(folders[0].path, 'favable.png', Buffer.from('x'));
+  const filePath = writeFixtureFile(
+    folders[0].path,
+    'favable.png',
+    Buffer.from('x')
+  );
   const file = await registerFixtureFile(folders[0].id, filePath);
 
   const on = await app.inject({
@@ -194,7 +219,11 @@ test('PUT /files/:id/favorite rejects non-boolean payload with 400', async () =>
   const seeded = await seedUser({ username: 'files_fav_bad' });
   const cookie = await cookieFor(seeded.user.id);
   const folders = await foldersRepo.listFolders(seeded.user.id);
-  const filePath = writeFixtureFile(folders[0].path, 'tmp.png', Buffer.from('x'));
+  const filePath = writeFixtureFile(
+    folders[0].path,
+    'tmp.png',
+    Buffer.from('x')
+  );
   const file = await registerFixtureFile(folders[0].id, filePath);
   const res = await app.inject({
     method: 'PUT',
@@ -209,7 +238,11 @@ test('DELETE /files/:id removes the file from disk and DB', async () => {
   const seeded = await seedUser({ username: 'files_delete_ok' });
   const cookie = await cookieFor(seeded.user.id);
   const folders = await foldersRepo.listFolders(seeded.user.id);
-  const filePath = writeFixtureFile(folders[0].path, 'to-delete.png', ONE_BY_ONE_PNG);
+  const filePath = writeFixtureFile(
+    folders[0].path,
+    'to-delete.png',
+    ONE_BY_ONE_PNG
+  );
   const file = await registerFixtureFile(folders[0].id, filePath);
 
   assert.equal(fs.existsSync(filePath), true);
@@ -228,7 +261,11 @@ test('DELETE /files/:id removes every favorite mapping for the deleted path', as
   const seeded = await seedUser({ username: 'files_delete_all_favs' });
   const cookie = await cookieFor(seeded.user.id);
   const folders = await foldersRepo.listFolders(seeded.user.id);
-  const filePath = writeFixtureFile(folders[0].path, 'to-delete-favs.png', ONE_BY_ONE_PNG);
+  const filePath = writeFixtureFile(
+    folders[0].path,
+    'to-delete-favs.png',
+    ONE_BY_ONE_PNG
+  );
   const file = await registerFixtureFile(folders[0].id, filePath);
 
   await favoritesRepo.upsertFavoriteItem(
@@ -251,7 +288,11 @@ test('DELETE /files/:id removes every favorite mapping for the deleted path', as
     },
     seeded.user.id
   );
-  assert.equal((await favoritesRepo.listFavoriteItemsByPath(file.path, seeded.user.id)).length, 2);
+  assert.equal(
+    (await favoritesRepo.listFavoriteItemsByPath(file.path, seeded.user.id))
+      .length,
+    2
+  );
 
   const res = await app.inject({
     method: 'DELETE',
@@ -259,7 +300,11 @@ test('DELETE /files/:id removes every favorite mapping for the deleted path', as
     headers: { cookie }
   });
   assert.equal(res.statusCode, 200);
-  assert.equal((await favoritesRepo.listFavoriteItemsByPath(file.path, seeded.user.id)).length, 0);
+  assert.equal(
+    (await favoritesRepo.listFavoriteItemsByPath(file.path, seeded.user.id))
+      .length,
+    0
+  );
 });
 
 test('DELETE /files/:id reverse-syncs custom Gelbooru favorites', async (t) => {
@@ -282,7 +327,6 @@ test('DELETE /files/:id reverse-syncs custom Gelbooru favorites', async (t) => {
 
   const seeded = await seedUser({ username: 'files_delete_gelbooru_reverse' });
   const cookie = await cookieFor(seeded.user.id);
-  await favoritesRepo.saveFavoritesSettings({ reverseSyncEnabled: true }, seeded.user.id);
   const site = await booruSitesRepo.insertBooruSite(
     {
       name: 'Gelbooru',
@@ -295,12 +339,17 @@ test('DELETE /files/:id reverse-syncs custom Gelbooru favorites', async (t) => {
       capFavorites: true,
       capTags: true,
       capSourceMatch: true,
-      capSearch: true
+      capSearch: true,
+      siteReverseSyncEnabled: true
     },
     seeded.user.id
   );
   const folders = await foldersRepo.listFolders(seeded.user.id);
-  const filePath = writeFixtureFile(folders[0].path, 'gelbooru-fav.png', ONE_BY_ONE_PNG);
+  const filePath = writeFixtureFile(
+    folders[0].path,
+    'gelbooru-fav.png',
+    ONE_BY_ONE_PNG
+  );
   const file = await registerFixtureFile(folders[0].id, filePath);
   await favoritesRepo.upsertFavoriteItem(
     {
@@ -346,7 +395,6 @@ test('DELETE /files/:id reports Gelbooru unfavorite redirects', async (t) => {
 
   const seeded = await seedUser({ username: 'files_delete_rule34_redirect' });
   const cookie = await cookieFor(seeded.user.id);
-  await favoritesRepo.saveFavoritesSettings({ reverseSyncEnabled: true }, seeded.user.id);
   const site = await booruSitesRepo.insertBooruSite(
     {
       name: 'Rule34',
@@ -359,12 +407,17 @@ test('DELETE /files/:id reports Gelbooru unfavorite redirects', async (t) => {
       capFavorites: true,
       capTags: true,
       capSourceMatch: true,
-      capSearch: true
+      capSearch: true,
+      siteReverseSyncEnabled: true
     },
     seeded.user.id
   );
   const folders = await foldersRepo.listFolders(seeded.user.id);
-  const filePath = writeFixtureFile(folders[0].path, 'rule34-fav.png', ONE_BY_ONE_PNG);
+  const filePath = writeFixtureFile(
+    folders[0].path,
+    'rule34-fav.png',
+    ONE_BY_ONE_PNG
+  );
   const file = await registerFixtureFile(folders[0].id, filePath);
   await favoritesRepo.upsertFavoriteItem(
     {
@@ -418,7 +471,10 @@ test('POST /folders/:id/uploads returns 404 for an unknown folder id', async () 
   const res = await app.inject({
     method: 'POST',
     url: '/folders/no-such-folder/uploads',
-    headers: { cookie: await cookieFor(seeded.user.id), 'content-type': 'multipart/form-data; boundary=----X' },
+    headers: {
+      cookie: await cookieFor(seeded.user.id),
+      'content-type': 'multipart/form-data; boundary=----X'
+    },
     payload: '------X--\r\n'
   });
   assert.equal(res.statusCode, 404);
@@ -430,7 +486,11 @@ test('GET /files/:id/content?download=1 sets Content-Disposition attachment', as
   const seeded = await seedUser({ username: 'files_download_attachment' });
   const cookie = await cookieFor(seeded.user.id);
   const folders = await foldersRepo.listFolders(seeded.user.id);
-  const filePath = writeFixtureFile(folders[0].path, 'pic.png', Buffer.from('payload'));
+  const filePath = writeFixtureFile(
+    folders[0].path,
+    'pic.png',
+    Buffer.from('payload')
+  );
   const file = await registerFixtureFile(folders[0].id, filePath);
   const res = await app.inject({
     method: 'GET',
@@ -439,7 +499,10 @@ test('GET /files/:id/content?download=1 sets Content-Disposition attachment', as
   });
   assert.equal(res.statusCode, 200);
   // path also asserts non-leak (filename encoded, no traversal).
-  assert.match(String(res.headers['content-disposition']), /^attachment; filename="pic\.png"/);
+  assert.match(
+    String(res.headers['content-disposition']),
+    /^attachment; filename="pic\.png"/
+  );
 });
 
 // Cleanup path probed: use a path that we know exists under the seeded
@@ -448,7 +511,11 @@ test('GET /files filters by mediaType=IMAGE', async () => {
   const seeded = await seedUser({ username: 'files_media_filter' });
   const cookie = await cookieFor(seeded.user.id);
   const folders = await foldersRepo.listFolders(seeded.user.id);
-  const filePath = writeFixtureFile(folders[0].path, 'still.png', Buffer.from('x'));
+  const filePath = writeFixtureFile(
+    folders[0].path,
+    'still.png',
+    Buffer.from('x')
+  );
   await registerFixtureFile(folders[0].id, filePath, { mediaType: 'IMAGE' });
   // No video, so VIDEO filter should be empty.
   const videoRes = await app.inject({

--- a/backend/test/migrate.test.ts
+++ b/backend/test/migrate.test.ts
@@ -26,7 +26,9 @@ const runMigrate = (dataFile: string) =>
 
 const listTables = (db: BetterSqlite3.Database) =>
   db
-    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+    )
     .all() as Array<{ name: string }>;
 
 test('migrate command bootstraps empty database with gooncave schema', () => {
@@ -37,7 +39,10 @@ test('migrate command bootstraps empty database with gooncave schema', () => {
   const result = runMigrate(dataFile);
 
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.ok(fs.existsSync(dataFile), 'migrate command should create sqlite file');
+  assert.ok(
+    fs.existsSync(dataFile),
+    'migrate command should create sqlite file'
+  );
 
   const db = new BetterSqlite3(dataFile, { readonly: true });
   const tables = new Set(listTables(db).map((row) => row.name));
@@ -69,10 +74,12 @@ test('migrate command upgrades legacy database without dropping existing rows', 
     );
   `);
   legacyDb
-    .prepare(`
+    .prepare(
+      `
       INSERT INTO users (id, username, password_hash, library_root, created_at, updated_at, last_login_at)
       VALUES (?, ?, ?, ?, ?, ?, ?)
-    `)
+    `
+    )
     .run(
       'user-1',
       'legacy-user',
@@ -90,7 +97,9 @@ test('migrate command upgrades legacy database without dropping existing rows', 
   const db = new BetterSqlite3(dataFile, { readonly: true });
   const user = db
     .prepare('SELECT id, username, library_root FROM users WHERE id = ?')
-    .get('user-1') as { id: string; username: string; library_root: string } | undefined;
+    .get('user-1') as
+    | { id: string; username: string; library_root: string }
+    | undefined;
   const tables = new Set(listTables(db).map((row) => row.name));
   db.close();
 
@@ -120,13 +129,85 @@ test('migrate command upgrades legacy drizzle metadata to checksum + name withou
       updated_at TEXT NOT NULL,
       last_login_at TEXT
     );
+    CREATE TABLE user_settings (
+      user_id TEXT NOT NULL,
+      key TEXT NOT NULL,
+      value TEXT NOT NULL,
+      PRIMARY KEY (user_id, key)
+    );
+    CREATE TABLE user_booru_sites (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      engine TEXT NOT NULL,
+      base_url TEXT NOT NULL,
+      username TEXT,
+      api_key TEXT,
+      is_preset INTEGER NOT NULL,
+      preset_key TEXT,
+      enabled INTEGER NOT NULL,
+      cap_favorites INTEGER NOT NULL,
+      cap_tags INTEGER NOT NULL,
+      cap_source_match INTEGER NOT NULL,
+      cap_search INTEGER NOT NULL,
+      sort_order INTEGER NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
     CREATE TABLE __drizzle_migrations (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       hash TEXT NOT NULL UNIQUE,
       created_at INTEGER NOT NULL
     );
   `);
-  db.prepare('INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)').run('0000_initial.sql', Date.now());
+  db.prepare(
+    `INSERT INTO users (id, username, password_hash, library_root, created_at, updated_at, last_login_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    'user-legacy',
+    'legacy',
+    'hash',
+    '/tmp/library',
+    '2026-01-01T00:00:00.000Z',
+    '2026-01-01T00:00:00.000Z',
+    null
+  );
+  db.prepare(
+    `INSERT INTO user_booru_sites
+      (id, user_id, name, engine, base_url, username, api_key, is_preset, preset_key,
+       enabled, cap_favorites, cap_tags, cap_source_match, cap_search, sort_order, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    'site-legacy',
+    'user-legacy',
+    'Legacy Site',
+    'e621',
+    'https://e621.net',
+    'legacy-user',
+    'legacy-key',
+    1,
+    'E621',
+    1,
+    1,
+    1,
+    1,
+    1,
+    0,
+    '2026-01-01T00:00:00.000Z',
+    '2026-01-01T00:00:00.000Z'
+  );
+  db.prepare(
+    'INSERT INTO user_settings (user_id, key, value) VALUES (?, ?, ?)'
+  ).run('user-legacy', 'favorites_auto_sync_midnight', 'false');
+  db.prepare(
+    'INSERT INTO user_settings (user_id, key, value) VALUES (?, ?, ?)'
+  ).run('user-legacy', 'favorites_reverse_sync', 'true');
+  db.prepare(
+    'INSERT INTO user_settings (user_id, key, value) VALUES (?, ?, ?)'
+  ).run('user-legacy', 'favorites_auto_fav', 'true');
+  db.prepare(
+    'INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)'
+  ).run('0000_initial.sql', Date.now());
   db.close();
 
   const result = runMigrate(dataFile);
@@ -134,13 +215,35 @@ test('migrate command upgrades legacy drizzle metadata to checksum + name withou
 
   const migratedDb = new BetterSqlite3(dataFile, { readonly: true });
   const row = migratedDb
-    .prepare('SELECT hash, name FROM __drizzle_migrations ORDER BY id ASC LIMIT 1')
+    .prepare(
+      'SELECT hash, name FROM __drizzle_migrations ORDER BY id ASC LIMIT 1'
+    )
     .get() as { hash: string; name: string } | undefined;
-  const count = migratedDb.prepare('SELECT COUNT(*) AS count FROM __drizzle_migrations').get() as { count: number };
+  const siteFlags = migratedDb
+    .prepare(
+      `SELECT site_auto_sync_midnight, site_reverse_sync_enabled, site_auto_fav_enabled
+       FROM user_booru_sites
+       WHERE id = ?`
+    )
+    .get('site-legacy') as
+    | {
+        site_auto_sync_midnight: number;
+        site_reverse_sync_enabled: number;
+        site_auto_fav_enabled: number;
+      }
+    | undefined;
+  const count = migratedDb
+    .prepare('SELECT COUNT(*) AS count FROM __drizzle_migrations')
+    .get() as { count: number };
   migratedDb.close();
 
   assert.ok(row);
   assert.equal(row?.name, '0000_initial.sql');
   assert.notEqual(row?.hash, '0000_initial.sql');
-  assert.equal(count.count, 1);
+  assert.deepEqual(siteFlags, {
+    site_auto_sync_midnight: 0,
+    site_reverse_sync_enabled: 1,
+    site_auto_fav_enabled: 1
+  });
+  assert.equal(count.count, 2);
 });

--- a/backend/test/runtime-entrypoints.test.ts
+++ b/backend/test/runtime-entrypoints.test.ts
@@ -48,19 +48,51 @@ const runBuiltWorkerBoot = (dataFile: string) =>
     encoding: 'utf8'
   });
 
+const runBuiltApiBoot = (dataFile: string) =>
+  spawnSync('node', ['dist/index.js'], {
+    cwd: backendRoot,
+    env: {
+      ...process.env,
+      DATA_FILE: dataFile,
+      NODE_ENV: 'test',
+      HOST: '127.0.0.1',
+      PORT: '0',
+      FRONTEND_DIR: '',
+      TAGGER_URL: '',
+      FAVORITES_SYNC_INTERVAL_HOURS: '0',
+      LOCAL_RESCAN_INTERVAL_MINUTES: '0',
+      WD14_BACKFILL_INTERVAL_HOURS: '0',
+      API_EXIT_AFTER_BOOT: 'true'
+    },
+    encoding: 'utf8'
+  });
+
 test('build copies SQL migrations into dist for runtime migrate command', () => {
   const buildResult = runBuild();
   assert.equal(buildResult.status, 0, buildResult.stderr || buildResult.stdout);
 
-  const sqlPath = path.join(backendRoot, 'dist', 'db', 'migrations', '0000_initial.sql');
-  assert.ok(fs.existsSync(sqlPath), 'build should copy SQL migrations into dist/db/migrations');
+  const sqlPath = path.join(
+    backendRoot,
+    'dist',
+    'db',
+    'migrations',
+    '0000_initial.sql'
+  );
+  assert.ok(
+    fs.existsSync(sqlPath),
+    'build should copy SQL migrations into dist/db/migrations'
+  );
 
   const tmpRoot = process.env.GOONCAVE_TEST_TMP_ROOT;
   assert.ok(tmpRoot, 'GOONCAVE_TEST_TMP_ROOT must be set by setupEnv');
 
   const dataFile = path.join(tmpRoot, 'runtime-built-migrate.sqlite');
   const migrateResult = runBuiltMigrate(dataFile);
-  assert.equal(migrateResult.status, 0, migrateResult.stderr || migrateResult.stdout);
+  assert.equal(
+    migrateResult.status,
+    0,
+    migrateResult.stderr || migrateResult.stdout
+  );
 });
 
 test('built worker boot migrates schema before startup queries run', () => {
@@ -72,17 +104,61 @@ test('built worker boot migrates schema before startup queries run', () => {
 
   const dataFile = path.join(tmpRoot, 'runtime-worker-boot.sqlite');
   const workerResult = runBuiltWorkerBoot(dataFile);
-  assert.equal(workerResult.status, 0, workerResult.stderr || workerResult.stdout);
+  assert.equal(
+    workerResult.status,
+    0,
+    workerResult.stderr || workerResult.stdout
+  );
 
   const db = new BetterSqlite3(dataFile, { readonly: true });
   const scansTable = db
-    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'scans'")
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'scans'"
+    )
     .get() as { name: string } | undefined;
   const usersTable = db
-    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'users'")
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'users'"
+    )
     .get() as { name: string } | undefined;
   db.close();
 
   assert.equal(scansTable?.name, 'scans');
   assert.equal(usersTable?.name, 'users');
+});
+
+test('built api boot migrates schema before startup queries run', () => {
+  const buildResult = runBuild();
+  assert.equal(buildResult.status, 0, buildResult.stderr || buildResult.stdout);
+
+  const tmpRoot = process.env.GOONCAVE_TEST_TMP_ROOT;
+  assert.ok(tmpRoot, 'GOONCAVE_TEST_TMP_ROOT must be set by setupEnv');
+
+  const dataFile = path.join(tmpRoot, 'runtime-api-boot.sqlite');
+  const apiResult = runBuiltApiBoot(dataFile);
+  assert.equal(apiResult.status, 0, apiResult.stderr || apiResult.stdout);
+
+  const db = new BetterSqlite3(dataFile, { readonly: true });
+  const siteFlags = db
+    .prepare(
+      `SELECT name
+       FROM pragma_table_info('user_booru_sites')
+       WHERE name IN (
+         'site_auto_sync_midnight',
+         'site_reverse_sync_enabled',
+         'site_auto_fav_enabled'
+       )
+       ORDER BY name ASC`
+    )
+    .all() as Array<{ name: string }>;
+  db.close();
+
+  assert.deepEqual(
+    siteFlags.map((row) => row.name),
+    [
+      'site_auto_fav_enabled',
+      'site_auto_sync_midnight',
+      'site_reverse_sync_enabled'
+    ]
+  );
 });

--- a/frontend/src/BooruSitesPanel.tsx
+++ b/frontend/src/BooruSitesPanel.tsx
@@ -1,15 +1,16 @@
 import { useCallback, useState } from 'react';
 
-import {
-  type BooruCredentialSchema,
-  type BooruEngineType,
-  type BooruSite
-} from './api';
+import { type BooruCredentialSchema, type BooruSite } from './api';
 
+import { BooruSiteCredentialForm } from '@/features/booru-sites/BooruSiteCredentialForm';
+import { AddBooruSiteForm } from '@/features/booru-sites/BooruSiteForms';
 import {
-  AddBooruSiteForm,
-  BooruSiteCredentialForm
-} from '@/features/booru-sites/BooruSiteForms';
+  CAPABILITY_HELP_TEXT,
+  SITE_SETTING_HELP_TEXT,
+  SITE_SETTING_LABELS,
+  SUGGESTION_PRESETS,
+  type SiteSettingKey
+} from '@/features/booru-sites/BooruSitesPanelText';
 import {
   CAPABILITY_LABELS,
   type CapabilityKey,
@@ -36,67 +37,6 @@ type Props = {
    */
   devOptions: boolean;
   showSuggestions?: boolean;
-};
-
-type SiteSettingKey =
-  | 'siteAutoSyncMidnight'
-  | 'siteReverseSyncEnabled'
-  | 'siteAutoFavEnabled';
-
-type SuggestionPreset = {
-  key: string;
-  name: string;
-  engine: BooruEngineType;
-  baseUrl: string;
-  iconLabel: string;
-};
-
-const SUGGESTION_PRESETS: SuggestionPreset[] = [
-  {
-    key: 'E621',
-    name: 'e621',
-    engine: 'e621',
-    baseUrl: 'https://e621.net',
-    iconLabel: 'E6'
-  },
-  {
-    key: 'DANBOORU',
-    name: 'Danbooru',
-    engine: 'danbooru',
-    baseUrl: 'https://danbooru.donmai.us',
-    iconLabel: 'DB'
-  },
-  {
-    key: 'RULE34',
-    name: 'Rule34',
-    engine: 'gelbooru',
-    baseUrl: 'https://rule34.xxx',
-    iconLabel: 'R34'
-  }
-];
-
-const CAPABILITY_HELP_TEXT: Record<CapabilityKey, string> = {
-  capFavorites:
-    'Match your local files to your favorites here: new favorites are downloaded, and files you unfavorited are deleted locally. Works when pressing the Sync favorites button, or at midnight if "Daily midnight sync" is enabled.',
-  capTags:
-    'Copy the tags a post has on this site onto your matching local file, so you can search and filter by them.',
-  capSourceMatch:
-    'Use the source link saved on a local file to find the same post on this site and connect the two.'
-};
-
-const SITE_SETTING_LABELS: Record<SiteSettingKey, string> = {
-  siteAutoSyncMidnight: 'Daily midnight sync',
-  siteReverseSyncEnabled: 'Delete locally also unfavorites remotely',
-  siteAutoFavEnabled: 'Auto-favorite source matches'
-};
-
-const SITE_SETTING_HELP_TEXT: Record<SiteSettingKey, string> = {
-  siteAutoSyncMidnight:
-    'Every night at midnight, sync favorites with this site automatically, so you never have to press Sync yourself.',
-  siteReverseSyncEnabled:
-    'When you delete a file in the app, also remove it from your favorites on this site.',
-  siteAutoFavEnabled:
-    'When the scanner finds one of your files on this site, automatically add that post to your favorites there.'
 };
 
 export const BooruSitesPanel = ({

--- a/frontend/src/BooruSitesPanel.tsx
+++ b/frontend/src/BooruSitesPanel.tsx
@@ -1,5 +1,21 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
+import {
+  type BooruCredentialSchema,
+  type BooruEngineType,
+  type BooruSite
+} from './api';
+
+import {
+  AddBooruSiteForm,
+  BooruSiteCredentialForm
+} from '@/features/booru-sites/BooruSiteForms';
+import {
+  CAPABILITY_LABELS,
+  type CapabilityKey,
+  ENGINE_LABELS,
+  credentialFieldsForSchema
+} from '@/features/booru-sites/shared';
 import {
   useBooruEngineCatalog,
   useBooruSites,
@@ -11,19 +27,6 @@ import {
   useUpdateBooruSite
 } from '@/hooks/booru-sites';
 
-import {
-  type BooruCredentialSchema,
-  type BooruEngineCatalog,
-  type BooruSite
-} from './api';
-import { AddBooruSiteForm, BooruSiteCredentialForm } from '@/features/booru-sites/BooruSiteForms';
-import {
-  CAPABILITY_LABELS,
-  type CapabilityKey,
-  ENGINE_LABELS,
-  credentialFieldsForSchema,
-} from '@/features/booru-sites/shared';
-
 type Props = {
   className?: string;
   /**
@@ -32,9 +35,75 @@ type Props = {
    * — the happy-path detection badge is enough for normal users.
    */
   devOptions: boolean;
+  showSuggestions?: boolean;
 };
 
-export const BooruSitesPanel = ({ className, devOptions }: Props) => {
+type SiteSettingKey =
+  | 'siteAutoSyncMidnight'
+  | 'siteReverseSyncEnabled'
+  | 'siteAutoFavEnabled';
+
+type SuggestionPreset = {
+  key: string;
+  name: string;
+  engine: BooruEngineType;
+  baseUrl: string;
+  iconLabel: string;
+};
+
+const SUGGESTION_PRESETS: SuggestionPreset[] = [
+  {
+    key: 'E621',
+    name: 'e621',
+    engine: 'e621',
+    baseUrl: 'https://e621.net',
+    iconLabel: 'E6'
+  },
+  {
+    key: 'DANBOORU',
+    name: 'Danbooru',
+    engine: 'danbooru',
+    baseUrl: 'https://danbooru.donmai.us',
+    iconLabel: 'DB'
+  },
+  {
+    key: 'RULE34',
+    name: 'Rule34',
+    engine: 'gelbooru',
+    baseUrl: 'https://rule34.xxx',
+    iconLabel: 'R34'
+  }
+];
+
+const CAPABILITY_HELP_TEXT: Record<CapabilityKey, string> = {
+  capFavorites:
+    'Match your local files to your favorites here: new favorites are downloaded, and files you unfavorited are deleted locally. Works when pressing the Sync favorites button, or at midnight if "Daily midnight sync" is enabled.',
+  capTags:
+    'Copy the tags a post has on this site onto your matching local file, so you can search and filter by them.',
+  capSourceMatch:
+    'Use the source link saved on a local file to find the same post on this site and connect the two.'
+};
+
+const SITE_SETTING_LABELS: Record<SiteSettingKey, string> = {
+  siteAutoSyncMidnight: 'Daily midnight sync',
+  siteReverseSyncEnabled: 'Delete locally also unfavorites remotely',
+  siteAutoFavEnabled: 'Auto-favorite source matches'
+};
+
+const SITE_SETTING_HELP_TEXT: Record<SiteSettingKey, string> = {
+  siteAutoSyncMidnight:
+    'Every night at midnight, sync favorites with this site automatically, so you never have to press Sync yourself.',
+  siteReverseSyncEnabled:
+    'When you delete a file in the app, also remove it from your favorites on this site.',
+  siteAutoFavEnabled:
+    'When the scanner finds one of your files on this site, automatically add that post to your favorites there.'
+};
+
+export const BooruSitesPanel = ({
+  className,
+  devOptions,
+  showSuggestions = false
+}: Props) => {
   const sitesQuery = useBooruSites();
   const catalogQuery = useBooruEngineCatalog();
   const sites = sitesQuery.data ?? [];
@@ -53,14 +122,27 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
     (catalogQuery.error as Error | null)?.message ??
     null;
   const [testingId, setTestingId] = useState<string | null>(null);
-  const [testResults, setTestResults] = useState<Record<string, { ok: boolean; message: string }>>({});
+  const [testResults, setTestResults] = useState<
+    Record<string, { ok: boolean; message: string }>
+  >({});
+  const [formPrefill, setFormPrefill] = useState<{
+    name: string;
+    baseUrl: string;
+    engine: BooruEngineType;
+    credentialSchema: BooruCredentialSchema;
+  } | null>(null);
+  const [showAddSiteForm, setShowAddSiteForm] = useState(!showSuggestions);
+  const [addFormInstance, setAddFormInstance] = useState(0);
 
   const reload = async () => {
     setLocalError(null);
     await Promise.all([sitesQuery.refetch(), catalogQuery.refetch()]);
   };
 
-  const toggleCapability = async (site: BooruSite, capability: CapabilityKey) => {
+  const toggleCapability = async (
+    site: BooruSite,
+    capability: CapabilityKey
+  ) => {
     try {
       await updateSiteMutation.mutateAsync({
         id: site.id,
@@ -82,9 +164,20 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
     }
   };
 
+  const toggleSiteSetting = async (site: BooruSite, key: SiteSettingKey) => {
+    try {
+      await updateSiteMutation.mutateAsync({
+        id: site.id,
+        payload: { [key]: !site[key] }
+      });
+    } catch (err) {
+      setLocalError((err as Error).message);
+    }
+  };
+
   const saveCredentials = async (
     site: BooruSite,
-    payload: { username: string | null; apiKey: string | null },
+    payload: { username: string | null; apiKey: string | null }
   ) => {
     try {
       return await updateSiteMutation.mutateAsync({ id: site.id, payload });
@@ -111,7 +204,9 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
         ...prev,
         [site.id]: {
           ok: res.ok,
-          message: res.ok ? `OK (HTTP ${res.status ?? '200'})` : res.error ?? `HTTP ${res.status ?? '?'}`
+          message: res.ok
+            ? `OK (HTTP ${res.status ?? '200'})`
+            : (res.error ?? `HTTP ${res.status ?? '?'}`)
         }
       }));
     } catch (err) {
@@ -130,7 +225,10 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
     const targetIdx = idx + direction;
     if (targetIdx < 0 || targetIdx >= sorted.length) return;
     const reordered = [...sorted];
-    [reordered[idx], reordered[targetIdx]] = [reordered[targetIdx], reordered[idx]];
+    [reordered[idx], reordered[targetIdx]] = [
+      reordered[targetIdx],
+      reordered[idx]
+    ];
     try {
       await reorderSitesMutation.mutateAsync(reordered.map((s) => s.id));
     } catch (err) {
@@ -139,141 +237,320 @@ export const BooruSitesPanel = ({ className, devOptions }: Props) => {
   };
 
   const credentialSchemaFor = (site: BooruSite) =>
-    catalog?.engines.find((entry) => entry.type === site.engine)?.credentialSchema ?? 'none';
+    catalog?.engines.find((entry) => entry.type === site.engine)
+      ?.credentialSchema ?? 'none';
+  const detectBooru = useCallback(
+    (baseUrl: string) => detectEngineMutation.mutateAsync(baseUrl),
+    [detectEngineMutation]
+  );
+  const renderToggleLabel = (id: string, text: string, helpText: string) => (
+    <label
+      className="form-check-label text-muted-foreground text-sm favorites-switch-label-wrap"
+      htmlFor={id}
+    >
+      {text}
+      <span
+        className="favorites-help-dot"
+        title={helpText}
+        aria-label={helpText}
+      >
+        ?
+      </span>
+    </label>
+  );
 
   if (loading) return <div className={className}>Loading booru sites…</div>;
+
+  const suggestionCards = SUGGESTION_PRESETS.filter((preset) =>
+    catalog?.presets.some((existingPreset) => existingPreset.key === preset.key)
+  );
 
   return (
     <div className={className}>
       {error ? (
         <div className="alert alert-danger" role="alert">
           {error}
-          <button type="button" className="btn btn-sm btn-link" onClick={() => setLocalError(null)}>
+          <button
+            type="button"
+            className="btn btn-sm btn-link"
+            onClick={() => setLocalError(null)}
+          >
             dismiss
           </button>
         </div>
       ) : null}
 
-      <h5 className="mt-4 text-foreground">Configured booru sources</h5>
-      {sites.length === 0 ? (
-        <p className="text-muted-foreground text-sm">No sites configured. Add one below to enable favorites sync and tag fetch.</p>
-      ) : (
-        <div className="mb-6 flex flex-col gap-2">
-          {[...sites]
-            .sort((a, b) => a.sortOrder - b.sortOrder)
-            .map((site) => {
-              const schema = credentialSchemaFor(site);
-              const fields = credentialFieldsForSchema(schema);
-              const test = testResults[site.id];
-              return (
-                <div key={site.id} className="border border-secondary rounded p-2 text-foreground">
-                  <div className="flex items-center gap-2">
-                    <div className="grow">
-                      <strong>{site.name}</strong>{' '}
-                      <span className="text-muted-foreground text-sm">
-                        {ENGINE_LABELS[site.engine]} · {site.baseUrl}
-                        {site.isPreset ? ' · preset' : ''}
-                      </span>
-                    </div>
-                    <button
-                      type="button"
-                      className="btn btn-sm btn-outline-light"
-                      onClick={() => moveSite(site, -1)}
-                      title="Move up"
-                    >
-                      ↑
-                    </button>
-                    <button
-                      type="button"
-                      className="btn btn-sm btn-outline-light"
-                      onClick={() => moveSite(site, 1)}
-                      title="Move down"
-                    >
-                      ↓
-                    </button>
-                    <div className="form-check form-switch m-0">
-                      <input
-                        className="form-check-input"
-                        type="checkbox"
-                        id={`enabled-${site.id}`}
-                        checked={site.enabled}
-                        onChange={() => toggleEnabled(site)}
-                      />
-                      <label className="form-check-label text-muted-foreground text-sm" htmlFor={`enabled-${site.id}`}>
-                        enabled
-                      </label>
-                    </div>
-                  </div>
+      {showSuggestions ? (
+        <div className="mb-0">
+          <h5 className="text-foreground mb-3">Suggestions</h5>
+          <div className="favorites-suggestions-grid">
+            {suggestionCards.map((preset) => (
+              <button
+                key={preset.key}
+                type="button"
+                className="favorites-suggestion-card"
+                onClick={() => {
+                  const schema =
+                    catalog?.engines.find(
+                      (entry) => entry.type === preset.engine
+                    )?.credentialSchema ?? 'none';
+                  setFormPrefill({
+                    name: preset.name,
+                    baseUrl: preset.baseUrl,
+                    engine: preset.engine,
+                    credentialSchema: schema
+                  });
+                  setShowAddSiteForm(true);
+                }}
+              >
+                <span className="favorites-suggestion-icon" aria-hidden="true">
+                  {preset.iconLabel}
+                </span>
+                <span className="favorites-suggestion-name">{preset.name}</span>
+              </button>
+            ))}
+            <button
+              type="button"
+              className="favorites-suggestion-card"
+              onClick={() => {
+                setFormPrefill(null);
+                setShowAddSiteForm(true);
+                setAddFormInstance((current) => current + 1);
+              }}
+            >
+              <span className="favorites-suggestion-icon" aria-hidden="true">
+                +
+              </span>
+              <span className="favorites-suggestion-name">New site</span>
+            </button>
+          </div>
+          {showAddSiteForm ? (
+            <div className="mt-4">
+              <h5 className="text-foreground">Add custom booru site</h5>
+              <AddBooruSiteForm
+                key={`add-site-form-${addFormInstance}`}
+                devOptions={devOptions}
+                prefill={formPrefill}
+                onDetect={detectBooru}
+                onCreate={async (payload) => {
+                  await createSiteMutation.mutateAsync(payload);
+                  setFormPrefill(null);
+                  setAddFormInstance((current) => current + 1);
+                  setShowAddSiteForm(false);
+                  await reload();
+                }}
+              />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
 
-                  <div className="row g-2 mt-2">
-                    {(Object.keys(CAPABILITY_LABELS) as CapabilityKey[]).map((cap) => (
-                      <div key={cap} className="col-6 col-md-3">
-                        <div className="form-check">
-                          <input
-                            className="form-check-input"
-                            type="checkbox"
-                            id={`${site.id}-${cap}`}
-                            checked={site[cap]}
-                            onChange={() => toggleCapability(site, cap)}
-                          />
-                          <label className="form-check-label text-muted-foreground text-sm" htmlFor={`${site.id}-${cap}`}>
-                            {CAPABILITY_LABELS[cap]}
-                          </label>
-                        </div>
+      <div>
+        <hr className="favorites-configured-divider" />
+        <h5 className="text-foreground m-0">Configured sites</h5>
+        {sites.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            No sites configured. Add one below to enable favorites sync and tag
+            fetch.
+          </p>
+        ) : (
+          <div className="mt-3 mb-6 flex flex-col gap-3">
+            {[...sites]
+              .sort((a, b) => a.sortOrder - b.sortOrder)
+              .map((site) => {
+                const schema = credentialSchemaFor(site);
+                const fields = credentialFieldsForSchema(schema);
+                const test = testResults[site.id];
+                return (
+                  <div
+                    key={site.id}
+                    className="border border-secondary rounded p-4 text-foreground"
+                  >
+                    <div className="flex items-center gap-2">
+                      <div className="grow">
+                        <strong>{site.name}</strong>{' '}
+                        <span className="text-muted-foreground text-sm">
+                          {ENGINE_LABELS[site.engine]} · {site.baseUrl}
+                          {site.isPreset ? ' · preset' : ''}
+                        </span>
                       </div>
-                    ))}
-                  </div>
-
-                  {(fields.username || fields.apiKey) ? (
-                    <BooruSiteCredentialForm
-                      site={site}
-                      schema={schema}
-                      loading={updateSiteMutation.isPending}
-                      testing={testingId === site.id}
-                      onSave={(payload) => saveCredentials(site, payload)}
-                      onTest={() => testSite(site)}
-                    />
-                  ) : (
-                    <div className="mt-2">
                       <button
                         type="button"
                         className="btn btn-sm btn-outline-light"
-                        onClick={() => testSite(site)}
-                        disabled={testingId === site.id}
+                        onClick={() => moveSite(site, -1)}
+                        title="Move up"
                       >
-                        {testingId === site.id ? 'Testing…' : 'Test connection'}
+                        ↑
                       </button>
-                    </div>
-                  )}
-
-                  {test ? (
-                    <div className={`text-sm mt-2 ${test.ok ? 'text-success' : 'text-destructive'}`}>
-                      {test.ok ? '✓ ' : '✗ '} {test.message}
-                    </div>
-                  ) : null}
-
-                  {!site.isPreset ? (
-                    <div className="mt-2">
-                      <button type="button" className="btn btn-sm btn-link text-destructive" onClick={() => deleteSite(site)}>
-                        Delete site
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-light"
+                        onClick={() => moveSite(site, 1)}
+                        title="Move down"
+                      >
+                        ↓
                       </button>
+                      <div className="form-check form-switch favorites-site-switch favorites-site-switch--tight m-0">
+                        <input
+                          className="form-check-input"
+                          type="checkbox"
+                          id={`enabled-${site.id}`}
+                          checked={site.enabled}
+                          onChange={() => toggleEnabled(site)}
+                        />
+                        <label
+                          className="form-check-label text-muted-foreground text-sm"
+                          htmlFor={`enabled-${site.id}`}
+                        >
+                          enabled
+                        </label>
+                      </div>
                     </div>
-                  ) : null}
-                </div>
-              );
-            })}
-        </div>
-      )}
 
-      <h5 className="mt-6 text-foreground">Add custom booru site</h5>
-      <AddBooruSiteForm
-        devOptions={devOptions}
-        onDetect={(baseUrl) => detectEngineMutation.mutateAsync(baseUrl)}
-        onCreate={async (payload) => {
-          await createSiteMutation.mutateAsync(payload);
-          await reload();
-        }}
-      />
+                    <div className="favorites-site-toggle-grid mt-2">
+                      {(Object.keys(CAPABILITY_LABELS) as CapabilityKey[]).map(
+                        (cap) => (
+                          <div key={cap} className="favorites-site-toggle-col">
+                            <div className="form-check form-switch favorites-site-switch">
+                              <input
+                                className="form-check-input"
+                                type="checkbox"
+                                id={`${site.id}-${cap}`}
+                                checked={site[cap]}
+                                onChange={() => toggleCapability(site, cap)}
+                              />
+                              {renderToggleLabel(
+                                `${site.id}-${cap}`,
+                                CAPABILITY_LABELS[cap],
+                                CAPABILITY_HELP_TEXT[cap]
+                              )}
+                            </div>
+                          </div>
+                        )
+                      )}
+                      <div className="favorites-site-toggle-col">
+                        <div className="form-check form-switch favorites-site-switch">
+                          <input
+                            className="form-check-input"
+                            type="checkbox"
+                            id={`${site.id}-site-auto-sync-midnight`}
+                            checked={site.siteAutoSyncMidnight}
+                            onChange={() =>
+                              void toggleSiteSetting(
+                                site,
+                                'siteAutoSyncMidnight'
+                              )
+                            }
+                          />
+                          {renderToggleLabel(
+                            `${site.id}-site-auto-sync-midnight`,
+                            SITE_SETTING_LABELS.siteAutoSyncMidnight,
+                            SITE_SETTING_HELP_TEXT.siteAutoSyncMidnight
+                          )}
+                        </div>
+                      </div>
+                      <div className="favorites-site-toggle-col">
+                        <div className="form-check form-switch favorites-site-switch">
+                          <input
+                            className="form-check-input"
+                            type="checkbox"
+                            id={`${site.id}-site-reverse-sync-enabled`}
+                            checked={site.siteReverseSyncEnabled}
+                            onChange={() =>
+                              void toggleSiteSetting(
+                                site,
+                                'siteReverseSyncEnabled'
+                              )
+                            }
+                          />
+                          {renderToggleLabel(
+                            `${site.id}-site-reverse-sync-enabled`,
+                            SITE_SETTING_LABELS.siteReverseSyncEnabled,
+                            SITE_SETTING_HELP_TEXT.siteReverseSyncEnabled
+                          )}
+                        </div>
+                      </div>
+                      <div className="favorites-site-toggle-col">
+                        <div className="form-check form-switch favorites-site-switch">
+                          <input
+                            className="form-check-input"
+                            type="checkbox"
+                            id={`${site.id}-site-auto-fav-enabled`}
+                            checked={site.siteAutoFavEnabled}
+                            onChange={() =>
+                              void toggleSiteSetting(site, 'siteAutoFavEnabled')
+                            }
+                          />
+                          {renderToggleLabel(
+                            `${site.id}-site-auto-fav-enabled`,
+                            SITE_SETTING_LABELS.siteAutoFavEnabled,
+                            SITE_SETTING_HELP_TEXT.siteAutoFavEnabled
+                          )}
+                        </div>
+                      </div>
+                    </div>
+
+                    {fields.username || fields.apiKey ? (
+                      <BooruSiteCredentialForm
+                        site={site}
+                        schema={schema}
+                        loading={updateSiteMutation.isPending}
+                        testing={testingId === site.id}
+                        onSave={(payload) => saveCredentials(site, payload)}
+                        onTest={() => testSite(site)}
+                        onDelete={() => void deleteSite(site)}
+                      />
+                    ) : (
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-outline-light shrink-0 whitespace-nowrap"
+                          onClick={() => testSite(site)}
+                          disabled={testingId === site.id}
+                        >
+                          {testingId === site.id
+                            ? 'Testing…'
+                            : 'Test connection'}
+                        </button>
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-outline-danger shrink-0 whitespace-nowrap"
+                          onClick={() => void deleteSite(site)}
+                        >
+                          Delete site
+                        </button>
+                      </div>
+                    )}
+
+                    {test ? (
+                      <div
+                        className={`text-sm mt-2 ${test.ok ? 'text-success' : 'text-destructive'}`}
+                      >
+                        {test.ok ? '✓ ' : '✗ '} {test.message}
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })}
+          </div>
+        )}
+      </div>
+
+      {!showSuggestions ? (
+        <>
+          <h5 className="mt-6 text-foreground">Add custom booru site</h5>
+          <AddBooruSiteForm
+            devOptions={devOptions}
+            prefill={formPrefill}
+            onDetect={detectBooru}
+            onCreate={async (payload) => {
+              await createSiteMutation.mutateAsync(payload);
+              setFormPrefill(null);
+              await reload();
+            }}
+          />
+        </>
+      ) : null}
     </div>
   );
 };

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -39,7 +39,6 @@ export type Folder = {
   status: 'IDLE' | 'SCANNING';
 };
 
-
 export type FileItem = {
   id: string;
   folderId: string;
@@ -198,6 +197,9 @@ export type BooruSite = {
   capTags: boolean;
   capSourceMatch: boolean;
   capSearch: boolean;
+  siteAutoSyncMidnight: boolean;
+  siteReverseSyncEnabled: boolean;
+  siteAutoFavEnabled: boolean;
   sortOrder: number;
   createdAt: string;
   updatedAt: string;
@@ -229,35 +231,73 @@ export type BooruDetectionResult =
       engine: BooruEngineType;
       confidence: 'hostname' | 'probe';
       credentialSchema: BooruCredentialSchema;
-      defaultCapabilities: { favorites: boolean; tags: boolean; sourceMatch: boolean; search: boolean } | null;
+      defaultCapabilities: {
+        favorites: boolean;
+        tags: boolean;
+        sourceMatch: boolean;
+        search: boolean;
+      } | null;
       sample: BooruDetectionSample | null;
       attempts: BooruDetectionAttempt[];
     }
-  | { error: 'unknown'; tried: BooruEngineType[]; attempts: BooruDetectionAttempt[] }
-  | { error: 'unreachable'; message: string; attempts: BooruDetectionAttempt[] };
+  | {
+      error: 'unknown';
+      tried: BooruEngineType[];
+      attempts: BooruDetectionAttempt[];
+    }
+  | {
+      error: 'unreachable';
+      message: string;
+      attempts: BooruDetectionAttempt[];
+    };
 
 export type BooruEngineCatalog = {
   engines: Array<{
     type: BooruEngineType;
     credentialSchema: BooruCredentialSchema;
-    defaultCapabilities: { favorites: boolean; tags: boolean; sourceMatch: boolean; search: boolean };
+    defaultCapabilities: {
+      favorites: boolean;
+      tags: boolean;
+      sourceMatch: boolean;
+      search: boolean;
+    };
   }>;
   presets: Array<{
     key: string;
     name: string;
     engine: BooruEngineType;
     baseUrl: string;
-    defaultCapabilities: { favorites: boolean; tags: boolean; sourceMatch: boolean; search: boolean };
+    defaultCapabilities: {
+      favorites: boolean;
+      tags: boolean;
+      sourceMatch: boolean;
+      search: boolean;
+    };
   }>;
 };
 
 type FoldersResponse = { folders: Folder[] };
 type DeleteResponse = { status: string; error?: string };
-export type FolderUploadItem = { name: string; fileId?: string | null; reason?: string };
-export type FolderUploadResult = { uploaded: FolderUploadItem[]; rejected: FolderUploadItem[] };
-export type FolderUploadProgress = { loaded: number; total: number | null; percent: number };
+export type FolderUploadItem = {
+  name: string;
+  fileId?: string | null;
+  reason?: string;
+};
+export type FolderUploadResult = {
+  uploaded: FolderUploadItem[];
+  rejected: FolderUploadItem[];
+};
+export type FolderUploadProgress = {
+  loaded: number;
+  total: number | null;
+  percent: number;
+};
 type FilesResponse = { files: FileItem[]; total?: number };
-type SauceResponse = { sources: SauceSource[]; settings: SauceSettings; progress: SauceProgress };
+type SauceResponse = {
+  sources: SauceSource[];
+  settings: SauceSettings;
+  progress: SauceProgress;
+};
 type TagsResponse = { tags: FileTag[] };
 export type ProviderRun = {
   id: string;
@@ -282,15 +322,22 @@ export type ProviderRun = {
 
 type ProvidersResponse = { providers: ProviderRun[] };
 type ProviderRunResponse = { providerRun?: ProviderRun; error?: string };
-type RemoveMatchResponse = { status: string; tags: FileTag[]; providers: ProviderRun[] };
+type RemoveMatchResponse = {
+  status: string;
+  tags: FileTag[];
+  providers: ProviderRun[];
+};
 type DuplicateScanResponse = DuplicateScanResult;
-type DuplicateScanStartResponse = { status: 'started' | 'busy'; state: DuplicateScanStatus };
+type DuplicateScanStartResponse = {
+  status: 'started' | 'busy';
+  state: DuplicateScanStatus;
+};
 type DuplicateScanStatusResponse = DuplicateScanStatus;
 type DuplicateSettingsResponse = DuplicateSettings;
 type ClearTagsResponse = { status: string; removed: number };
 type FileFavoriteResponse = { status: string; isFavorite: boolean };
 type FavoriteSyncResult = {
-  provider: 'E621' | 'DANBOORU';
+  provider: string;
   fetched: number;
   added: number;
   removed: number;
@@ -298,7 +345,7 @@ type FavoriteSyncResult = {
   errors: string[];
 };
 type FavoriteSyncProgress = {
-  provider: 'E621' | 'DANBOORU';
+  provider: string;
   stage: 'idle' | 'fetching' | 'downloading' | 'deleting' | 'done' | 'error';
   fetched: number;
   total: number;
@@ -316,8 +363,11 @@ export type FavoriteSyncStatus = {
   progress: { providers: FavoriteSyncProgress[] } | null;
   results: FavoriteSyncResult[];
 };
-type FavoritesSettings = { reverseSyncEnabled: boolean; autoSyncMidnight: boolean; autoFavEnabled: boolean; favoritesRootId: string | null };
-type FavoriteSyncResponse = { status: 'started' | 'busy'; state: FavoriteSyncStatus };
+type FavoritesSettings = { favoritesRootId: string | null };
+type FavoriteSyncResponse = {
+  status: 'started' | 'busy';
+  state: FavoriteSyncStatus;
+};
 type CredentialsResponse = { credentials: CredentialSummary[] };
 type CredentialUpdateResponse = { credential: CredentialSummary };
 type AuthResponse = { user: AuthUser };
@@ -328,8 +378,13 @@ export const extractErrorMessage = (text: string, fallback: string) => {
   let message = text || fallback;
   if (text) {
     try {
-      const parsed = JSON.parse(text) as { error?: string; issues?: Array<{ message?: string }> };
-      const firstIssue = parsed?.issues?.find((issue) => issue?.message)?.message;
+      const parsed = JSON.parse(text) as {
+        error?: string;
+        issues?: Array<{ message?: string }>;
+      };
+      const firstIssue = parsed?.issues?.find(
+        (issue) => issue?.message
+      )?.message;
       const parsedMessage = firstIssue || parsed?.error;
       if (parsedMessage) {
         message = parsedMessage;
@@ -339,7 +394,7 @@ export const extractErrorMessage = (text: string, fallback: string) => {
       // proxy/gateway errors, so we keep the raw text we already have in
       // `message`. Surface the parse failure on the console so a malformed
       // JSON response from our own backend doesn't disappear silently.
-      // eslint-disable-next-line no-console
+
       console.debug('extractErrorMessage: response body was not JSON', err);
     }
   }
@@ -392,9 +447,15 @@ export const api = {
     const suffix = options?.download ? '?download=1' : '';
     return `${API_BASE}/files/${fileId}/content${suffix}`;
   },
-  getFileContentBlob: async (fileId: string, options?: { signal?: AbortSignal; download?: boolean }) => {
+  getFileContentBlob: async (
+    fileId: string,
+    options?: { signal?: AbortSignal; download?: boolean }
+  ) => {
     const url = api.getFileContentUrl(fileId, { download: options?.download });
-    const res = await apiFetch(url, options?.signal ? { signal: options.signal } : undefined);
+    const res = await apiFetch(
+      url,
+      options?.signal ? { signal: options.signal } : undefined
+    );
     if (!res.ok) {
       const text = await res.text();
       throw new Error(text || res.statusText);
@@ -424,7 +485,10 @@ export const api = {
       xhr.responseType = 'text';
       xhr.upload.onprogress = (event) => {
         const total = event.lengthComputable ? event.total : null;
-        const percent = total && total > 0 ? Math.min(100, Math.round((event.loaded / total) * 100)) : 0;
+        const percent =
+          total && total > 0
+            ? Math.min(100, Math.round((event.loaded / total) * 100))
+            : 0;
         options?.onProgress?.({ loaded: event.loaded, total, percent });
       };
       xhr.onerror = () => reject(new Error('Upload failed'));
@@ -435,12 +499,25 @@ export const api = {
           if (xhr.status === 401) {
             notifyAuthRequired();
           }
-          reject(new Error(extractErrorMessage(responseText, xhr.statusText || 'Upload failed')));
+          reject(
+            new Error(
+              extractErrorMessage(
+                responseText,
+                xhr.statusText || 'Upload failed'
+              )
+            )
+          );
           return;
         }
         try {
-          const parsed = responseText ? (JSON.parse(responseText) as Partial<FolderUploadResult>) : {};
-          if ((parsed.uploaded !== undefined && !Array.isArray(parsed.uploaded)) || (parsed.rejected !== undefined && !Array.isArray(parsed.rejected))) {
+          const parsed = responseText
+            ? (JSON.parse(responseText) as Partial<FolderUploadResult>)
+            : {};
+          if (
+            (parsed.uploaded !== undefined &&
+              !Array.isArray(parsed.uploaded)) ||
+            (parsed.rejected !== undefined && !Array.isArray(parsed.rejected))
+          ) {
             reject(new Error('Invalid upload response shape'));
             return;
           }
@@ -483,7 +560,10 @@ export const api = {
     if (options?.mediaType) params.set('mediaType', options.mediaType);
     if (options?.favoritesOnly) params.set('favorites', 'true');
     const query = params.toString() ? `?${params.toString()}` : '';
-    const res = await apiFetch(`${API_BASE}/files${query}`, options?.signal ? { signal: options.signal } : undefined);
+    const res = await apiFetch(
+      `${API_BASE}/files${query}`,
+      options?.signal ? { signal: options.signal } : undefined
+    );
     const data = await handle<FilesResponse>(res);
     return data;
   },
@@ -492,7 +572,9 @@ export const api = {
     return handle<ProvidersResponse>(res);
   },
   deleteFile: async (fileId: string) => {
-    const res = await apiFetch(`${API_BASE}/files/${fileId}`, { method: 'DELETE' });
+    const res = await apiFetch(`${API_BASE}/files/${fileId}`, {
+      method: 'DELETE'
+    });
     return handle<{ status: string; errors?: string[] }>(res);
   },
   updateFileFavorite: async (fileId: string, favorite: boolean) => {
@@ -504,9 +586,12 @@ export const api = {
     return handle<FileFavoriteResponse>(res);
   },
   runProvider: async (fileId: string, provider: 'saucenao' | 'fluffle') => {
-    const res = await apiFetch(`${API_BASE}/files/${fileId}/providers/${provider}`, {
-      method: 'POST'
-    });
+    const res = await apiFetch(
+      `${API_BASE}/files/${fileId}/providers/${provider}`,
+      {
+        method: 'POST'
+      }
+    );
     return handle<ProviderRunResponse>(res);
   },
   getSauces: async () => {
@@ -514,7 +599,11 @@ export const api = {
     return handle<SauceResponse>(res);
   },
   updateSauceSettings: async (settings: SauceSettings) => {
-    const payload: { display: string[]; targets: string[]; displayInitialized?: boolean } = {
+    const payload: {
+      display: string[];
+      targets: string[];
+      displayInitialized?: boolean;
+    } = {
       display: settings.display,
       targets: settings.targets
     };
@@ -536,7 +625,10 @@ export const api = {
     });
     return handle<{ status: string; saved: number }>(res);
   },
-  syncFavorites: async (payload?: { providers?: ('E621' | 'DANBOORU')[]; deleteMissing?: boolean }) => {
+  syncFavorites: async (payload?: {
+    providers?: string[];
+    deleteMissing?: boolean;
+  }) => {
     const res = await apiFetch(`${API_BASE}/favorites/sync`, {
       method: 'POST',
       headers: jsonHeaders,
@@ -553,7 +645,11 @@ export const api = {
     const data = await handle<CredentialsResponse>(res);
     return data.credentials;
   },
-  updateCredential: async (payload: { provider: CredentialProvider; username?: string; apiKey?: string }) => {
+  updateCredential: async (payload: {
+    provider: CredentialProvider;
+    username?: string;
+    apiKey?: string;
+  }) => {
     const res = await apiFetch(`${API_BASE}/credentials`, {
       method: 'PUT',
       headers: jsonHeaders,
@@ -635,7 +731,9 @@ export const api = {
     return handle<DuplicateScanStatusResponse>(res);
   },
   cancelDuplicateScan: async () => {
-    const res = await apiFetch(`${API_BASE}/duplicates/scan/cancel`, { method: 'POST' });
+    const res = await apiFetch(`${API_BASE}/duplicates/scan/cancel`, {
+      method: 'POST'
+    });
     return handle<{ status: string }>(res);
   },
   getDuplicateSettings: async () => {
@@ -680,6 +778,9 @@ export const api = {
     capTags?: boolean;
     capSourceMatch?: boolean;
     capSearch?: boolean;
+    siteAutoSyncMidnight?: boolean;
+    siteReverseSyncEnabled?: boolean;
+    siteAutoFavEnabled?: boolean;
     enabled?: boolean;
   }) => {
     const res = await apiFetch(`${API_BASE}/booru-sites`, {
@@ -690,18 +791,24 @@ export const api = {
     const data = await handle<{ site: BooruSite }>(res);
     return data.site;
   },
-  updateBooruSite: async (id: string, payload: Partial<{
-    name: string;
-    username: string | null;
-    apiKey: string | null;
-    enabled: boolean;
-    capFavorites: boolean;
-    capTags: boolean;
-    capSourceMatch: boolean;
-    capSearch: boolean;
-    engine: BooruEngineType;
-    baseUrl: string;
-  }>) => {
+  updateBooruSite: async (
+    id: string,
+    payload: Partial<{
+      name: string;
+      username: string | null;
+      apiKey: string | null;
+      enabled: boolean;
+      capFavorites: boolean;
+      capTags: boolean;
+      capSourceMatch: boolean;
+      capSearch: boolean;
+      siteAutoSyncMidnight: boolean;
+      siteReverseSyncEnabled: boolean;
+      siteAutoFavEnabled: boolean;
+      engine: BooruEngineType;
+      baseUrl: string;
+    }>
+  ) => {
     const res = await apiFetch(`${API_BASE}/booru-sites/${id}`, {
       method: 'PUT',
       headers: jsonHeaders,
@@ -711,11 +818,15 @@ export const api = {
     return data.site;
   },
   deleteBooruSite: async (id: string) => {
-    const res = await apiFetch(`${API_BASE}/booru-sites/${id}`, { method: 'DELETE' });
+    const res = await apiFetch(`${API_BASE}/booru-sites/${id}`, {
+      method: 'DELETE'
+    });
     return handle<{ ok: boolean }>(res);
   },
   testBooruSite: async (id: string) => {
-    const res = await apiFetch(`${API_BASE}/booru-sites/${id}/test`, { method: 'POST' });
+    const res = await apiFetch(`${API_BASE}/booru-sites/${id}/test`, {
+      method: 'POST'
+    });
     return handle<{ ok: boolean; status?: number; error?: string }>(res);
   },
   reorderBooruSites: async (orderedIds: string[]) => {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -186,77 +186,187 @@
   .col-auto {
     @apply flex-none w-auto;
   }
-  .col-1 { @apply w-[8.333%]; }
-  .col-2 { @apply w-[16.666%]; }
-  .col-3 { @apply w-[25%]; }
-  .col-4 { @apply w-[33.333%]; }
-  .col-5 { @apply w-[41.666%]; }
-  .col-6 { @apply w-[50%]; }
-  .col-7 { @apply w-[58.333%]; }
-  .col-8 { @apply w-[66.666%]; }
-  .col-9 { @apply w-[75%]; }
-  .col-10 { @apply w-[83.333%]; }
-  .col-11 { @apply w-[91.666%]; }
-  .col-12 { @apply w-full; }
+  .col-1 {
+    @apply w-[8.333%];
+  }
+  .col-2 {
+    @apply w-[16.666%];
+  }
+  .col-3 {
+    @apply w-[25%];
+  }
+  .col-4 {
+    @apply w-[33.333%];
+  }
+  .col-5 {
+    @apply w-[41.666%];
+  }
+  .col-6 {
+    @apply w-[50%];
+  }
+  .col-7 {
+    @apply w-[58.333%];
+  }
+  .col-8 {
+    @apply w-[66.666%];
+  }
+  .col-9 {
+    @apply w-[75%];
+  }
+  .col-10 {
+    @apply w-[83.333%];
+  }
+  .col-11 {
+    @apply w-[91.666%];
+  }
+  .col-12 {
+    @apply w-full;
+  }
 
   @media (min-width: 768px) {
-    .col-md-1 { @apply w-[8.333%]; }
-    .col-md-2 { @apply w-[16.666%]; }
-    .col-md-3 { @apply w-[25%]; }
-    .col-md-4 { @apply w-[33.333%]; }
-    .col-md-5 { @apply w-[41.666%]; }
-    .col-md-6 { @apply w-[50%]; }
-    .col-md-7 { @apply w-[58.333%]; }
-    .col-md-8 { @apply w-[66.666%]; }
-    .col-md-9 { @apply w-[75%]; }
-    .col-md-10 { @apply w-[83.333%]; }
-    .col-md-11 { @apply w-[91.666%]; }
-    .col-md-12 { @apply w-full; }
+    .col-md-1 {
+      @apply w-[8.333%];
+    }
+    .col-md-2 {
+      @apply w-[16.666%];
+    }
+    .col-md-3 {
+      @apply w-[25%];
+    }
+    .col-md-4 {
+      @apply w-[33.333%];
+    }
+    .col-md-5 {
+      @apply w-[41.666%];
+    }
+    .col-md-6 {
+      @apply w-[50%];
+    }
+    .col-md-7 {
+      @apply w-[58.333%];
+    }
+    .col-md-8 {
+      @apply w-[66.666%];
+    }
+    .col-md-9 {
+      @apply w-[75%];
+    }
+    .col-md-10 {
+      @apply w-[83.333%];
+    }
+    .col-md-11 {
+      @apply w-[91.666%];
+    }
+    .col-md-12 {
+      @apply w-full;
+    }
   }
   @media (min-width: 1024px) {
-    .col-lg-1 { @apply w-[8.333%]; }
-    .col-lg-2 { @apply w-[16.666%]; }
-    .col-lg-3 { @apply w-[25%]; }
-    .col-lg-4 { @apply w-[33.333%]; }
-    .col-lg-5 { @apply w-[41.666%]; }
-    .col-lg-6 { @apply w-[50%]; }
-    .col-lg-12 { @apply w-full; }
+    .col-lg-1 {
+      @apply w-[8.333%];
+    }
+    .col-lg-2 {
+      @apply w-[16.666%];
+    }
+    .col-lg-3 {
+      @apply w-[25%];
+    }
+    .col-lg-4 {
+      @apply w-[33.333%];
+    }
+    .col-lg-5 {
+      @apply w-[41.666%];
+    }
+    .col-lg-6 {
+      @apply w-[50%];
+    }
+    .col-lg-12 {
+      @apply w-full;
+    }
   }
 
-  .g-0 { @apply gap-0; }
-  .g-1 { @apply gap-1; }
-  .g-2 { @apply gap-2; }
-  .g-3 { @apply gap-4; }
-  .g-4 { @apply gap-6; }
-  .g-5 { @apply gap-12; }
-  .gx-0 { @apply gap-x-0; }
-  .gx-1 { @apply gap-x-1; }
-  .gx-2 { @apply gap-x-2; }
-  .gx-3 { @apply gap-x-4; }
-  .gy-0 { @apply gap-y-0; }
-  .gy-1 { @apply gap-y-1; }
-  .gy-2 { @apply gap-y-2; }
-  .gy-3 { @apply gap-y-4; }
+  .g-0 {
+    @apply gap-0;
+  }
+  .g-1 {
+    @apply gap-1;
+  }
+  .g-2 {
+    @apply gap-2;
+  }
+  .g-3 {
+    @apply gap-4;
+  }
+  .g-4 {
+    @apply gap-6;
+  }
+  .g-5 {
+    @apply gap-12;
+  }
+  .gx-0 {
+    @apply gap-x-0;
+  }
+  .gx-1 {
+    @apply gap-x-1;
+  }
+  .gx-2 {
+    @apply gap-x-2;
+  }
+  .gx-3 {
+    @apply gap-x-4;
+  }
+  .gy-0 {
+    @apply gap-y-0;
+  }
+  .gy-1 {
+    @apply gap-y-1;
+  }
+  .gy-2 {
+    @apply gap-y-2;
+  }
+  .gy-3 {
+    @apply gap-y-4;
+  }
 
   /* Badges */
   .badge {
     @apply inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium;
   }
-  .badge.bg-primary { @apply bg-primary text-primary-foreground; }
-  .badge.bg-secondary { @apply bg-secondary text-secondary-foreground; }
-  .badge.bg-success { @apply bg-success text-success-foreground; }
-  .badge.bg-danger { @apply bg-destructive text-destructive-foreground; }
-  .badge.bg-warning { @apply bg-warning text-warning-foreground; }
-  .badge.bg-info { @apply bg-primary text-primary-foreground; }
-  .badge.bg-light { @apply bg-secondary text-secondary-foreground; }
-  .badge.bg-dark { @apply bg-background text-foreground; }
+  .badge.bg-primary {
+    @apply bg-primary text-primary-foreground;
+  }
+  .badge.bg-secondary {
+    @apply bg-secondary text-secondary-foreground;
+  }
+  .badge.bg-success {
+    @apply bg-success text-success-foreground;
+  }
+  .badge.bg-danger {
+    @apply bg-destructive text-destructive-foreground;
+  }
+  .badge.bg-warning {
+    @apply bg-warning text-warning-foreground;
+  }
+  .badge.bg-info {
+    @apply bg-primary text-primary-foreground;
+  }
+  .badge.bg-light {
+    @apply bg-secondary text-secondary-foreground;
+  }
+  .badge.bg-dark {
+    @apply bg-background text-foreground;
+  }
 
   /* Alerts */
   .alert {
     @apply rounded-md border px-4 py-3 text-sm;
   }
-  .alert-danger { @apply border-destructive/50 bg-destructive/10 text-destructive; }
-  .alert-warning { @apply border-warning/50 bg-warning/10 text-warning; }
+  .alert-danger {
+    @apply border-destructive/50 bg-destructive/10 text-destructive;
+  }
+  .alert-warning {
+    @apply border-warning/50 bg-warning/10 text-warning;
+  }
 
   /* Progress */
   .progress {
@@ -282,8 +392,12 @@
     animation: progress-bar-stripes 1s linear infinite;
   }
   @keyframes progress-bar-stripes {
-    from { background-position: 1rem 0; }
-    to { background-position: 0 0; }
+    from {
+      background-position: 1rem 0;
+    }
+    to {
+      background-position: 0 0;
+    }
   }
 
   /* Tables */
@@ -421,6 +535,22 @@
   margin-top: 1.25rem;
   padding-top: 1.25rem;
   border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.settings-sections {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.settings-sections > [class^='col'],
+.settings-sections > [class*=' col'] {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+
+.settings-section-flat {
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .settings-section-card,
@@ -708,7 +838,9 @@
   font-size: 2.75rem;
   line-height: 1;
   opacity: 0;
-  transition: opacity 0.2s ease, background 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    background 0.2s ease;
   display: flex;
   align-items: center;
   z-index: 4;
@@ -732,19 +864,11 @@
 }
 
 .file-detail-nav-peek.file-detail-nav-left {
-  background: linear-gradient(
-    to right,
-    rgba(0, 0, 0, 0.35),
-    rgba(0, 0, 0, 0)
-  );
+  background: linear-gradient(to right, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0));
 }
 
 .file-detail-nav-peek.file-detail-nav-right {
-  background: linear-gradient(
-    to left,
-    rgba(0, 0, 0, 0.35),
-    rgba(0, 0, 0, 0)
-  );
+  background: linear-gradient(to left, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0));
 }
 
 .file-detail-nav:disabled {
@@ -763,11 +887,7 @@
   }
 
   .file-detail-nav-right:hover {
-    background: linear-gradient(
-      to left,
-      rgba(0, 0, 0, 0.35),
-      rgba(0, 0, 0, 0)
-    );
+    background: linear-gradient(to left, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0));
   }
 }
 
@@ -992,6 +1112,121 @@
   max-width: 400px;
 }
 
+.favorites-suggestions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+  max-width: 560px;
+}
+
+.favorites-suggestion-card {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.04);
+  color: hsl(var(--foreground));
+  padding: 0.8rem 0.65rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 84px;
+  transition:
+    border-color 120ms ease,
+    background-color 120ms ease;
+}
+
+.favorites-suggestion-card:hover {
+  border-color: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.favorites-suggestion-icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.favorites-suggestion-name {
+  font-size: 0.82rem;
+  line-height: 1.1;
+}
+
+.favorites-configured-divider {
+  margin: 1.25rem 0;
+  width: 100%;
+  display: block;
+  border: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.24);
+  opacity: 1;
+}
+
+.favorites-site-switch {
+  align-items: center;
+  min-height: 2.75rem;
+}
+
+.favorites-site-switch.favorites-site-switch--tight {
+  min-height: 0;
+}
+
+.favorites-site-switch .form-check-input {
+  flex-shrink: 0;
+  margin-top: 0;
+  width: 2.25rem;
+  height: 1.25rem;
+}
+
+.favorites-site-switch .form-check-label {
+  line-height: 1.25;
+}
+
+.favorites-switch-label-wrap {
+  line-height: 1.35;
+}
+
+.favorites-help-dot {
+  width: 0.92rem;
+  height: 0.92rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.64rem;
+  font-weight: 700;
+  line-height: 1;
+  color: #ffffff;
+  background: #60a5fa;
+  cursor: help;
+  user-select: none;
+  flex-shrink: 0;
+  margin-left: 0.35rem;
+  vertical-align: middle;
+}
+
+.favorites-site-toggle-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.5rem;
+}
+
+.favorites-site-toggle-col {
+  min-width: 0;
+}
+
+@media (min-width: 768px) {
+  .favorites-site-toggle-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 .sauce-progress-wrap {
   width: 100%;
   max-width: none;
@@ -1076,7 +1311,9 @@
   min-width: 0;
   gap: 0.5rem;
   padding: 0.6rem 0.75rem;
-  transition: border-color 0.18s ease, background 0.18s ease;
+  transition:
+    border-color 0.18s ease,
+    background 0.18s ease;
 }
 
 .folder-card-root {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1202,8 +1202,8 @@
   font-size: 0.64rem;
   font-weight: 700;
   line-height: 1;
-  color: #ffffff;
-  background: #60a5fa;
+  color: hsl(var(--primary-foreground));
+  background: hsl(var(--primary));
   cursor: help;
   user-select: none;
   flex-shrink: 0;

--- a/frontend/src/features/booru-sites/BooruSiteCredentialForm.tsx
+++ b/frontend/src/features/booru-sites/BooruSiteCredentialForm.tsx
@@ -1,0 +1,130 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect, useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+
+import {
+  type BooruCredentialFormValues,
+  createBooruCredentialSchema,
+  toBooruCredentialUpdatePayload
+} from './formSchemas';
+import { credentialFieldsForSchema } from './shared';
+
+import type { BooruCredentialSchema, BooruSite } from '@/api';
+
+type BooruSiteCredentialFormProps = {
+  site: BooruSite;
+  schema: BooruCredentialSchema;
+  loading: boolean;
+  testing: boolean;
+  onSave: (
+    payload: ReturnType<typeof toBooruCredentialUpdatePayload>
+  ) => Promise<BooruSite>;
+  onTest: () => Promise<void>;
+  onDelete: () => void;
+};
+
+export function BooruSiteCredentialForm({
+  site,
+  schema,
+  loading,
+  testing,
+  onSave,
+  onTest,
+  onDelete
+}: BooruSiteCredentialFormProps) {
+  const fields = useMemo(() => credentialFieldsForSchema(schema), [schema]);
+  const formSchema = useMemo(
+    () => createBooruCredentialSchema(schema),
+    [schema]
+  );
+  const usernameId = `site-${site.id}-username`;
+  const apiKeyId = `site-${site.id}-api-key`;
+  const { register, reset, handleSubmit } = useForm<BooruCredentialFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      username: site.username ?? '',
+      apiKey: ''
+    }
+  });
+
+  useEffect(() => {
+    reset({
+      username: site.username ?? '',
+      apiKey: ''
+    });
+  }, [reset, site.id, site.username]);
+
+  return (
+    <form
+      onSubmit={handleSubmit(async (values) => {
+        const updated = await onSave(toBooruCredentialUpdatePayload(values));
+        reset({
+          username: updated.username ?? '',
+          apiKey: ''
+        });
+      })}
+      className="row g-2 mt-2"
+    >
+      {fields.username ? (
+        <div className="col-md-4">
+          <label
+            className="form-label text-sm mb-1 text-muted-foreground"
+            htmlFor={usernameId}
+          >
+            {fields.usernameLabel}
+          </label>
+          <input
+            id={usernameId}
+            type="text"
+            className="form-control form-control-sm bg-background text-foreground border-secondary"
+            {...register('username')}
+          />
+        </div>
+      ) : null}
+      {fields.apiKey ? (
+        <div className="col-md-4">
+          <label
+            className="form-label text-sm mb-1 text-muted-foreground"
+            htmlFor={apiKeyId}
+          >
+            {fields.apiKeyLabel}
+            {site.hasApiKey ? (
+              <span className="text-muted-foreground"> · saved</span>
+            ) : null}
+          </label>
+          <input
+            id={apiKeyId}
+            type="password"
+            className="form-control form-control-sm bg-background text-foreground border-secondary"
+            placeholder={site.hasApiKey ? '••••••••' : ''}
+            {...register('apiKey')}
+          />
+        </div>
+      ) : null}
+      <div className="col-12 flex flex-wrap items-end gap-2">
+        <button
+          type="submit"
+          className="btn btn-sm btn-outline-light shrink-0 whitespace-nowrap"
+          disabled={loading}
+        >
+          Save credentials
+        </button>
+        <button
+          type="button"
+          className="btn btn-sm btn-outline-light shrink-0 whitespace-nowrap"
+          onClick={() => void onTest()}
+          disabled={testing}
+        >
+          {testing ? 'Testing…' : 'Test'}
+        </button>
+        <button
+          type="button"
+          className="btn btn-sm btn-outline-danger shrink-0 whitespace-nowrap"
+          onClick={() => onDelete()}
+        >
+          Delete site
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/booru-sites/BooruSiteForms.tsx
+++ b/frontend/src/features/booru-sites/BooruSiteForms.tsx
@@ -3,11 +3,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import {
-  type BooruCredentialFormValues,
   type BooruSiteAddFormValues,
   booruSiteAddSchema,
-  createBooruCredentialSchema,
-  toBooruCredentialUpdatePayload,
   toBooruSiteCreatePayload
 } from './formSchemas';
 import { ENGINE_LABELS, credentialFieldsForSchema } from './shared';
@@ -15,8 +12,7 @@ import { ENGINE_LABELS, credentialFieldsForSchema } from './shared';
 import type {
   BooruCredentialSchema,
   BooruDetectionResult,
-  BooruEngineType,
-  BooruSite
+  BooruEngineType
 } from '@/api';
 import { ensureHttps } from '@/urlUtils';
 
@@ -388,124 +384,6 @@ export function AddBooruSiteForm({
           }}
         >
           Reset
-        </button>
-      </div>
-    </form>
-  );
-}
-
-type BooruSiteCredentialFormProps = {
-  site: BooruSite;
-  schema: BooruCredentialSchema;
-  loading: boolean;
-  testing: boolean;
-  onSave: (
-    payload: ReturnType<typeof toBooruCredentialUpdatePayload>
-  ) => Promise<BooruSite>;
-  onTest: () => Promise<void>;
-  onDelete: () => void;
-};
-
-export function BooruSiteCredentialForm({
-  site,
-  schema,
-  loading,
-  testing,
-  onSave,
-  onTest,
-  onDelete
-}: BooruSiteCredentialFormProps) {
-  const fields = useMemo(() => credentialFieldsForSchema(schema), [schema]);
-  const formSchema = useMemo(
-    () => createBooruCredentialSchema(schema),
-    [schema]
-  );
-  const usernameId = `site-${site.id}-username`;
-  const apiKeyId = `site-${site.id}-api-key`;
-  const { register, reset, handleSubmit } = useForm<BooruCredentialFormValues>({
-    resolver: zodResolver(formSchema),
-    defaultValues: {
-      username: site.username ?? '',
-      apiKey: ''
-    }
-  });
-
-  useEffect(() => {
-    reset({
-      username: site.username ?? '',
-      apiKey: ''
-    });
-  }, [reset, site.id, site.username]);
-
-  return (
-    <form
-      onSubmit={handleSubmit(async (values) => {
-        const updated = await onSave(toBooruCredentialUpdatePayload(values));
-        reset({
-          username: updated.username ?? '',
-          apiKey: ''
-        });
-      })}
-      className="row g-2 mt-2"
-    >
-      {fields.username ? (
-        <div className="col-md-4">
-          <label
-            className="form-label text-sm mb-1 text-muted-foreground"
-            htmlFor={usernameId}
-          >
-            {fields.usernameLabel}
-          </label>
-          <input
-            id={usernameId}
-            type="text"
-            className="form-control form-control-sm bg-background text-foreground border-secondary"
-            {...register('username')}
-          />
-        </div>
-      ) : null}
-      {fields.apiKey ? (
-        <div className="col-md-4">
-          <label
-            className="form-label text-sm mb-1 text-muted-foreground"
-            htmlFor={apiKeyId}
-          >
-            {fields.apiKeyLabel}
-            {site.hasApiKey ? (
-              <span className="text-muted-foreground"> · saved</span>
-            ) : null}
-          </label>
-          <input
-            id={apiKeyId}
-            type="password"
-            className="form-control form-control-sm bg-background text-foreground border-secondary"
-            placeholder={site.hasApiKey ? '••••••••' : ''}
-            {...register('apiKey')}
-          />
-        </div>
-      ) : null}
-      <div className="col-12 flex flex-wrap items-end gap-2">
-        <button
-          type="submit"
-          className="btn btn-sm btn-outline-light shrink-0 whitespace-nowrap"
-          disabled={loading}
-        >
-          Save credentials
-        </button>
-        <button
-          type="button"
-          className="btn btn-sm btn-outline-light shrink-0 whitespace-nowrap"
-          onClick={() => void onTest()}
-          disabled={testing}
-        >
-          {testing ? 'Testing…' : 'Test'}
-        </button>
-        <button
-          type="button"
-          className="btn btn-sm btn-outline-danger shrink-0 whitespace-nowrap"
-          onClick={() => onDelete()}
-        >
-          Delete site
         </button>
       </div>
     </form>

--- a/frontend/src/features/booru-sites/BooruSiteForms.tsx
+++ b/frontend/src/features/booru-sites/BooruSiteForms.tsx
@@ -1,14 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-
-import type {
-  BooruCredentialSchema,
-  BooruDetectionResult,
-  BooruEngineType,
-  BooruSite,
-} from '@/api';
-import { ensureHttps } from '@/urlUtils';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
 
 import {
   type BooruCredentialFormValues,
@@ -16,26 +8,46 @@ import {
   booruSiteAddSchema,
   createBooruCredentialSchema,
   toBooruCredentialUpdatePayload,
-  toBooruSiteCreatePayload,
+  toBooruSiteCreatePayload
 } from './formSchemas';
-import {
-  CAPABILITY_LABELS,
-  ENGINE_LABELS,
-  credentialFieldsForSchema,
-} from './shared';
+import { ENGINE_LABELS, credentialFieldsForSchema } from './shared';
+
+import type {
+  BooruCredentialSchema,
+  BooruDetectionResult,
+  BooruEngineType,
+  BooruSite
+} from '@/api';
+import { ensureHttps } from '@/urlUtils';
 
 type AddBooruSiteFormProps = {
   devOptions: boolean;
-  onCreate: (payload: ReturnType<typeof toBooruSiteCreatePayload>) => Promise<void>;
+  onCreate: (
+    payload: ReturnType<typeof toBooruSiteCreatePayload>
+  ) => Promise<void>;
   onDetect: (baseUrl: string) => Promise<BooruDetectionResult>;
+  prefill?: {
+    name: string;
+    baseUrl: string;
+    engine: BooruEngineType;
+    credentialSchema: BooruCredentialSchema;
+  } | null;
 };
 
-export function AddBooruSiteForm({ devOptions, onCreate, onDetect }: AddBooruSiteFormProps) {
+export function AddBooruSiteForm({
+  devOptions,
+  onCreate,
+  onDetect,
+  prefill
+}: AddBooruSiteFormProps) {
   const [detection, setDetection] = useState<BooruDetectionResult | null>(null);
   const [detecting, setDetecting] = useState(false);
   const [detectError, setDetectError] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [addingBusy, setAddingBusy] = useState(false);
+  const detectRequestSeq = useRef(0);
+  const lastDetectedBaseUrl = useRef<string | null>(null);
+  const onDetectRef = useRef(onDetect);
   const form = useForm<BooruSiteAddFormValues>({
     resolver: zodResolver(booruSiteAddSchema),
     defaultValues: {
@@ -46,9 +58,9 @@ export function AddBooruSiteForm({ devOptions, onCreate, onDetect }: AddBooruSit
       capabilities: {
         capFavorites: false,
         capTags: true,
-        capSourceMatch: true,
-      },
-    },
+        capSourceMatch: true
+      }
+    }
   });
   const {
     register,
@@ -56,72 +68,137 @@ export function AddBooruSiteForm({ devOptions, onCreate, onDetect }: AddBooruSit
     reset,
     setValue,
     watch,
-    formState: { errors },
+    formState: { errors }
   } = form;
   const baseUrl = watch('baseUrl');
+  const normalizedBaseUrl = ensureHttps(baseUrl);
   const detectedEngine = useMemo(() => {
     if (detection && 'engine' in detection) {
       return detection.engine;
     }
     return null;
   }, [detection]);
-  const detectedSchema: BooruCredentialSchema = useMemo(() => {
-    if (detection && 'engine' in detection) {
-      return detection.credentialSchema;
-    }
-    return 'none';
-  }, [detection]);
+  const prefillBaseUrl = ensureHttps(prefill?.baseUrl ?? '');
+  const prefillMatchesBaseUrl =
+    !!prefill && !!normalizedBaseUrl && normalizedBaseUrl === prefillBaseUrl;
+  const selectedEngine =
+    detectedEngine ??
+    (prefillMatchesBaseUrl ? (prefill?.engine ?? null) : null);
+  const selectedSchema: BooruCredentialSchema =
+    detection && 'engine' in detection
+      ? detection.credentialSchema
+      : prefillMatchesBaseUrl
+        ? (prefill?.credentialSchema ?? 'none')
+        : 'none';
   const detectedFields = useMemo(
-    () => credentialFieldsForSchema(detectedSchema),
-    [detectedSchema],
+    () => credentialFieldsForSchema(selectedSchema),
+    [selectedSchema]
   );
   const addUsernameId = 'booru-detected-username';
   const addApiKeyId = 'booru-detected-api-key';
 
   useEffect(() => {
-    const normalized = ensureHttps(baseUrl);
+    onDetectRef.current = onDetect;
+  }, [onDetect]);
+
+  useEffect(() => {
+    if (!prefill) return;
+    setValue('name', prefill.name, { shouldValidate: true });
+    setValue('baseUrl', prefill.baseUrl, { shouldValidate: true });
+    setSubmitError(null);
+    setDetectError(null);
+    setDetection(null);
+    lastDetectedBaseUrl.current = null;
+  }, [prefill, setValue]);
+
+  useEffect(() => {
+    const normalized = normalizedBaseUrl;
     if (!normalized) {
       setDetection(null);
       setDetecting(false);
       setDetectError(null);
+      lastDetectedBaseUrl.current = null;
       return;
     }
+    if (normalized === lastDetectedBaseUrl.current) {
+      return;
+    }
+    const requestSeq = ++detectRequestSeq.current;
+    setDetection(null);
     const timeoutId = window.setTimeout(async () => {
       setDetecting(true);
       setDetectError(null);
       try {
-        const nextDetection = await onDetect(normalized);
+        const nextDetection = await new Promise<BooruDetectionResult>(
+          (resolve, reject) => {
+            const failTimerId = window.setTimeout(
+              () => reject(new Error('Engine detection timed out. Try again.')),
+              8_000
+            );
+            onDetectRef
+              .current(normalized)
+              .then((result) => {
+                window.clearTimeout(failTimerId);
+                resolve(result);
+              })
+              .catch((error: unknown) => {
+                window.clearTimeout(failTimerId);
+                reject(error);
+              });
+          }
+        );
+        if (requestSeq !== detectRequestSeq.current) return;
         setDetection(nextDetection);
+        lastDetectedBaseUrl.current = normalized;
         if ('engine' in nextDetection && nextDetection.defaultCapabilities) {
-          setValue('capabilities.capFavorites', nextDetection.defaultCapabilities.favorites);
-          setValue('capabilities.capTags', nextDetection.defaultCapabilities.tags);
-          setValue('capabilities.capSourceMatch', nextDetection.defaultCapabilities.sourceMatch);
+          setValue(
+            'capabilities.capFavorites',
+            nextDetection.defaultCapabilities.favorites
+          );
+          setValue(
+            'capabilities.capTags',
+            nextDetection.defaultCapabilities.tags
+          );
+          setValue(
+            'capabilities.capSourceMatch',
+            nextDetection.defaultCapabilities.sourceMatch
+          );
         }
       } catch (error) {
+        if (requestSeq !== detectRequestSeq.current) return;
         setDetection(null);
         setDetectError((error as Error).message);
       } finally {
-        setDetecting(false);
+        if (requestSeq === detectRequestSeq.current) {
+          setDetecting(false);
+        }
       }
     }, 600);
 
-    return () => window.clearTimeout(timeoutId);
-  }, [baseUrl, onDetect, setValue]);
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [normalizedBaseUrl, setValue]);
 
   return (
     <form
       onSubmit={handleSubmit(async (values) => {
-        if (!detectedEngine) {
-          setSubmitError('No engine selected. Wait for detection or choose manually.');
+        if (!selectedEngine) {
+          setSubmitError(
+            'No engine selected. Wait for detection or choose manually.'
+          );
           return;
         }
         setAddingBusy(true);
         setSubmitError(null);
         try {
-          await onCreate(toBooruSiteCreatePayload(values, detectedEngine as BooruEngineType));
+          await onCreate(
+            toBooruSiteCreatePayload(values, selectedEngine as BooruEngineType)
+          );
           reset();
           setDetection(null);
           setDetectError(null);
+          lastDetectedBaseUrl.current = null;
         } catch (error) {
           setSubmitError((error as Error).message);
         } finally {
@@ -131,7 +208,10 @@ export function AddBooruSiteForm({ devOptions, onCreate, onDetect }: AddBooruSit
       className="row g-2"
     >
       <div className="col-md-6">
-        <label htmlFor="booru-name" className="form-label text-sm mb-1 text-muted-foreground">
+        <label
+          htmlFor="booru-name"
+          className="form-label text-sm mb-1 text-muted-foreground"
+        >
           Name
         </label>
         <input
@@ -142,11 +222,16 @@ export function AddBooruSiteForm({ devOptions, onCreate, onDetect }: AddBooruSit
           {...register('name')}
         />
         {errors.name ? (
-          <div className="text-destructive text-sm mt-1">{errors.name.message}</div>
+          <div className="text-destructive text-sm mt-1">
+            {errors.name.message}
+          </div>
         ) : null}
       </div>
       <div className="col-md-6">
-        <label htmlFor="booru-url" className="form-label text-sm mb-1 text-muted-foreground">
+        <label
+          htmlFor="booru-url"
+          className="form-label text-sm mb-1 text-muted-foreground"
+        >
           Base URL
         </label>
         <input
@@ -161,11 +246,17 @@ export function AddBooruSiteForm({ devOptions, onCreate, onDetect }: AddBooruSit
           }}
         />
         {errors.baseUrl ? (
-          <div className="text-destructive text-sm mt-1">{errors.baseUrl.message}</div>
+          <div className="text-destructive text-sm mt-1">
+            {errors.baseUrl.message}
+          </div>
         ) : null}
       </div>
 
-      {detecting ? <div className="col-12 text-muted-foreground text-sm">Detecting engine…</div> : null}
+      {detecting ? (
+        <div className="col-12 text-muted-foreground text-sm">
+          Detecting engine…
+        </div>
+      ) : null}
 
       {detection && 'engine' in detection ? (
         <div className="col-12">
@@ -175,28 +266,13 @@ export function AddBooruSiteForm({ devOptions, onCreate, onDetect }: AddBooruSit
             </span>
             {devOptions ? (
               <span className="text-muted-foreground text-sm">
-                via {detection.confidence === 'hostname' ? 'known hostname' : 'API probe'}
+                via{' '}
+                {detection.confidence === 'hostname'
+                  ? 'known hostname'
+                  : 'API probe'}
               </span>
             ) : null}
           </div>
-          {detection.sample?.thumbUrl ? (
-            <div className="mt-2 flex items-start gap-2">
-              <a
-                href={detection.sample.postUrl}
-                target="_blank"
-                rel="noreferrer"
-                title={`Sample post #${detection.sample.postId}`}
-              >
-                <img
-                  src={detection.sample.thumbUrl}
-                  alt={`Sample post #${detection.sample.postId}`}
-                  style={{ maxWidth: 96, maxHeight: 96 }}
-                  className="border border-secondary rounded"
-                  loading="lazy"
-                />
-              </a>
-            </div>
-          ) : null}
         </div>
       ) : null}
 
@@ -239,7 +315,9 @@ export function AddBooruSiteForm({ devOptions, onCreate, onDetect }: AddBooruSit
                         </span>
                       </td>
                       <td>{attempt.httpStatus ?? '—'}</td>
-                      <td className="text-muted-foreground">{attempt.error ?? ''}</td>
+                      <td className="text-muted-foreground">
+                        {attempt.error ?? ''}
+                      </td>
                     </tr>
                   ))}
                 </tbody>
@@ -249,11 +327,14 @@ export function AddBooruSiteForm({ devOptions, onCreate, onDetect }: AddBooruSit
         </div>
       ) : null}
 
-      {detectedEngine ? (
+      {selectedEngine ? (
         <>
           {detectedFields.username ? (
             <div className="col-md-6">
-              <label className="form-label text-sm mb-1" htmlFor={addUsernameId}>
+              <label
+                className="form-label text-sm mb-1"
+                htmlFor={addUsernameId}
+              >
                 {detectedFields.usernameLabel}
               </label>
               <input
@@ -277,34 +358,22 @@ export function AddBooruSiteForm({ devOptions, onCreate, onDetect }: AddBooruSit
               />
             </div>
           ) : null}
-          <div className="col-12 mt-2">
-            <span className="text-muted-foreground text-sm block mb-1">Capabilities</span>
-            <div className="row g-2">
-              {Object.entries(CAPABILITY_LABELS).map(([key, label]) => (
-                <div key={key} className="col-6 col-md-3">
-                  <div className="form-check">
-                    <input
-                      className="form-check-input"
-                      type="checkbox"
-                      id={`new-${key}`}
-                      {...register(`capabilities.${key as keyof BooruSiteAddFormValues['capabilities']}`)}
-                    />
-                    <label className="form-check-label text-muted-foreground text-sm" htmlFor={`new-${key}`}>
-                      {label}
-                    </label>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
         </>
       ) : null}
 
-      {detectError ? <div className="col-12 text-destructive text-sm">{detectError}</div> : null}
-      {submitError ? <div className="col-12 text-destructive text-sm">{submitError}</div> : null}
+      {detectError ? (
+        <div className="col-12 text-destructive text-sm">{detectError}</div>
+      ) : null}
+      {submitError ? (
+        <div className="col-12 text-destructive text-sm">{submitError}</div>
+      ) : null}
 
       <div className="col-12 flex gap-2 mt-2">
-        <button type="submit" className="btn btn-sm btn-outline-light" disabled={addingBusy || !detectedEngine}>
+        <button
+          type="submit"
+          className="btn btn-sm btn-outline-light"
+          disabled={addingBusy || !selectedEngine}
+        >
           {addingBusy ? 'Adding…' : 'Add site'}
         </button>
         <button
@@ -315,6 +384,7 @@ export function AddBooruSiteForm({ devOptions, onCreate, onDetect }: AddBooruSit
             setDetection(null);
             setDetectError(null);
             setSubmitError(null);
+            lastDetectedBaseUrl.current = null;
           }}
         >
           Reset
@@ -330,9 +400,10 @@ type BooruSiteCredentialFormProps = {
   loading: boolean;
   testing: boolean;
   onSave: (
-    payload: ReturnType<typeof toBooruCredentialUpdatePayload>,
+    payload: ReturnType<typeof toBooruCredentialUpdatePayload>
   ) => Promise<BooruSite>;
   onTest: () => Promise<void>;
+  onDelete: () => void;
 };
 
 export function BooruSiteCredentialForm({
@@ -342,27 +413,27 @@ export function BooruSiteCredentialForm({
   testing,
   onSave,
   onTest,
+  onDelete
 }: BooruSiteCredentialFormProps) {
   const fields = useMemo(() => credentialFieldsForSchema(schema), [schema]);
-  const formSchema = useMemo(() => createBooruCredentialSchema(schema), [schema]);
+  const formSchema = useMemo(
+    () => createBooruCredentialSchema(schema),
+    [schema]
+  );
   const usernameId = `site-${site.id}-username`;
   const apiKeyId = `site-${site.id}-api-key`;
-  const {
-    register,
-    reset,
-    handleSubmit,
-  } = useForm<BooruCredentialFormValues>({
+  const { register, reset, handleSubmit } = useForm<BooruCredentialFormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       username: site.username ?? '',
-      apiKey: '',
-    },
+      apiKey: ''
+    }
   });
 
   useEffect(() => {
     reset({
       username: site.username ?? '',
-      apiKey: '',
+      apiKey: ''
     });
   }, [reset, site.id, site.username]);
 
@@ -372,14 +443,17 @@ export function BooruSiteCredentialForm({
         const updated = await onSave(toBooruCredentialUpdatePayload(values));
         reset({
           username: updated.username ?? '',
-          apiKey: '',
+          apiKey: ''
         });
       })}
       className="row g-2 mt-2"
     >
       {fields.username ? (
         <div className="col-md-4">
-          <label className="form-label text-sm mb-1 text-muted-foreground" htmlFor={usernameId}>
+          <label
+            className="form-label text-sm mb-1 text-muted-foreground"
+            htmlFor={usernameId}
+          >
             {fields.usernameLabel}
           </label>
           <input
@@ -392,9 +466,14 @@ export function BooruSiteCredentialForm({
       ) : null}
       {fields.apiKey ? (
         <div className="col-md-4">
-          <label className="form-label text-sm mb-1 text-muted-foreground" htmlFor={apiKeyId}>
+          <label
+            className="form-label text-sm mb-1 text-muted-foreground"
+            htmlFor={apiKeyId}
+          >
             {fields.apiKeyLabel}
-            {site.hasApiKey ? <span className="text-muted-foreground"> · saved</span> : null}
+            {site.hasApiKey ? (
+              <span className="text-muted-foreground"> · saved</span>
+            ) : null}
           </label>
           <input
             id={apiKeyId}
@@ -405,17 +484,28 @@ export function BooruSiteCredentialForm({
           />
         </div>
       ) : null}
-      <div className="col-md-4 flex items-end gap-2">
-        <button type="submit" className="btn btn-sm btn-outline-light" disabled={loading}>
+      <div className="col-12 flex flex-wrap items-end gap-2">
+        <button
+          type="submit"
+          className="btn btn-sm btn-outline-light shrink-0 whitespace-nowrap"
+          disabled={loading}
+        >
           Save credentials
         </button>
         <button
           type="button"
-          className="btn btn-sm btn-outline-light"
+          className="btn btn-sm btn-outline-light shrink-0 whitespace-nowrap"
           onClick={() => void onTest()}
           disabled={testing}
         >
           {testing ? 'Testing…' : 'Test'}
+        </button>
+        <button
+          type="button"
+          className="btn btn-sm btn-outline-danger shrink-0 whitespace-nowrap"
+          onClick={() => onDelete()}
+        >
+          Delete site
         </button>
       </div>
     </form>

--- a/frontend/src/features/booru-sites/BooruSitesPanelText.ts
+++ b/frontend/src/features/booru-sites/BooruSitesPanelText.ts
@@ -1,0 +1,65 @@
+import type { CapabilityKey } from './shared';
+
+import type { BooruEngineType } from '@/api';
+
+
+export type SiteSettingKey =
+  | 'siteAutoSyncMidnight'
+  | 'siteReverseSyncEnabled'
+  | 'siteAutoFavEnabled';
+
+export type SuggestionPreset = {
+  key: string;
+  name: string;
+  engine: BooruEngineType;
+  baseUrl: string;
+  iconLabel: string;
+};
+
+export const SUGGESTION_PRESETS: SuggestionPreset[] = [
+  {
+    key: 'E621',
+    name: 'e621',
+    engine: 'e621',
+    baseUrl: 'https://e621.net',
+    iconLabel: 'E6'
+  },
+  {
+    key: 'DANBOORU',
+    name: 'Danbooru',
+    engine: 'danbooru',
+    baseUrl: 'https://danbooru.donmai.us',
+    iconLabel: 'DB'
+  },
+  {
+    key: 'RULE34',
+    name: 'Rule34',
+    engine: 'gelbooru',
+    baseUrl: 'https://rule34.xxx',
+    iconLabel: 'R34'
+  }
+];
+
+export const CAPABILITY_HELP_TEXT: Record<CapabilityKey, string> = {
+  capFavorites:
+    'Match your local files to your favorites here: new favorites are downloaded, and files you unfavorited are deleted locally. Works when pressing the Sync favorites button, or at midnight if "Daily midnight sync" is enabled.',
+  capTags:
+    'Copy the tags a post has on this site onto your matching local file, so you can search and filter by them.',
+  capSourceMatch:
+    'Use the source link saved on a local file to find the same post on this site and connect the two.'
+};
+
+export const SITE_SETTING_LABELS: Record<SiteSettingKey, string> = {
+  siteAutoSyncMidnight: 'Daily midnight sync',
+  siteReverseSyncEnabled: 'Delete locally also unfavorites remotely',
+  siteAutoFavEnabled: 'Auto-favorite source matches'
+};
+
+export const SITE_SETTING_HELP_TEXT: Record<SiteSettingKey, string> = {
+  siteAutoSyncMidnight:
+    'Every night at midnight, sync favorites with this site automatically, so you never have to press Sync yourself.',
+  siteReverseSyncEnabled:
+    'When you delete a file in the app, also remove it from your favorites on this site.',
+  siteAutoFavEnabled:
+    'When the scanner finds one of your files on this site, automatically add that post to your favorites there.'
+};

--- a/frontend/src/features/favorites-accounts/FavoritesAccountsSettings.tsx
+++ b/frontend/src/features/favorites-accounts/FavoritesAccountsSettings.tsx
@@ -1,0 +1,145 @@
+import type { FavoriteSyncStatus } from '@/api';
+import { BooruSitesPanel } from '@/BooruSitesPanel';
+import { formatDateTime } from '@/lib/format';
+
+type FetchState = { loading: boolean; error: string | null };
+
+export interface FavoritesAccountsSettingsProps {
+  favoritesSyncState: FetchState;
+  favoritesSyncStatus: FavoriteSyncStatus | null;
+  favoritesProgress: number | null;
+  favoritesSummary: string[];
+  favoritesErrors: string[];
+  runFavoritesSync: (deleteMissing: boolean) => Promise<void>;
+  booruDevOptions: boolean;
+  setBooruDevOptionsPersistent: (next: boolean) => void;
+}
+
+export function FavoritesAccountsSettings({
+  favoritesSyncState,
+  favoritesSyncStatus,
+  favoritesProgress,
+  favoritesSummary,
+  favoritesErrors,
+  runFavoritesSync,
+  booruDevOptions,
+  setBooruDevOptionsPersistent
+}: FavoritesAccountsSettingsProps) {
+  return (
+    <div className="row g-0 settings-sections">
+      <div className="col-12 settings-section">
+        <div className="card bg-transparent text-foreground border-0 h-full settings-section-card">
+          <div className="card-body">
+            <div className="flex justify-between items-center mb-2">
+              <h2 className="h5 mb-0">Favorites accounts</h2>
+            </div>
+            <p className="text-muted-foreground text-sm mb-4">
+              Manage booru accounts, per-site sync behavior, and favorites sync
+              status.
+            </p>
+
+            <div className="flex flex-wrap gap-2 mb-2">
+              <button
+                className="btn btn-outline-light btn-sm"
+                onClick={() => void runFavoritesSync(true)}
+                disabled={favoritesSyncState.loading}
+              >
+                Sync favorites
+              </button>
+            </div>
+
+            {favoritesSyncState.loading ||
+            favoritesSyncStatus?.status === 'running' ? (
+              <div className="text-muted-foreground text-sm">
+                {favoritesSyncStatus?.message ?? 'Syncing favorites…'}
+              </div>
+            ) : null}
+            {favoritesSyncStatus ? (
+              <div className="text-muted-foreground text-sm mt-1 mb-2">
+                <div>
+                  Last sync started:{' '}
+                  {formatDateTime(favoritesSyncStatus.startedAt)}
+                </div>
+                <div>
+                  Last sync updated:{' '}
+                  {formatDateTime(favoritesSyncStatus.updatedAt)}
+                </div>
+              </div>
+            ) : null}
+            {favoritesSyncState.error ? (
+              <div className="text-destructive text-sm mb-2">
+                Error: {favoritesSyncState.error}
+              </div>
+            ) : null}
+            {favoritesSyncStatus?.status === 'running' &&
+            favoritesProgress !== null ? (
+              <div
+                className="progress bg-background border border-secondary mt-2"
+                style={{ height: 8 }}
+              >
+                <div
+                  className="progress-bar bg-info"
+                  role="progressbar"
+                  style={{ width: `${favoritesProgress}%` }}
+                  aria-valuenow={favoritesProgress}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                />
+              </div>
+            ) : null}
+            {favoritesSyncStatus?.progress?.providers?.length ? (
+              <div className="text-muted-foreground text-sm mt-2 mb-2">
+                {favoritesSyncStatus.progress.providers.map((entry) => (
+                  <div key={entry.provider}>
+                    {entry.provider}: {entry.stage} · {entry.processed}/
+                    {entry.total} · +{entry.added} / -{entry.removed}
+                  </div>
+                ))}
+              </div>
+            ) : null}
+            {favoritesSummary.length ? (
+              <div className="text-muted-foreground text-sm mb-2">
+                {favoritesSummary.map((line) => (
+                  <div key={line}>{line}</div>
+                ))}
+              </div>
+            ) : null}
+            {favoritesErrors.length ? (
+              <div className="text-destructive text-sm mt-2 mb-3">
+                {favoritesErrors.slice(0, 6).map((line) => (
+                  <div key={line}>{line}</div>
+                ))}
+                {favoritesErrors.length > 6 ? (
+                  <div>…and {favoritesErrors.length - 6} more errors</div>
+                ) : null}
+              </div>
+            ) : null}
+
+            <BooruSitesPanel
+              className="mb-6"
+              devOptions={booruDevOptions}
+              showSuggestions
+            />
+
+            <hr className="border-secondary mt-0 mb-4" />
+            <div className="form-check form-switch">
+              <input
+                className="form-check-input"
+                type="checkbox"
+                id="booru-dev-options-toggle"
+                checked={booruDevOptions}
+                onChange={(e) => setBooruDevOptionsPersistent(e.target.checked)}
+              />
+              <label
+                className="form-check-label text-muted-foreground text-sm"
+                htmlFor="booru-dev-options-toggle"
+              >
+                Developer options
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/favorites-sauce/SauceFavoritesSettings.tsx
+++ b/frontend/src/features/favorites-sauce/SauceFavoritesSettings.tsx
@@ -1,21 +1,6 @@
-import { BooruSitesPanel } from '@/BooruSitesPanel';
-import type {
-  FavoriteSyncStatus,
-  SauceProgress,
-  SauceSettings,
-  SauceSource,
-} from '@/api';
-import type { CredentialProvider } from '@/api';
-import { formatDateTime } from '@/lib/format';
+import type { CredentialProvider, SauceProgress, SauceSource } from '@/api';
 
 type FetchState = { loading: boolean; error: string | null };
-
-interface FavoritesSettings {
-  reverseSyncEnabled: boolean;
-  autoSyncMidnight: boolean;
-  autoFavEnabled: boolean;
-  favoritesRootId: string | null;
-}
 
 interface SauceProgressSegments {
   matched: number;
@@ -24,7 +9,6 @@ interface SauceProgressSegments {
 }
 
 export interface SauceFavoritesSettingsProps {
-  // Sauce state
   sauceSources: SauceSource[];
   sauceProgress: SauceProgress;
   sauceState: FetchState;
@@ -32,45 +16,32 @@ export interface SauceFavoritesSettingsProps {
   displaySet: Set<string>;
   targetSet: Set<string>;
 
-  // Favorites state
-  favoritesSyncState: FetchState;
-  favoritesSyncStatus: FavoriteSyncStatus | null;
-  favoritesSettings: FavoritesSettings;
-  favoritesSettingsState: FetchState;
-  favoritesProgress: number | null;
-  favoritesSummary: string[];
-  favoritesErrors: string[];
-
-  // Legacy credential state (for E621 / Danbooru legacy cards)
-  e621Ready: boolean;
-  danbooruReady: boolean;
   saucenaoReady: boolean;
   credentialsState: FetchState;
   credentialLastProvider: CredentialProvider | null;
-  credentialInputs: Record<CredentialProvider, { username: string; apiKey: string }>;
+  credentialInputs: Record<
+    CredentialProvider,
+    { username: string; apiKey: string }
+  >;
   credentialExpanded: Record<CredentialProvider, boolean>;
 
-  // Booru dev options
-  booruDevOptions: boolean;
-
-  // Handlers — sauce
   toggleDisplaySauce: (key: string) => void;
   toggleTargetSauce: (key: string) => void;
   setAllDisplay: (value: boolean) => void;
   setAllTargets: (value: boolean) => void;
 
-  // Handlers — favorites
-  runFavoritesSync: (deleteMissing: boolean) => Promise<void>;
-  updateFavoritesSettings: (updates: Partial<Omit<FavoritesSettings, 'favoritesRootId'> & { favoritesRootId?: string | null }>) => Promise<void>;
-
-  // Handlers — legacy credentials
   logoutCredential: (provider: CredentialProvider) => Promise<void>;
   saveCredential: (provider: CredentialProvider) => Promise<void>;
-  updateCredentialInput: (provider: CredentialProvider, field: 'username' | 'apiKey', value: string) => void;
-  setCredentialExpanded: (updater: (prev: Record<CredentialProvider, boolean>) => Record<CredentialProvider, boolean>) => void;
-
-  // Handlers — dev options
-  setBooruDevOptionsPersistent: (next: boolean) => void;
+  updateCredentialInput: (
+    provider: CredentialProvider,
+    field: 'username' | 'apiKey',
+    value: string
+  ) => void;
+  setCredentialExpanded: (
+    updater: (
+      prev: Record<CredentialProvider, boolean>
+    ) => Record<CredentialProvider, boolean>
+  ) => void;
 }
 
 export function SauceFavoritesSettings({
@@ -80,531 +51,263 @@ export function SauceFavoritesSettings({
   sauceProgressSegments,
   displaySet,
   targetSet,
-  favoritesSyncState,
-  favoritesSyncStatus,
-  favoritesSettings,
-  favoritesSettingsState,
-  favoritesProgress,
-  favoritesSummary,
-  favoritesErrors,
-  e621Ready,
-  danbooruReady,
   saucenaoReady,
   credentialsState,
   credentialLastProvider,
   credentialInputs,
   credentialExpanded,
-  booruDevOptions,
   toggleDisplaySauce,
   toggleTargetSauce,
   setAllDisplay,
   setAllTargets,
-  runFavoritesSync,
-  updateFavoritesSettings,
   logoutCredential,
   saveCredential,
   updateCredentialInput,
-  setCredentialExpanded,
-  setBooruDevOptionsPersistent,
+  setCredentialExpanded
 }: SauceFavoritesSettingsProps) {
   return (
     <>
-      {/* Sync favorites section */}
-      <div className="col-12 settings-section">
-        <div className="card bg-transparent text-foreground border-0 h-full settings-section-card">
-          <div className="card-body">
-            <div className="flex justify-between items-center mb-2">
-              <h2 className="h5 mb-0">Sync favorites</h2>
+      <div className="col-12 settings-section settings-section-flat text-foreground">
+        <div className="flex justify-between items-center mb-2">
+          <h2 className="h5 mb-0">Sauces</h2>
+        </div>
+        <p className="text-muted-foreground text-sm mb-4">
+          Pick which sources appear in the file view and which ones the scanner
+          should look for automatically. Targeted sources are retried daily for
+          up to a week or until a match is found.
+        </p>
+        <div className="credential-grid mb-4">
+          <div className="credential-col">
+            <div className="border border-secondary rounded p-2 credential-card">
+              <div className="flex justify-between items-center gap-2">
+                <div className="font-semibold">SauceNAO</div>
+                <div className="flex items-center gap-2">
+                  {saucenaoReady ? (
+                    <>
+                      <button
+                        type="button"
+                        className="btn btn-outline-light btn-sm"
+                        onClick={() => void logoutCredential('SAUCENAO')}
+                        disabled={credentialsState.loading}
+                      >
+                        Log out
+                      </button>
+                      <span className="btn btn-success btn-sm credential-status">
+                        Logged in
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        type="button"
+                        className="btn btn-outline-light btn-sm"
+                        onClick={() =>
+                          setCredentialExpanded((prev) => ({
+                            ...prev,
+                            SAUCENAO: true
+                          }))
+                        }
+                        disabled={credentialsState.loading}
+                      >
+                        Log in
+                      </button>
+                      <span className="btn btn-danger btn-sm credential-status">
+                        Logged out
+                      </span>
+                    </>
+                  )}
+                </div>
+              </div>
+              {!saucenaoReady && credentialExpanded.SAUCENAO ? (
+                <div
+                  className="mt-2 credential-fields"
+                  id="credential-saucenao"
+                >
+                  <label
+                    className="form-label text-sm text-muted-foreground"
+                    htmlFor="cred-saucenao-username"
+                  >
+                    Username
+                  </label>
+                  <input
+                    id="cred-saucenao-username"
+                    name="saucenao-username"
+                    type="text"
+                    className="form-control form-control-sm mb-2"
+                    value=""
+                    placeholder="Not used for SauceNAO"
+                    disabled
+                  />
+                  <label
+                    className="form-label text-sm text-muted-foreground"
+                    htmlFor="cred-saucenao-apikey"
+                  >
+                    API key
+                  </label>
+                  <input
+                    id="cred-saucenao-apikey"
+                    name="saucenao-api-key"
+                    type="password"
+                    className="form-control form-control-sm"
+                    value={credentialInputs.SAUCENAO.apiKey}
+                    onChange={(event) =>
+                      updateCredentialInput(
+                        'SAUCENAO',
+                        'apiKey',
+                        event.target.value
+                      )
+                    }
+                    placeholder="Enter API key"
+                    disabled={credentialsState.loading}
+                  />
+                  <div className="flex items-center gap-2 mt-2">
+                    <button
+                      className="btn btn-outline-light btn-sm"
+                      onClick={() => void saveCredential('SAUCENAO')}
+                      disabled={credentialsState.loading}
+                    >
+                      Save
+                    </button>
+                  </div>
+                </div>
+              ) : null}
             </div>
-            <p className="text-muted-foreground text-sm mb-4">
-              Connect your e621 and Danbooru accounts to double-sync favorites.
-            </p>
-
-            <BooruSitesPanel className="mb-6" devOptions={booruDevOptions} />
-
-            <div className="flex flex-wrap gap-2 mb-2">
+          </div>
+          <div className="credential-col">
+            <div className="border border-secondary rounded p-2 credential-card">
+              <div className="flex justify-between items-center gap-2">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <div className="font-semibold">Fluffle</div>
+                  <div className="text-muted-foreground text-sm">
+                    No login required.
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="btn btn-success btn-sm credential-status">
+                    Working
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        {credentialsState.error && credentialLastProvider === 'SAUCENAO' ? (
+          <div className="text-destructive text-sm mb-2">
+            Credentials error: {credentialsState.error}
+          </div>
+        ) : null}
+        <div className="sauce-progress-wrap mb-4">
+          <div
+            className="sauce-progress-bar border border-secondary bg-background"
+            role="img"
+            aria-label="Sauce target scan progress"
+          >
+            <div
+              className="sauce-progress-segment bg-success"
+              style={{ width: `${sauceProgressSegments.matched}%` }}
+            />
+            <div
+              className="sauce-progress-segment bg-danger"
+              style={{ width: `${sauceProgressSegments.failed}%` }}
+            />
+            <div
+              className="sauce-progress-segment sauce-progress-segment-pending"
+              style={{ width: `${sauceProgressSegments.pending}%` }}
+            />
+          </div>
+          <div className="sauce-progress-legend text-muted-foreground text-sm mt-2">
+            <span className="sauce-progress-legend-item">
+              <span className="sauce-progress-dot bg-success" />
+              Target found ({sauceProgress.matched})
+            </span>
+            <span className="sauce-progress-legend-item">
+              <span className="sauce-progress-dot bg-danger" />
+              Failed ({sauceProgress.failed})
+            </span>
+            <span className="sauce-progress-legend-item">
+              <span className="sauce-progress-dot sauce-progress-dot-pending" />
+              Pending ({sauceProgress.pending})
+            </span>
+          </div>
+          <hr className="sauce-progress-separator" />
+        </div>
+        {sauceState.error ? (
+          <div className="text-destructive mb-2">Error: {sauceState.error}</div>
+        ) : null}
+        {sauceSources.length === 0 ? (
+          <p className="text-muted-foreground">No sources discovered yet.</p>
+        ) : (
+          <>
+            <div className="flex flex-wrap gap-2 mb-4">
               <button
                 className="btn btn-outline-light btn-sm"
-                onClick={() => void runFavoritesSync(true)}
-                disabled={favoritesSyncState.loading}
+                onClick={() => setAllDisplay(true)}
               >
-                Sync favorites
+                Show all
+              </button>
+              <button
+                className="btn btn-outline-light btn-sm"
+                onClick={() => setAllDisplay(false)}
+              >
+                Show none
+              </button>
+              <button
+                className="btn btn-outline-light btn-sm"
+                onClick={() => setAllTargets(true)}
+              >
+                Target all
+              </button>
+              <button
+                className="btn btn-outline-light btn-sm"
+                onClick={() => setAllTargets(false)}
+              >
+                Clear targets
               </button>
             </div>
-            <div className="form-check form-switch mb-2">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                id="auto-sync-toggle-top"
-                checked={favoritesSettings.autoSyncMidnight}
-                onChange={(event) => void updateFavoritesSettings({ autoSyncMidnight: event.target.checked })}
-                disabled={favoritesSettingsState.loading}
-              />
-              <label className="form-check-label text-muted-foreground text-sm" htmlFor="auto-sync-toggle-top">
-                Run a daily sync at midnight to keep favorites current
-              </label>
-            </div>
-            <div className="form-check form-switch mb-2">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                id="reverse-sync-toggle-top"
-                checked={favoritesSettings.reverseSyncEnabled}
-                onChange={(event) => void updateFavoritesSettings({ reverseSyncEnabled: event.target.checked })}
-                disabled={favoritesSettingsState.loading}
-              />
-              <label className="form-check-label text-muted-foreground text-sm" htmlFor="reverse-sync-toggle-top">
-                When you delete a file here, also remove it from favorites
-              </label>
-            </div>
-            <div className="form-check form-switch mb-4">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                id="auto-fav-toggle-top"
-                checked={favoritesSettings.autoFavEnabled}
-                onChange={(event) => void updateFavoritesSettings({ autoFavEnabled: event.target.checked })}
-                disabled={favoritesSettingsState.loading}
-              />
-              <label className="form-check-label text-muted-foreground text-sm" htmlFor="auto-fav-toggle-top">
-                When the sources scanner finds a match on a logged-in source, auto-favorite it there
-              </label>
-            </div>
-
-            <details className="mb-4">
-              <summary className="text-muted-foreground text-sm">Legacy credential cards (E621 / Danbooru)</summary>
-              <div className="credential-grid mb-4">
-                <div className="credential-col">
-                  <div className="border border-secondary rounded p-2 credential-card">
-                    <div className="flex justify-between items-center gap-2">
-                      <div className="font-semibold">e621</div>
-                      <div className="flex items-center gap-2">
-                        {e621Ready ? (
-                          <>
-                            <button
-                              type="button"
-                              className="btn btn-outline-light btn-sm"
-                              onClick={() => void logoutCredential('E621')}
-                              disabled={credentialsState.loading}
-                            >
-                              Log out
-                            </button>
-                            <span className="btn btn-success btn-sm credential-status">Logged in</span>
-                          </>
-                        ) : (
-                          <>
-                            <button
-                              type="button"
-                              className="btn btn-outline-light btn-sm"
-                              onClick={() =>
-                                setCredentialExpanded((prev) => ({ ...prev, E621: true }))
-                              }
-                              disabled={credentialsState.loading}
-                            >
-                              Log in
-                            </button>
-                            <span className="btn btn-danger btn-sm credential-status">Logged out</span>
-                          </>
-                        )}
-                      </div>
-                    </div>
-                    {!e621Ready && credentialExpanded.E621 ? (
-                      <div className="mt-2 credential-fields" id="credential-e621">
-                        <label className="form-label text-sm text-muted-foreground" htmlFor="cred-e621-username">Username</label>
-                        <input
-                          id="cred-e621-username"
-                          name="e621-username"
-                          type="text"
-                          className="form-control form-control-sm mb-2"
-                          value={credentialInputs.E621.username}
-                          onChange={(event) => updateCredentialInput('E621', 'username', event.target.value)}
-                          placeholder="Enter your e621 username"
-                          disabled={credentialsState.loading}
-                          autoComplete="username"
-                        />
-                        <label className="form-label text-sm text-muted-foreground" htmlFor="cred-e621-apikey">API key</label>
-                        <input
-                          id="cred-e621-apikey"
-                          name="e621-api-key"
-                          type="password"
-                          className="form-control form-control-sm"
-                          value={credentialInputs.E621.apiKey}
-                          onChange={(event) => updateCredentialInput('E621', 'apiKey', event.target.value)}
-                          placeholder="Enter API key"
-                          disabled={credentialsState.loading}
-                          autoComplete="off"
-                        />
-                        <div className="flex items-center gap-2 mt-2">
-                          <button
-                            className="btn btn-outline-light btn-sm"
-                            onClick={() => void saveCredential('E621')}
-                            disabled={credentialsState.loading}
-                          >
-                            Save
-                          </button>
-                        </div>
-                      </div>
-                    ) : null}
-                  </div>
-                </div>
-                <div className="credential-col">
-                  <div className="border border-secondary rounded p-2 credential-card">
-                    <div className="flex justify-between items-center gap-2">
-                      <div className="font-semibold">Danbooru</div>
-                      <div className="flex items-center gap-2">
-                        {danbooruReady ? (
-                          <>
-                            <button
-                              type="button"
-                              className="btn btn-outline-light btn-sm"
-                              onClick={() => void logoutCredential('DANBOORU')}
-                              disabled={credentialsState.loading}
-                            >
-                              Log out
-                            </button>
-                            <span className="btn btn-success btn-sm credential-status">Logged in</span>
-                          </>
-                        ) : (
-                          <>
-                            <button
-                              type="button"
-                              className="btn btn-outline-light btn-sm"
-                              onClick={() =>
-                                setCredentialExpanded((prev) => ({ ...prev, DANBOORU: true }))
-                              }
-                              disabled={credentialsState.loading}
-                            >
-                              Log in
-                            </button>
-                            <span className="btn btn-danger btn-sm credential-status">Logged out</span>
-                          </>
-                        )}
-                      </div>
-                    </div>
-                    {!danbooruReady && credentialExpanded.DANBOORU ? (
-                      <div className="mt-2 credential-fields" id="credential-danbooru">
-                        <label className="form-label text-sm text-muted-foreground" htmlFor="cred-danbooru-username">Username</label>
-                        <input
-                          id="cred-danbooru-username"
-                          name="danbooru-username"
-                          type="text"
-                          className="form-control form-control-sm mb-2"
-                          value={credentialInputs.DANBOORU.username}
-                          onChange={(event) => updateCredentialInput('DANBOORU', 'username', event.target.value)}
-                          placeholder="Enter your Danbooru username"
-                          disabled={credentialsState.loading}
-                          autoComplete="username"
-                        />
-                        <label className="form-label text-sm text-muted-foreground" htmlFor="cred-danbooru-apikey">API key</label>
-                        <input
-                          id="cred-danbooru-apikey"
-                          name="danbooru-api-key"
-                          type="password"
-                          className="form-control form-control-sm"
-                          value={credentialInputs.DANBOORU.apiKey}
-                          onChange={(event) => updateCredentialInput('DANBOORU', 'apiKey', event.target.value)}
-                          placeholder="Enter API key"
-                          disabled={credentialsState.loading}
-                          autoComplete="off"
-                        />
-                        <div className="flex items-center gap-2 mt-2">
-                          <button
-                            className="btn btn-outline-light btn-sm"
-                            onClick={() => void saveCredential('DANBOORU')}
-                            disabled={credentialsState.loading}
-                          >
-                            Save
-                          </button>
-                        </div>
-                      </div>
-                    ) : null}
-                  </div>
-                </div>
-              </div>
-            </details>
-            {credentialsState.error &&
-            (credentialLastProvider === null ||
-              credentialLastProvider === 'E621' ||
-              credentialLastProvider === 'DANBOORU') ? (
-              <div className="text-destructive text-sm mb-2">Credentials error: {credentialsState.error}</div>
-            ) : null}
-            {favoritesSettingsState.error ? (
-              <div className="text-destructive text-sm">Settings error: {favoritesSettingsState.error}</div>
-            ) : null}
-            {favoritesSyncState.loading || favoritesSyncStatus?.status === 'running' ? (
-              <div className="text-muted-foreground text-sm">
-                {favoritesSyncStatus?.message ?? 'Syncing favorites…'}
-              </div>
-            ) : null}
-            {favoritesSyncStatus ? (
-              <div className="text-muted-foreground text-sm mt-1">
-                <div>Last sync started: {formatDateTime(favoritesSyncStatus.startedAt)}</div>
-                <div>Last sync updated: {formatDateTime(favoritesSyncStatus.updatedAt)}</div>
-              </div>
-            ) : null}
-            {favoritesSyncState.error ? (
-              <div className="text-destructive text-sm">Error: {favoritesSyncState.error}</div>
-            ) : null}
-            {favoritesSyncStatus?.status === 'running' && favoritesProgress !== null ? (
-              <div className="progress bg-background border border-secondary mt-2" style={{ height: 8 }}>
-                <div
-                  className="progress-bar bg-info"
-                  role="progressbar"
-                  style={{ width: `${favoritesProgress}%` }}
-                  aria-valuenow={favoritesProgress}
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                />
-              </div>
-            ) : null}
-            {favoritesSyncStatus?.progress?.providers?.length ? (
-              <div className="text-muted-foreground text-sm mt-2">
-                {favoritesSyncStatus.progress.providers.map((entry) => (
-                  <div key={entry.provider}>
-                    {entry.provider}: {entry.stage} · {entry.processed}/{entry.total} · +{entry.added} / -
-                    {entry.removed}
-                  </div>
-                ))}
-              </div>
-            ) : null}
-            {favoritesSummary.length ? (
-              <div className="text-muted-foreground text-sm">
-                {favoritesSummary.map((line) => (
-                  <div key={line}>{line}</div>
-                ))}
-              </div>
-            ) : null}
-            {favoritesErrors.length ? (
-              <div className="text-destructive text-sm mt-2">
-                {favoritesErrors.slice(0, 6).map((line) => (
-                  <div key={line}>{line}</div>
-                ))}
-                {favoritesErrors.length > 6 ? (
-                  <div>…and {favoritesErrors.length - 6} more errors</div>
-                ) : null}
-              </div>
-            ) : null}
-          </div>
-        </div>
-      </div>
-
-      {/* Sauces section */}
-      <div className="col-12 settings-section">
-        <div className="card bg-transparent text-foreground border-0 h-full settings-section-card">
-          <div className="card-body">
-            <div className="flex justify-between items-center mb-2">
-              <h2 className="h5 mb-0">Sauces</h2>
-            </div>
-            <p className="text-muted-foreground text-sm mb-4">
-              Pick which sources appear in the file view and which ones the scanner should look for
-              automatically. Targeted sources are retried daily for up to a week or until a match is found.
-            </p>
-            <div className="credential-grid mb-4">
-              <div className="credential-col">
-                <div className="border border-secondary rounded p-2 credential-card">
-                  <div className="flex justify-between items-center gap-2">
-                    <div className="font-semibold">SauceNAO</div>
-                    <div className="flex items-center gap-2">
-                      {saucenaoReady ? (
-                        <>
-                          <button
-                            type="button"
-                            className="btn btn-outline-light btn-sm"
-                            onClick={() => void logoutCredential('SAUCENAO')}
-                            disabled={credentialsState.loading}
-                          >
-                            Log out
-                          </button>
-                          <span className="btn btn-success btn-sm credential-status">Logged in</span>
-                        </>
-                      ) : (
-                        <>
-                          <button
-                            type="button"
-                            className="btn btn-outline-light btn-sm"
-                            onClick={() =>
-                              setCredentialExpanded((prev) => ({ ...prev, SAUCENAO: true }))
-                            }
-                            disabled={credentialsState.loading}
-                          >
-                            Log in
-                          </button>
-                          <span className="btn btn-danger btn-sm credential-status">Logged out</span>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                  {!saucenaoReady && credentialExpanded.SAUCENAO ? (
-                    <div className="mt-2 credential-fields" id="credential-saucenao">
-                      <label className="form-label text-sm text-muted-foreground" htmlFor="cred-saucenao-username">Username</label>
-                      <input
-                        id="cred-saucenao-username"
-                        name="saucenao-username"
-                        type="text"
-                        className="form-control form-control-sm mb-2"
-                        value=""
-                        placeholder="Not used for SauceNAO"
-                        disabled
-                      />
-                      <label className="form-label text-sm text-muted-foreground" htmlFor="cred-saucenao-apikey">API key</label>
-                      <input
-                        id="cred-saucenao-apikey"
-                        name="saucenao-api-key"
-                        type="password"
-                        className="form-control form-control-sm"
-                        value={credentialInputs.SAUCENAO.apiKey}
-                        onChange={(event) => updateCredentialInput('SAUCENAO', 'apiKey', event.target.value)}
-                        placeholder="Enter API key"
-                        disabled={credentialsState.loading}
-                      />
-                      <div className="flex items-center gap-2 mt-2">
-                        <button
-                          className="btn btn-outline-light btn-sm"
-                          onClick={() => void saveCredential('SAUCENAO')}
-                          disabled={credentialsState.loading}
-                        >
-                          Save
-                        </button>
-                      </div>
-                    </div>
-                  ) : null}
-                </div>
-              </div>
-              <div className="credential-col">
-                <div className="border border-secondary rounded p-2 credential-card">
-                  <div className="flex justify-between items-center gap-2">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <div className="font-semibold">Fluffle</div>
-                      <div className="text-muted-foreground text-sm">No login required.</div>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span className="btn btn-success btn-sm credential-status">Working</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            {credentialsState.error && credentialLastProvider === 'SAUCENAO' ? (
-              <div className="text-destructive text-sm mb-2">Credentials error: {credentialsState.error}</div>
-            ) : null}
-            <div className="sauce-progress-wrap mb-4">
-              <div className="sauce-progress-bar border border-secondary bg-background" role="img" aria-label="Sauce target scan progress">
-                <div
-                  className="sauce-progress-segment bg-success"
-                  style={{ width: `${sauceProgressSegments.matched}%` }}
-                />
-                <div
-                  className="sauce-progress-segment bg-danger"
-                  style={{ width: `${sauceProgressSegments.failed}%` }}
-                />
-                <div
-                  className="sauce-progress-segment sauce-progress-segment-pending"
-                  style={{ width: `${sauceProgressSegments.pending}%` }}
-                />
-              </div>
-              <div className="sauce-progress-legend text-muted-foreground text-sm mt-2">
-                <span className="sauce-progress-legend-item">
-                  <span className="sauce-progress-dot bg-success" />
-                  Target found ({sauceProgress.matched})
-                </span>
-                <span className="sauce-progress-legend-item">
-                  <span className="sauce-progress-dot bg-danger" />
-                  Failed ({sauceProgress.failed})
-                </span>
-                <span className="sauce-progress-legend-item">
-                  <span className="sauce-progress-dot sauce-progress-dot-pending" />
-                  Pending ({sauceProgress.pending})
-                </span>
-              </div>
-              <hr className="sauce-progress-separator" />
-            </div>
-            {sauceState.error ? <div className="text-destructive mb-2">Error: {sauceState.error}</div> : null}
-            {sauceSources.length === 0 ? (
-              <p className="text-muted-foreground">No sources discovered yet.</p>
-            ) : (
-              <>
-                <div className="flex flex-wrap gap-2 mb-4">
-                  <button className="btn btn-outline-light btn-sm" onClick={() => setAllDisplay(true)}>
-                    Show all
-                  </button>
-                  <button className="btn btn-outline-light btn-sm" onClick={() => setAllDisplay(false)}>
-                    Show none
-                  </button>
-                  <button className="btn btn-outline-light btn-sm" onClick={() => setAllTargets(true)}>
-                    Target all
-                  </button>
-                  <button className="btn btn-outline-light btn-sm" onClick={() => setAllTargets(false)}>
-                    Clear targets
-                  </button>
-                </div>
-                <div className="table-responsive">
-                  <table className="table table-dark table-sm align-middle mb-0">
-                    <thead>
-                      <tr>
-                        <th>Source</th>
-                        <th className="text-center">Show</th>
-                        <th className="text-center">Target</th>
-                        <th className="text-right">Hits</th>
+            <div className="table-responsive">
+              <table className="table table-dark table-sm align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th>Source</th>
+                    <th className="text-center">Show</th>
+                    <th className="text-center">Target</th>
+                    <th className="text-right">Hits</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sauceSources.map((source) => {
+                    const displayChecked = displaySet.has(source.key);
+                    const targetChecked = targetSet.has(source.key);
+                    return (
+                      <tr key={source.key}>
+                        <td>{source.label}</td>
+                        <td className="text-center">
+                          <input
+                            type="checkbox"
+                            className="form-check-input"
+                            checked={displayChecked}
+                            onChange={() => toggleDisplaySauce(source.key)}
+                          />
+                        </td>
+                        <td className="text-center">
+                          <input
+                            type="checkbox"
+                            className="form-check-input"
+                            checked={targetChecked}
+                            onChange={() => toggleTargetSauce(source.key)}
+                          />
+                        </td>
+                        <td className="text-right text-muted-foreground">
+                          {source.count}
+                        </td>
                       </tr>
-                    </thead>
-                    <tbody>
-                      {sauceSources.map((source) => {
-                        const displayChecked = displaySet.has(source.key);
-                        const targetChecked = targetSet.has(source.key);
-                        return (
-                          <tr key={source.key}>
-                            <td>{source.label}</td>
-                            <td className="text-center">
-                              <input
-                                type="checkbox"
-                                className="form-check-input"
-                                checked={displayChecked}
-                                onChange={() => toggleDisplaySauce(source.key)}
-                              />
-                            </td>
-                            <td className="text-center">
-                              <input
-                                type="checkbox"
-                                className="form-check-input"
-                                checked={targetChecked}
-                                onChange={() => toggleTargetSauce(source.key)}
-                              />
-                            </td>
-                            <td className="text-right text-muted-foreground">{source.count}</td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
-              </>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {/* Developer options toggle */}
-      <div className="col-12 settings-section">
-        <div className="card bg-transparent text-foreground border-0 h-full settings-section-card">
-          <div className="card-body">
-            <hr className="border-secondary mt-0 mb-4" />
-            <div className="form-check form-switch">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                id="booru-dev-options-toggle"
-                checked={booruDevOptions}
-                onChange={(e) => setBooruDevOptionsPersistent(e.target.checked)}
-              />
-              <label
-                className="form-check-label text-muted-foreground text-sm"
-                htmlFor="booru-dev-options-toggle"
-              >
-                Developer options
-              </label>
+                    );
+                  })}
+                </tbody>
+              </table>
             </div>
-          </div>
-        </div>
+          </>
+        )}
       </div>
     </>
   );

--- a/frontend/src/features/favorites-sauce/useSauceFavoritesController.ts
+++ b/frontend/src/features/favorites-sauce/useSauceFavoritesController.ts
@@ -1,24 +1,32 @@
 import { useMemo, useState } from 'react';
 
-import type { AuthUser, CredentialProvider, CredentialSummary, FavoriteSyncStatus, SauceProgress, SauceSettings, SauceSource } from '@/api';
-import { useCredentials, useUpdateCredential } from '@/hooks/credentials';
-import { useFavoritesSettings, useFavoritesSyncStatus, useSyncFavorites, useUpdateFavoritesSettings } from '@/hooks/favorites';
-import { useSauces, useUpdateSauceSettings } from '@/hooks/sauces';
-import { useSettingsUiStore } from '@/stores/settingsUiStore';
 import type { SauceFavoritesSettingsProps } from './SauceFavoritesSettings';
 
-// ---------------------------------------------------------------------------
-// Local types (mirror App.tsx local types; not exported from api)
-// ---------------------------------------------------------------------------
+import type {
+  AuthUser,
+  CredentialProvider,
+  CredentialSummary,
+  FavoriteSyncStatus,
+  SauceProgress,
+  SauceSettings,
+  SauceSource
+} from '@/api';
+import type { FavoritesAccountsSettingsProps } from '@/features/favorites-accounts/FavoritesAccountsSettings';
+import { useCredentials, useUpdateCredential } from '@/hooks/credentials';
+import {
+  useFavoritesSettings,
+  useFavoritesSyncStatus,
+  useSyncFavorites,
+  useUpdateFavoritesSettings
+} from '@/hooks/favorites';
+import { useSauces, useUpdateSauceSettings } from '@/hooks/sauces';
+import { useSettingsUiStore } from '@/stores/settingsUiStore';
 
 type FetchState = { loading: boolean; error: string | null };
 
-interface FavoritesSettings {
-  reverseSyncEnabled: boolean;
-  autoSyncMidnight: boolean;
-  autoFavEnabled: boolean;
+type FavoritesRootSettings = {
   favoritesRootId: string | null;
-}
+};
 
 interface SauceProgressSegments {
   matched: number;
@@ -26,17 +34,13 @@ interface SauceProgressSegments {
   pending: number;
 }
 
-// ---------------------------------------------------------------------------
-// Helpers (mirrored from App.tsx)
-// ---------------------------------------------------------------------------
-
 const emptySauceProgress: SauceProgress = {
   total: 0,
   matched: 0,
   failed: 0,
   pending: 0,
   videos: 0,
-  failedImages: 0,
+  failedImages: 0
 };
 
 const normalizeSauceKey = (value: string) => value.trim().toLowerCase();
@@ -49,7 +53,7 @@ const canonicalSauces: Record<string, string> = {
   'static3.e621.net': 'e621',
   'static4.e621.net': 'e621',
   'danbooru.donmai.us': 'danbooru',
-  'www.danbooru.donmai.us': 'danbooru',
+  'www.danbooru.donmai.us': 'danbooru'
 };
 
 const canonicalizeSauceKey = (value: string): string => {
@@ -61,46 +65,31 @@ const canonicalizeSauceKey = (value: string): string => {
 
 const isCredentialReady = (
   provider: CredentialProvider,
-  credential: CredentialSummary | undefined,
+  credential: CredentialSummary | undefined
 ): boolean => {
   if (!credential) return false;
   if (provider === 'SAUCENAO') return credential.hasApiKey;
   return Boolean(credential.username) && credential.hasApiKey;
 };
 
-// ---------------------------------------------------------------------------
-// Hook I/O types
-// ---------------------------------------------------------------------------
-
 export type SauceFavoritesControllerInput = {
-  /** Gates all queries — pass null when not authenticated. */
   authUser: AuthUser | null;
 };
 
 export type SauceFavoritesControllerOutput = {
-  /** Exact prop bag consumed by SauceFavoritesSettings. */
-  settingsProps: SauceFavoritesSettingsProps;
-  /** Shared with file-detail panel (displayFilterActive). */
+  sauceSettingsProps: SauceFavoritesSettingsProps;
+  favoritesAccountsProps: FavoritesAccountsSettingsProps;
   sauceSettings: SauceSettings;
-  /** Credential ready flags consumed by file-detail provider scan. */
-  credentialsReady: { E621: boolean; DANBOORU: boolean; SAUCENAO: boolean };
-  /** Raw sync status exposed to callers that track running state. */
-  favoritesSyncStatus: FavoriteSyncStatus | null;
+  favoritesRootSettings: FavoritesRootSettings;
+  favoritesRootSettingsState: FetchState;
+  updateFavoritesRoot: (favoritesRootId: string | null) => Promise<void>;
 };
 
-// ---------------------------------------------------------------------------
-// Controller hook
-// ---------------------------------------------------------------------------
-
 export function useSauceFavoritesController(
-  input: SauceFavoritesControllerInput,
+  input: SauceFavoritesControllerInput
 ): SauceFavoritesControllerOutput {
   const { authUser } = input;
   const enabled = Boolean(authUser);
-
-  // ------------------------------------------------------------------
-  // TanStack queries
-  // ------------------------------------------------------------------
 
   const saucesQuery = useSauces({ enabled });
   const updateSauceSettingsMutation = useUpdateSauceSettings();
@@ -110,90 +99,103 @@ export function useSauceFavoritesController(
 
   const syncFavoritesMutation = useSyncFavorites();
 
-  // Derive whether a sync is actively running so we can drive refetchInterval
-  // from query data rather than a separate setInterval.
-  // We read from the query cache first; if undefined, treat as not running.
   const favoritesSyncStatusQuery = useFavoritesSyncStatus({
     enabled,
-    // Poll every 2 s while a sync is running; TanStack Query stops when tab is
-    // hidden and resumes automatically — cleaner than a manual setInterval.
     refetchInterval: (query) => {
       const data = query.state.data as FavoriteSyncStatus | undefined;
       return data?.status === 'running' ? 2000 : false;
-    },
+    }
   });
   const favoritesSyncStatus = favoritesSyncStatusQuery.data ?? null;
 
   const credentialsQuery = useCredentials({ enabled });
   const updateCredentialMutation = useUpdateCredential();
 
-  // ------------------------------------------------------------------
-  // Local state that the UI still needs (loading/error overlays)
-  // ------------------------------------------------------------------
+  const [sauceState, setSauceState] = useState<FetchState>({
+    loading: false,
+    error: null
+  });
+  const [favoritesSyncState, setFavoritesSyncState] = useState<FetchState>({
+    loading: false,
+    error: null
+  });
+  const [credentialsState, setCredentialsState] = useState<FetchState>({
+    loading: false,
+    error: null
+  });
 
-  const [sauceState, setSauceState] = useState<FetchState>({ loading: false, error: null });
-  const [favoritesSyncState, setFavoritesSyncState] = useState<FetchState>({ loading: false, error: null });
-  const [credentialsState, setCredentialsState] = useState<FetchState>({ loading: false, error: null });
-  const credentialLastProvider = useSettingsUiStore((state) => state.credentialLastProvider);
-  const setCredentialLastProvider = useSettingsUiStore((state) => state.setCredentialLastProvider);
-  const credentialInputs = useSettingsUiStore((state) => state.credentialInputs);
-  const setCredentialInputs = useSettingsUiStore((state) => state.setCredentialInputs);
-  const credentialExpanded = useSettingsUiStore((state) => state.credentialExpanded);
-  const setCredentialExpanded = useSettingsUiStore((state) => state.setCredentialExpanded);
+  const credentialLastProvider = useSettingsUiStore(
+    (state) => state.credentialLastProvider
+  );
+  const setCredentialLastProvider = useSettingsUiStore(
+    (state) => state.setCredentialLastProvider
+  );
+  const credentialInputs = useSettingsUiStore(
+    (state) => state.credentialInputs
+  );
+  const setCredentialInputs = useSettingsUiStore(
+    (state) => state.setCredentialInputs
+  );
+  const credentialExpanded = useSettingsUiStore(
+    (state) => state.credentialExpanded
+  );
+  const setCredentialExpanded = useSettingsUiStore(
+    (state) => state.setCredentialExpanded
+  );
   const booruDevOptions = useSettingsUiStore((state) => state.booruDevOptions);
-  const setBooruDevOptions = useSettingsUiStore((state) => state.setBooruDevOptions);
+  const setBooruDevOptions = useSettingsUiStore(
+    (state) => state.setBooruDevOptions
+  );
 
-  // ------------------------------------------------------------------
-  // Derived data from queries
-  // ------------------------------------------------------------------
-
-  const sauceSources: SauceSource[] = saucesQuery.data?.sources ?? [];
+  const sauceSources: SauceSource[] = useMemo(
+    () => saucesQuery.data?.sources ?? [],
+    [saucesQuery.data?.sources]
+  );
   const sauceSettings: SauceSettings = useMemo(
     () => ({
       display: saucesQuery.data?.settings.display ?? [],
       targets: saucesQuery.data?.settings.targets ?? [],
-      displayInitialized: saucesQuery.data?.settings.displayInitialized ?? false,
+      displayInitialized: saucesQuery.data?.settings.displayInitialized ?? false
     }),
-    [saucesQuery.data],
+    [saucesQuery.data]
   );
-  const sauceProgress: SauceProgress = saucesQuery.data?.progress ?? emptySauceProgress;
+  const sauceProgress: SauceProgress =
+    saucesQuery.data?.progress ?? emptySauceProgress;
 
-  const favoritesSettings: FavoritesSettings = useMemo(
-    () =>
-      favoritesSettingsQuery.data ?? {
-        reverseSyncEnabled: false,
-        autoSyncMidnight: false,
-        autoFavEnabled: false,
-        favoritesRootId: null,
-      },
-    [favoritesSettingsQuery.data],
+  const favoritesRootSettings: FavoritesRootSettings = useMemo(
+    () => favoritesSettingsQuery.data ?? { favoritesRootId: null },
+    [favoritesSettingsQuery.data]
   );
-  const favoritesSettingsState: FetchState = {
+
+  const favoritesRootSettingsState: FetchState = {
     loading: favoritesSettingsQuery.isFetching,
-    error: favoritesSettingsQuery.error ? (favoritesSettingsQuery.error as Error).message : null,
+    error: favoritesSettingsQuery.error
+      ? (favoritesSettingsQuery.error as Error).message
+      : null
   };
 
-  const credentials = credentialsQuery.data ?? [];
+  const credentials = useMemo(
+    () => credentialsQuery.data ?? [],
+    [credentialsQuery.data]
+  );
   const credentialMap = useMemo(() => {
     const map = new Map<CredentialProvider, CredentialSummary>();
     credentials.forEach((entry) => map.set(entry.provider, entry));
     return map;
   }, [credentials]);
 
-  const e621Ready = isCredentialReady('E621', credentialMap.get('E621'));
-  const danbooruReady = isCredentialReady('DANBOORU', credentialMap.get('DANBOORU'));
-  const saucenaoReady = isCredentialReady('SAUCENAO', credentialMap.get('SAUCENAO'));
-
-  // ------------------------------------------------------------------
-  // Sauce derived values
-  // ------------------------------------------------------------------
+  const saucenaoReady = isCredentialReady(
+    'SAUCENAO',
+    credentialMap.get('SAUCENAO')
+  );
 
   const sauceKeys = useMemo(
     () => sauceSources.map((source) => canonicalizeSauceKey(source.key)),
-    [sauceSources],
+    [sauceSources]
   );
   const displayFilterActive =
-    (sauceSettings.displayInitialized ?? false) || sauceSettings.display.length > 0;
+    (sauceSettings.displayInitialized ?? false) ||
+    sauceSettings.display.length > 0;
 
   const displaySet = useMemo(() => {
     if (!displayFilterActive) return new Set(sauceKeys);
@@ -202,7 +204,7 @@ export function useSauceFavoritesController(
 
   const targetSet = useMemo(
     () => new Set(sauceSettings.targets.map(canonicalizeSauceKey)),
-    [sauceSettings.targets],
+    [sauceSettings.targets]
   );
 
   const sauceProgressSegments = useMemo((): SauceProgressSegments => {
@@ -213,14 +215,12 @@ export function useSauceFavoritesController(
     return { matched, failed, pending: Math.max(0, 100 - matched - failed) };
   }, [sauceProgress]);
 
-  // ------------------------------------------------------------------
-  // Favorites derived values
-  // ------------------------------------------------------------------
-
   const favoritesSummary = useMemo(() => {
     if (!favoritesSyncStatus?.results?.length) return [];
     return favoritesSyncStatus.results.map((entry) => {
-      const errors = entry.errors.length ? ` • ${entry.errors.length} errors` : '';
+      const errors = entry.errors.length
+        ? ` • ${entry.errors.length} errors`
+        : '';
       return `${entry.provider}: ${entry.added} added, ${entry.removed} removed, ${entry.skipped} skipped, ${entry.fetched} fetched${errors}`;
     });
   }, [favoritesSyncStatus]);
@@ -228,7 +228,7 @@ export function useSauceFavoritesController(
   const favoritesErrors = useMemo(() => {
     if (!favoritesSyncStatus?.results?.length) return [];
     return favoritesSyncStatus.results.flatMap((entry) =>
-      entry.errors.map((error) => `${entry.provider}: ${error}`),
+      entry.errors.map((error) => `${entry.provider}: ${error}`)
     );
   }, [favoritesSyncStatus]);
 
@@ -237,22 +237,19 @@ export function useSauceFavoritesController(
     const total = providers.reduce((sum, entry) => sum + (entry.total || 0), 0);
     const processed = providers.reduce(
       (sum, entry) => sum + Math.min(entry.processed || 0, entry.total || 0),
-      0,
+      0
     );
     if (!total) return null;
     return Math.min(100, Math.round((processed / total) * 100));
   }, [favoritesSyncStatus]);
 
-  // ------------------------------------------------------------------
-  // Sauce handlers
-  // ------------------------------------------------------------------
-
   const saveSauceSettings = async (next: SauceSettings) => {
-    const displayInitialized = next.displayInitialized ?? sauceSettings.displayInitialized ?? false;
+    const displayInitialized =
+      next.displayInitialized ?? sauceSettings.displayInitialized ?? false;
     const nextSettings: SauceSettings = {
       display: next.display ?? [],
       targets: next.targets ?? [],
-      displayInitialized,
+      displayInitialized
     };
     setSauceState({ loading: true, error: null });
     try {
@@ -276,7 +273,7 @@ export function useSauceFavoritesController(
     void saveSauceSettings({
       display: Array.from(base),
       targets: sauceSettings.targets,
-      displayInitialized: true,
+      displayInitialized: true
     });
   };
 
@@ -288,12 +285,19 @@ export function useSauceFavoritesController(
     } else {
       base.add(normalized);
     }
-    void saveSauceSettings({ display: sauceSettings.display, targets: Array.from(base) });
+    void saveSauceSettings({
+      display: sauceSettings.display,
+      targets: Array.from(base)
+    });
   };
 
   const setAllDisplay = (value: boolean) => {
     const next = value ? sauceKeys : [];
-    void saveSauceSettings({ display: next, targets: sauceSettings.targets, displayInitialized: true });
+    void saveSauceSettings({
+      display: next,
+      targets: sauceSettings.targets,
+      displayInitialized: true
+    });
   };
 
   const setAllTargets = (value: boolean) => {
@@ -301,55 +305,51 @@ export function useSauceFavoritesController(
     void saveSauceSettings({ display: sauceSettings.display, targets: next });
   };
 
-  // ------------------------------------------------------------------
-  // Favorites handlers
-  // ------------------------------------------------------------------
-
   const runFavoritesSync = async (deleteMissing: boolean): Promise<void> => {
     setFavoritesSyncState({ loading: true, error: null });
     try {
       await syncFavoritesMutation.mutateAsync({ deleteMissing });
       setFavoritesSyncState({ loading: false, error: null });
-      // refetchInterval on the status query takes over polling from here
     } catch (err) {
       setFavoritesSyncState({ loading: false, error: (err as Error).message });
     }
   };
 
-  const updateFavoritesSettings = async (
-    updates: Partial<Omit<FavoritesSettings, 'favoritesRootId'> & { favoritesRootId?: string | null }>,
+  const updateFavoritesRoot = async (
+    favoritesRootId: string | null
   ): Promise<void> => {
     try {
-      await updateFavoritesSettingsMutation.mutateAsync(updates);
+      await updateFavoritesSettingsMutation.mutateAsync({ favoritesRootId });
     } catch (err) {
-      // error surfaced via favoritesSettingsState.error from query
       throw err;
     }
   };
 
-  // ------------------------------------------------------------------
-  // Credential handlers
-  // ------------------------------------------------------------------
-
   const updateCredentialInput = (
     provider: CredentialProvider,
     field: 'username' | 'apiKey',
-    value: string,
+    value: string
   ) => {
     setCredentialInputs((prev) => ({
       ...prev,
-      [provider]: { ...prev[provider], [field]: value },
+      [provider]: { ...prev[provider], [field]: value }
     }));
   };
 
-  const saveCredential = async (provider: CredentialProvider): Promise<void> => {
+  const saveCredential = async (
+    provider: CredentialProvider
+  ): Promise<void> => {
     setCredentialLastProvider(provider);
     setCredentialsState({ loading: true, error: null });
     try {
       const inputEntry = credentialInputs[provider];
       const username = inputEntry.username.trim();
       const apiKey = inputEntry.apiKey.trim();
-      const payload: { provider: CredentialProvider; username?: string; apiKey?: string } = { provider };
+      const payload: {
+        provider: CredentialProvider;
+        username?: string;
+        apiKey?: string;
+      } = { provider };
       if (provider !== 'SAUCENAO' && username) {
         payload.username = username;
       }
@@ -364,9 +364,12 @@ export function useSauceFavoritesController(
       setCredentialInputs((prev) => ({
         ...prev,
         [provider]: {
-          username: provider === 'SAUCENAO' ? '' : (updated.username ?? prev[provider].username),
-          apiKey: '',
-        },
+          username:
+            provider === 'SAUCENAO'
+              ? ''
+              : (updated.username ?? prev[provider].username),
+          apiKey: ''
+        }
       }));
       setCredentialExpanded((prev) => ({ ...prev, [provider]: false }));
       setCredentialsState({ loading: false, error: null });
@@ -375,14 +378,20 @@ export function useSauceFavoritesController(
     }
   };
 
-  const logoutCredential = async (provider: CredentialProvider): Promise<void> => {
+  const logoutCredential = async (
+    provider: CredentialProvider
+  ): Promise<void> => {
     setCredentialLastProvider(provider);
     setCredentialsState({ loading: true, error: null });
     try {
-      await updateCredentialMutation.mutateAsync({ provider, username: '', apiKey: '' });
+      await updateCredentialMutation.mutateAsync({
+        provider,
+        username: '',
+        apiKey: ''
+      });
       setCredentialInputs((prev) => ({
         ...prev,
-        [provider]: { username: '', apiKey: '' },
+        [provider]: { username: '', apiKey: '' }
       }));
       setCredentialExpanded((prev) => ({ ...prev, [provider]: false }));
       setCredentialsState({ loading: false, error: null });
@@ -390,10 +399,6 @@ export function useSauceFavoritesController(
       setCredentialsState({ loading: false, error: (err as Error).message });
     }
   };
-
-  // ------------------------------------------------------------------
-  // Dev options handler
-  // ------------------------------------------------------------------
 
   const setBooruDevOptionsPersistent = (next: boolean) => {
     setBooruDevOptions(next);
@@ -402,64 +407,45 @@ export function useSauceFavoritesController(
     }
   };
 
-  // ------------------------------------------------------------------
-  // Assemble settingsProps
-  // ------------------------------------------------------------------
-
-  const settingsProps: SauceFavoritesSettingsProps = {
-    // Sauce state
+  const sauceSettingsProps: SauceFavoritesSettingsProps = {
     sauceSources,
     sauceProgress,
     sauceState,
     sauceProgressSegments,
     displaySet,
     targetSet,
-
-    // Favorites state
-    favoritesSyncState,
-    favoritesSyncStatus,
-    favoritesSettings,
-    favoritesSettingsState,
-    favoritesProgress,
-    favoritesSummary,
-    favoritesErrors,
-
-    // Legacy credential state
-    e621Ready,
-    danbooruReady,
     saucenaoReady,
     credentialsState,
     credentialLastProvider,
     credentialInputs,
     credentialExpanded,
-
-    // Dev options
-    booruDevOptions,
-
-    // Handlers — sauce
     toggleDisplaySauce,
     toggleTargetSauce,
     setAllDisplay,
     setAllTargets,
-
-    // Handlers — favorites
-    runFavoritesSync,
-    updateFavoritesSettings,
-
-    // Handlers — credentials
     logoutCredential,
     saveCredential,
     updateCredentialInput,
-    setCredentialExpanded,
+    setCredentialExpanded
+  };
 
-    // Handlers — dev options
-    setBooruDevOptionsPersistent,
+  const favoritesAccountsProps: FavoritesAccountsSettingsProps = {
+    favoritesSyncState,
+    favoritesSyncStatus,
+    favoritesProgress,
+    favoritesSummary,
+    favoritesErrors,
+    runFavoritesSync,
+    booruDevOptions,
+    setBooruDevOptionsPersistent
   };
 
   return {
-    settingsProps,
+    sauceSettingsProps,
+    favoritesAccountsProps,
     sauceSettings,
-    credentialsReady: { E621: e621Ready, DANBOORU: danbooruReady, SAUCENAO: saucenaoReady },
-    favoritesSyncStatus,
+    favoritesRootSettings,
+    favoritesRootSettingsState,
+    updateFavoritesRoot
   };
 }

--- a/frontend/src/features/folders/FoldersListPanel.tsx
+++ b/frontend/src/features/folders/FoldersListPanel.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
+
 import type { Folder } from '@/api';
 
 type FetchState = { loading: boolean; error: string | null };
 
-type FolderUploadPhase = 'uploading' | 'processing' | 'success' | 'warning' | 'error';
+type FolderUploadPhase =
+  | 'uploading'
+  | 'processing'
+  | 'success'
+  | 'warning'
+  | 'error';
 
 type FolderUploadState = {
   phase: FolderUploadPhase;
@@ -31,7 +37,9 @@ export interface FoldersListPanelProps {
   libraryRoot: string;
   uploadInputAccept: string;
   uploadInputRef: React.RefObject<HTMLInputElement | null>;
-  onFolderUploadInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onFolderUploadInputChange: (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => void;
   onOpenFolderUploadPicker: (folderId: string) => void;
   onUpdateFavoritesRoot: (folderId: string) => void;
   onDeleteFolder: (folder: Folder) => void;
@@ -69,109 +77,152 @@ export function FoldersListPanel({
   onOpenFolderUploadPicker,
   onUpdateFavoritesRoot,
   onDeleteFolder,
-  describeFolder,
+  describeFolder
 }: FoldersListPanelProps) {
   return (
-    <div className="col-12 settings-section">
-      <div className="card bg-transparent text-foreground border-0 h-full settings-section-card">
-        <div className="card-body">
-          <div className="flex justify-between items-center mb-4">
-            <h2 className="h5 mb-0">Library folders</h2>
-          </div>
-          <input
-            ref={uploadInputRef}
-            type="file"
-            className="hidden"
-            multiple
-            accept={uploadInputAccept}
-            onChange={onFolderUploadInputChange}
-          />
-          <div className="text-muted-foreground text-sm mb-4">
-            Your main library appears below automatically. Mounted folders also appear automatically when they
-            are direct children of your library root. Check the README for setup instructions.
-          </div>
-          {folderActionState.error ? (
-            <div className="text-destructive text-sm mb-4">Folder error: {folderActionState.error}</div>
-          ) : null}
-          {orderedFolders.length === 0 ? (
-            <p className="text-muted-foreground">No folders configured.</p>
-          ) : (
-            <div className="list-group folder-list">
-              {orderedFolders.map((folder) => {
-                const isFavoritesRoot = favoritesSettings.favoritesRootId === folder.id;
-                const folderInfo = folderDetailsById.get(folder.id) ?? describeFolder(folder, libraryRoot);
-                const uploadState = folderUploads[folder.id];
-                const uploadBusy = uploadState?.phase === 'uploading' || uploadState?.phase === 'processing';
-                return (
-                  <div
-                    key={folder.id}
-                    className={`list-group-item flex justify-between items-center bg-secondary text-foreground border border-secondary folder-card${folderInfo.isRoot ? ' folder-card-root' : ''}${uploadBusy ? ' folder-card-uploading' : ''}`}
-                  >
-                    <div className="folder-card-body">
-                      <div className="folder-card-header">
-                        <div className="folder-card-heading">
-                          <div className="font-semibold folder-card-title">{folderInfo.title}</div>
-                          {folderInfo.subtitle ? <div className="text-muted-foreground text-sm">{folderInfo.subtitle}</div> : null}
-                        </div>
-                        <div className="flex gap-2 folder-card-actions">
-                          <button
-                            className="btn btn-outline-light btn-sm"
-                            onClick={() => { onOpenFolderUploadPicker(folder.id); }}
-                            disabled={uploadBusy || folderActionState.loading}
-                            title="Upload files into this folder"
-                          >
-                            {uploadState?.phase === 'processing' ? 'Processing…' : uploadState?.phase === 'uploading' ? 'Uploading…' : 'Upload files'}
-                          </button>
-                          <button
-                            className={`btn btn-outline-warning btn-sm${isFavoritesRoot ? ' active' : ''}`}
-                            onClick={() => { onUpdateFavoritesRoot(folder.id); }}
-                            disabled={favoritesSettingsState.loading || uploadBusy}
-                            title="Use this folder for favorites sync"
-                          >
-                            {isFavoritesRoot ? 'Favorites sync' : 'Use for favorites'}
-                          </button>
-                          {folderInfo.isRoot || folderInfo.isAutoManaged ? null : (
-                            <button
-                              className="btn btn-sm btn-outline-danger"
-                              onClick={() => { void onDeleteFolder(folder); }}
-                              disabled={folderActionState.loading || folder.status === 'SCANNING' || uploadBusy}
-                              title="Remove this folder"
-                            >
-                              Remove
-                            </button>
-                          )}
-                        </div>
+    <div className="col-12 settings-section settings-section-flat text-foreground">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="h5 mb-0">Library folders</h2>
+      </div>
+      <input
+        ref={uploadInputRef}
+        type="file"
+        className="hidden"
+        multiple
+        accept={uploadInputAccept}
+        onChange={onFolderUploadInputChange}
+      />
+      <div className="text-muted-foreground text-sm mb-4">
+        Your main library appears below automatically. Mounted folders also
+        appear automatically when they are direct children of your library root.
+        Check the README for setup instructions.
+      </div>
+      {folderActionState.error ? (
+        <div className="text-destructive text-sm mb-4">
+          Folder error: {folderActionState.error}
+        </div>
+      ) : null}
+      {orderedFolders.length === 0 ? (
+        <p className="text-muted-foreground">No folders configured.</p>
+      ) : (
+        <div className="list-group folder-list">
+          {orderedFolders.map((folder) => {
+            const isFavoritesRoot =
+              favoritesSettings.favoritesRootId === folder.id;
+            const folderInfo =
+              folderDetailsById.get(folder.id) ??
+              describeFolder(folder, libraryRoot);
+            const uploadState = folderUploads[folder.id];
+            const uploadBusy =
+              uploadState?.phase === 'uploading' ||
+              uploadState?.phase === 'processing';
+            return (
+              <div
+                key={folder.id}
+                className={`list-group-item flex justify-between items-center bg-secondary text-foreground border border-secondary folder-card${folderInfo.isRoot ? ' folder-card-root' : ''}${uploadBusy ? ' folder-card-uploading' : ''}`}
+              >
+                <div className="folder-card-body">
+                  <div className="folder-card-header">
+                    <div className="folder-card-heading">
+                      <div className="font-semibold folder-card-title">
+                        {folderInfo.title}
                       </div>
-                      <div className="folder-card-meta">
-                        <div className="folder-card-pathline">
-                          <span className="folder-card-meta-label">Path</span>
-                          <span className="text-muted-foreground text-sm folder-card-path" title={folder.path}>{folder.path}</span>
-                        </div>
-                      </div>
-                      {uploadState ? (
-                        <div className="folder-upload-state mt-4">
-                          <div className="progress folder-upload-progress" role="progressbar" aria-valuenow={uploadState.progress} aria-valuemin={0} aria-valuemax={100}>
-                            <div
-                              className={`progress-bar ${folderUploadBarClass(uploadState.phase)}`}
-                              style={{ width: `${Math.max(uploadState.progress, uploadState.phase === 'processing' ? 100 : 0)}%` }}
-                            >
-                              {uploadState.progress}%
-                            </div>
-                          </div>
-                          <div className="text-sm mt-2 folder-upload-message">{uploadState.message}</div>
-                          {uploadState.detail ? (
-                            <div className="text-sm text-muted-foreground mt-1 folder-upload-detail">{uploadState.detail}</div>
-                          ) : null}
+                      {folderInfo.subtitle ? (
+                        <div className="text-muted-foreground text-sm">
+                          {folderInfo.subtitle}
                         </div>
                       ) : null}
                     </div>
+                    <div className="flex gap-2 folder-card-actions">
+                      <button
+                        className="btn btn-outline-light btn-sm"
+                        onClick={() => {
+                          onOpenFolderUploadPicker(folder.id);
+                        }}
+                        disabled={uploadBusy || folderActionState.loading}
+                        title="Upload files into this folder"
+                      >
+                        {uploadState?.phase === 'processing'
+                          ? 'Processing…'
+                          : uploadState?.phase === 'uploading'
+                            ? 'Uploading…'
+                            : 'Upload files'}
+                      </button>
+                      <button
+                        className={`btn btn-outline-warning btn-sm${isFavoritesRoot ? ' active' : ''}`}
+                        onClick={() => {
+                          onUpdateFavoritesRoot(folder.id);
+                        }}
+                        disabled={favoritesSettingsState.loading || uploadBusy}
+                        title="Use this folder for favorites sync"
+                      >
+                        {isFavoritesRoot
+                          ? 'Favorites sync'
+                          : 'Use for favorites'}
+                      </button>
+                      {folderInfo.isRoot || folderInfo.isAutoManaged ? null : (
+                        <button
+                          className="btn btn-sm btn-outline-danger"
+                          onClick={() => {
+                            void onDeleteFolder(folder);
+                          }}
+                          disabled={
+                            folderActionState.loading ||
+                            folder.status === 'SCANNING' ||
+                            uploadBusy
+                          }
+                          title="Remove this folder"
+                        >
+                          Remove
+                        </button>
+                      )}
+                    </div>
                   </div>
-                );
-              })}
-            </div>
-          )}
+                  <div className="folder-card-meta">
+                    <div className="folder-card-pathline">
+                      <span className="folder-card-meta-label">Path</span>
+                      <span
+                        className="text-muted-foreground text-sm folder-card-path"
+                        title={folder.path}
+                      >
+                        {folder.path}
+                      </span>
+                    </div>
+                  </div>
+                  {uploadState ? (
+                    <div className="folder-upload-state mt-4">
+                      <div
+                        className="progress folder-upload-progress"
+                        role="progressbar"
+                        aria-valuenow={uploadState.progress}
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                      >
+                        <div
+                          className={`progress-bar ${folderUploadBarClass(uploadState.phase)}`}
+                          style={{
+                            width: `${Math.max(uploadState.progress, uploadState.phase === 'processing' ? 100 : 0)}%`
+                          }}
+                        >
+                          {uploadState.progress}%
+                        </div>
+                      </div>
+                      <div className="text-sm mt-2 folder-upload-message">
+                        {uploadState.message}
+                      </div>
+                      {uploadState.detail ? (
+                        <div className="text-sm text-muted-foreground mt-1 folder-upload-detail">
+                          {uploadState.detail}
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            );
+          })}
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/shell/AppRoutes.tsx
+++ b/frontend/src/features/shell/AppRoutes.tsx
@@ -1,0 +1,155 @@
+import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useCallback, useEffect, useRef } from 'react';
+
+import { useAppShellContext } from './AppShell';
+import {
+  getGalleryDetailSyncAction,
+  shouldApplyFileIdToSelection
+} from './galleryDetailSync';
+
+import { DuplicatesView } from '@/features/duplicates/DuplicatesView';
+import { FavoritesAccountsSettings } from '@/features/favorites-accounts/FavoritesAccountsSettings';
+import { SauceFavoritesSettings } from '@/features/favorites-sauce/SauceFavoritesSettings';
+import { FileDetailPanel } from '@/features/file-detail/FileDetailPanel';
+import { FoldersListPanel } from '@/features/folders/FoldersListPanel';
+import { GalleryView } from '@/features/library/GalleryView';
+
+export function GalleryRouteView() {
+  const { galleryCtl, fileDetailCtl, openGalleryFile } = useAppShellContext();
+  const navigate = useNavigate({ from: '/app/gallery' });
+  const { fileId } = useSearch({ from: '/app/gallery' });
+  const previousFileIdRef = useRef<string | undefined>(fileId);
+  const selectedFileId = fileDetailCtl.selectedFile?.id;
+  const { closeFile } = fileDetailCtl;
+  const previousSelectedFileIdRef = useRef<string | undefined>(selectedFileId);
+  const clearGalleryDetailUrl = useCallback(() => {
+    void navigate({
+      replace: true,
+      search: {}
+    });
+  }, [navigate]);
+
+  useEffect(() => {
+    if (!fileId) {
+      if (previousFileIdRef.current && fileDetailCtl.selectedFile) {
+        fileDetailCtl.closeFile();
+      }
+      previousFileIdRef.current = fileId;
+      return;
+    }
+    if (
+      !shouldApplyFileIdToSelection({
+        fileId,
+        selectedFileId,
+        previousFileId: previousFileIdRef.current,
+        previousSelectedFileId: previousSelectedFileIdRef.current
+      })
+    ) {
+      previousFileIdRef.current = fileId;
+      return;
+    }
+    const match = galleryCtl.galleryFiles.find((file) => file.id === fileId);
+    if (match) {
+      openGalleryFile(match);
+    }
+    previousFileIdRef.current = fileId;
+  }, [
+    fileId,
+    selectedFileId,
+    fileDetailCtl,
+    galleryCtl.galleryFiles,
+    openGalleryFile
+  ]);
+
+  useEffect(
+    () => () => {
+      closeFile({ syncUrl: false });
+    },
+    [closeFile]
+  );
+
+  useEffect(() => {
+    const action = getGalleryDetailSyncAction({
+      fileId,
+      selectedFileId,
+      hadSelectedFile: Boolean(previousSelectedFileIdRef.current)
+    });
+    if (action.type === 'set') {
+      void navigate({
+        replace: true,
+        search: (prev) => ({ ...prev, fileId: action.fileId })
+      });
+      return;
+    }
+    if (action.type === 'clear') {
+      clearGalleryDetailUrl();
+    }
+  }, [clearGalleryDetailUrl, fileId, navigate, selectedFileId, fileDetailCtl]);
+
+  useEffect(() => {
+    if (!fileId) {
+      previousSelectedFileIdRef.current = undefined;
+      return;
+    }
+    if (selectedFileId !== undefined) {
+      previousSelectedFileIdRef.current = selectedFileId;
+    }
+  }, [fileId, selectedFileId, fileDetailCtl]);
+
+  return (
+    <>
+      {fileDetailCtl.selectedFile ? null : (
+        <div className="row g-4">
+          <GalleryView
+            {...galleryCtl.viewProps}
+            onFileOpen={(file) => {
+              openGalleryFile(file);
+              void navigate({
+                search: (prev) => ({ ...prev, fileId: file.id })
+              });
+            }}
+          />
+        </div>
+      )}
+
+      {fileDetailCtl.selectedFile ? (
+        <FileDetailPanel
+          {...fileDetailCtl.panelProps}
+          onClose={() => {
+            fileDetailCtl.closeFile({ syncUrl: false });
+            clearGalleryDetailUrl();
+          }}
+        />
+      ) : null}
+    </>
+  );
+}
+
+export function FoldersRouteView() {
+  const { foldersCtl, sauceFavoritesCtl } = useAppShellContext();
+
+  return (
+    <div className="page-chrome">
+      <div className="row g-0 settings-sections">
+        <FoldersListPanel {...foldersCtl.panelProps} />
+        <SauceFavoritesSettings {...sauceFavoritesCtl.sauceSettingsProps} />
+      </div>
+    </div>
+  );
+}
+
+export function FavoritesRouteView() {
+  const { sauceFavoritesCtl } = useAppShellContext();
+  return (
+    <FavoritesAccountsSettings {...sauceFavoritesCtl.favoritesAccountsProps} />
+  );
+}
+
+export function DuplicatesRouteView() {
+  const { duplicatesCtl } = useAppShellContext();
+  return (
+    <div className="row g-4">
+      <DuplicatesView {...duplicatesCtl.viewProps} />
+    </div>
+  );
+}

--- a/frontend/src/features/shell/AppShell.tsx
+++ b/frontend/src/features/shell/AppShell.tsx
@@ -1,31 +1,36 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { Link, Outlet, useNavigate, useSearch } from '@tanstack/react-router';
 import {
   createContext,
   useCallback,
   useContext,
   useEffect,
   useMemo,
-  useRef,
+  useRef
 } from 'react';
-import { Link, Outlet, useNavigate, useSearch } from '@tanstack/react-router';
-import { useQueryClient } from '@tanstack/react-query';
+
+import {
+  getGalleryDetailSyncAction,
+  shouldApplyFileIdToSelection
+} from './galleryDetailSync';
 
 import { authRequiredEvent, type FileItem } from '@/api';
 import { DuplicatesView } from '@/features/duplicates/DuplicatesView';
-import { FileDetailPanel } from '@/features/file-detail/FileDetailPanel';
-import { FoldersListPanel } from '@/features/folders/FoldersListPanel';
+import { useDuplicatesController } from '@/features/duplicates/useDuplicatesController';
+import { FavoritesAccountsSettings } from '@/features/favorites-accounts/FavoritesAccountsSettings';
 import { SauceFavoritesSettings } from '@/features/favorites-sauce/SauceFavoritesSettings';
+import { useSauceFavoritesController } from '@/features/favorites-sauce/useSauceFavoritesController';
+import { FileDetailPanel } from '@/features/file-detail/FileDetailPanel';
+import { useFileDetailController } from '@/features/file-detail/useFileDetailController';
+import { FoldersListPanel } from '@/features/folders/FoldersListPanel';
 import { useFoldersController } from '@/features/folders/useFoldersController';
 import { GalleryView } from '@/features/library/GalleryView';
-import { useDuplicatesController } from '@/features/duplicates/useDuplicatesController';
-import { useSauceFavoritesController } from '@/features/favorites-sauce/useSauceFavoritesController';
 import { useGalleryController } from '@/features/library/useGalleryController';
-import { useFileDetailController } from '@/features/file-detail/useFileDetailController';
 import { useCurrentUser, useLogout } from '@/hooks/auth';
 import { queryKeys } from '@/lib/query-keys';
 import { useDuplicatesUiStore } from '@/stores/duplicatesUiStore';
 import { useGalleryUiStore } from '@/stores/galleryUiStore';
 import { useSettingsUiStore } from '@/stores/settingsUiStore';
-import { getGalleryDetailSyncAction } from './galleryDetailSync';
 
 type AppShellContextValue = {
   authUser: NonNullable<ReturnType<typeof useCurrentUser>['data']>;
@@ -56,14 +61,24 @@ export function AppShell() {
   const authQuery = useCurrentUser();
   const logoutMutation = useLogout();
   const navigate = useNavigate();
-  const resetGalleryUiState = useGalleryUiStore((state) => state.resetGalleryUiState);
-  const resetDuplicatesUiState = useDuplicatesUiStore((state) => state.resetDuplicatesUiState);
-  const resetSettingsUiState = useSettingsUiStore((state) => state.resetSettingsUiState);
+  const resetGalleryUiState = useGalleryUiStore(
+    (state) => state.resetGalleryUiState
+  );
+  const resetDuplicatesUiState = useDuplicatesUiStore(
+    (state) => state.resetDuplicatesUiState
+  );
+  const resetSettingsUiState = useSettingsUiStore(
+    (state) => state.resetSettingsUiState
+  );
 
   const selectedFileRef = useRef<FileItem | null>(null);
   const openFileRef = useRef<(file: FileItem) => void>(() => undefined);
-  const galleryCtlRef = useRef<ReturnType<typeof useGalleryController> | null>(null);
-  const fileDetailCtlRef = useRef<ReturnType<typeof useFileDetailController> | null>(null);
+  const galleryCtlRef = useRef<ReturnType<typeof useGalleryController> | null>(
+    null
+  );
+  const fileDetailCtlRef = useRef<ReturnType<
+    typeof useFileDetailController
+  > | null>(null);
 
   const authUser = authQuery.data;
   if (!authUser) {
@@ -73,24 +88,24 @@ export function AppShell() {
   const libraryRoot = authUser.libraryRoot ?? '';
 
   const sauceFavoritesCtl = useSauceFavoritesController({
-    authUser,
+    authUser
   });
 
   const foldersCtl = useFoldersController({
     authUser,
     libraryRoot,
-    favoritesSettings: sauceFavoritesCtl.settingsProps.favoritesSettings,
-    favoritesSettingsState: sauceFavoritesCtl.settingsProps.favoritesSettingsState,
+    favoritesSettings: sauceFavoritesCtl.favoritesRootSettings,
+    favoritesSettingsState: sauceFavoritesCtl.favoritesRootSettingsState,
     onUpdateFavoritesRoot: (folderId) =>
-      void sauceFavoritesCtl.settingsProps.updateFavoritesSettings({ favoritesRootId: folderId }),
+      void sauceFavoritesCtl.updateFavoritesRoot(folderId),
     uploadInputAccept:
       '.jpg,.jpeg,.png,.gif,.bmp,.webp,.tif,.tiff,.avif,.mp4,.mov,.avi,.mkv,.webm,.wmv,.flv,.m4v',
     onUploadComplete: () => void galleryCtlRef.current?.reloadGallery(),
-    onScanFinished: () => void galleryCtlRef.current?.reloadGallery(),
+    onScanFinished: () => void galleryCtlRef.current?.reloadGallery()
   });
 
   const duplicatesCtl = useDuplicatesController({
-    authUser,
+    authUser
   });
 
   const galleryCtl = useGalleryController({
@@ -99,7 +114,7 @@ export function AppShell() {
     orderedFolders: foldersCtl.orderedFolders,
     folderDetailsById: foldersCtl.folderDetailsById,
     isActive: true,
-    onRefreshAfterOrderFailure: () => void foldersCtl.refreshFolders(),
+    onRefreshAfterOrderFailure: () => void foldersCtl.refreshFolders()
   });
   galleryCtlRef.current = galleryCtl;
 
@@ -116,9 +131,17 @@ export function AppShell() {
       }
       if (delta > 0 && galleryCtl.galleryHasMore) {
         await galleryCtl.goRelative(current.id, delta);
+        const freshCurrent = selectedFileRef.current;
+        if (!freshCurrent) return;
+        const freshIndex = galleryCtl.selectedFileIndex(freshCurrent.id);
+        if (freshIndex === -1) return;
+        const loadedNeighbor = galleryCtl.galleryFiles[freshIndex + delta];
+        if (loadedNeighbor) {
+          openFileRef.current(loadedNeighbor);
+        }
       }
     },
-    [galleryCtl],
+    [galleryCtl]
   );
 
   const selectedFileId = selectedFileRef.current?.id;
@@ -128,7 +151,7 @@ export function AppShell() {
     void navigate({
       to: '/app/gallery',
       replace: true,
-      search: {},
+      search: {}
     });
   }, [navigate]);
 
@@ -137,11 +160,11 @@ export function AppShell() {
       files: galleryCtl.galleryFiles,
       currentIndex,
       goRelative: (delta) => void goRelativeWrapper(delta),
-      sortIsManual: galleryCtl.viewProps.gallerySort === 'manual',
+      sortIsManual: galleryCtl.viewProps.gallerySort === 'manual'
     },
     sauceSettings: sauceFavoritesCtl.sauceSettings,
     historyMode: 'external',
-    onExternalClose: clearGalleryDetailUrl,
+    onExternalClose: clearGalleryDetailUrl
   });
 
   selectedFileRef.current = fileDetailCtl.selectedFile;
@@ -152,7 +175,7 @@ export function AppShell() {
       galleryCtl.openFile();
       fileDetailCtl.openFile(file);
     },
-    [fileDetailCtl, galleryCtl],
+    [fileDetailCtl, galleryCtl]
   );
 
   const closeGalleryFile = useCallback(() => {
@@ -161,31 +184,37 @@ export function AppShell() {
 
   openFileRef.current = openGalleryFile;
 
-  const filePanelProps = {
-    ...fileDetailCtl.panelProps,
-    onToggleFavorite: () => {
-      const current = selectedFileRef.current;
-      fileDetailCtl.panelProps.onToggleFavorite();
-      if (current) {
-        galleryCtl.updateFavoriteFlag(current.id, !current.isFavorite);
+  const filePanelProps = useMemo(
+    () => ({
+      ...fileDetailCtl.panelProps,
+      onToggleFavorite: () => {
+        const current = selectedFileRef.current;
+        fileDetailCtl.panelProps.onToggleFavorite();
+        if (current) {
+          galleryCtl.updateFavoriteFlag(current.id, !current.isFavorite);
+        }
+      },
+      onDeleteFile: (id: string) => {
+        fileDetailCtl.panelProps.onDeleteFile(id);
+        galleryCtl.removeFileFromGallery(id);
       }
-    },
-    onDeleteFile: (id: string) => {
-      fileDetailCtl.panelProps.onDeleteFile(id);
-      galleryCtl.removeFileFromGallery(id);
-    },
-  };
+    }),
+    [fileDetailCtl.panelProps, galleryCtl]
+  );
 
-  const duplicatesViewProps = {
-    ...duplicatesCtl.viewProps,
-    resolveDuplicateChoice: (keep: FileItem, discard: FileItem) => {
-      duplicatesCtl.viewProps.resolveDuplicateChoice(keep, discard);
-      galleryCtl.removeFileFromGallery(discard.id);
-      if (selectedFileRef.current?.id === discard.id) {
-        fileDetailCtl.closeFile();
+  const duplicatesViewProps = useMemo(
+    () => ({
+      ...duplicatesCtl.viewProps,
+      resolveDuplicateChoice: (keep: FileItem, discard: FileItem) => {
+        duplicatesCtl.viewProps.resolveDuplicateChoice(keep, discard);
+        galleryCtl.removeFileFromGallery(discard.id);
+        if (selectedFileRef.current?.id === discard.id) {
+          fileDetailCtl.closeFile();
+        }
       }
-    },
-  };
+    }),
+    [duplicatesCtl.viewProps, fileDetailCtl, galleryCtl]
+  );
 
   useEffect(() => {
     const handle = () => {
@@ -212,7 +241,7 @@ export function AppShell() {
     } catch (err) {
       // useLogout already clears local auth/query state on success.
       // Keep the visible warning so network failures do not disappear.
-      // eslint-disable-next-line no-console
+
       console.warn('logout request failed', err);
     } finally {
       resetGalleryUiState();
@@ -229,7 +258,7 @@ export function AppShell() {
     navigate,
     resetDuplicatesUiState,
     resetGalleryUiState,
-    resetSettingsUiState,
+    resetSettingsUiState
   ]);
 
   const value = useMemo<AppShellContextValue>(
@@ -242,15 +271,15 @@ export function AppShell() {
       sauceFavoritesCtl,
       duplicatesCtl: {
         ...duplicatesCtl,
-        viewProps: duplicatesViewProps,
+        viewProps: duplicatesViewProps
       },
       galleryCtl,
       fileDetailCtl: {
         ...fileDetailCtl,
-        panelProps: filePanelProps,
+        panelProps: filePanelProps
       },
       openGalleryFile,
-      closeGalleryFile,
+      closeGalleryFile
     }),
     [
       authUser,
@@ -265,8 +294,8 @@ export function AppShell() {
       logoutMutation.error,
       logoutMutation.isPending,
       openGalleryFile,
-      sauceFavoritesCtl,
-    ],
+      sauceFavoritesCtl
+    ]
   );
 
   return (
@@ -291,12 +320,18 @@ export function AppShell() {
                   {logoutMutation.isPending ? 'Logging out…' : 'Logout'}
                 </button>
                 {value.logoutError ? (
-                  <div className="text-destructive text-sm">{value.logoutError}</div>
+                  <div className="text-destructive text-sm">
+                    {value.logoutError}
+                  </div>
                 ) : null}
               </div>
             </div>
 
-            <div className="btn-group mb-6" role="group" aria-label="view switcher">
+            <div
+              className="btn-group mb-4"
+              role="group"
+              aria-label="view switcher"
+            >
               <Link
                 to="/app/gallery"
                 search={{}}
@@ -304,6 +339,13 @@ export function AppShell() {
                 activeProps={{ className: 'btn btn-primary' }}
               >
                 Gallery
+              </Link>
+              <Link
+                to="/app/favorites"
+                className="btn btn-outline-light"
+                activeProps={{ className: 'btn btn-primary' }}
+              >
+                Favorites
               </Link>
               <Link
                 to="/app/duplicates"
@@ -332,7 +374,6 @@ export function AppShell() {
               </div>
             ) : null}
           </div>
-
           <Outlet />
         </div>
       </div>
@@ -341,7 +382,7 @@ export function AppShell() {
 }
 
 export function GalleryRouteView() {
-  const { galleryCtl, fileDetailCtl, openGalleryFile, closeGalleryFile } = useAppShellContext();
+  const { galleryCtl, fileDetailCtl, openGalleryFile } = useAppShellContext();
   const navigate = useNavigate({ from: '/app/gallery' });
   const { fileId } = useSearch({ from: '/app/gallery' });
   const previousFileIdRef = useRef<string | undefined>(fileId);
@@ -350,7 +391,7 @@ export function GalleryRouteView() {
   const clearGalleryDetailUrl = useCallback(() => {
     void navigate({
       replace: true,
-      search: {},
+      search: {}
     });
   }, [navigate]);
 
@@ -362,7 +403,14 @@ export function GalleryRouteView() {
       previousFileIdRef.current = fileId;
       return;
     }
-    if (fileDetailCtl.selectedFile?.id === fileId) {
+    if (
+      !shouldApplyFileIdToSelection({
+        fileId,
+        selectedFileId,
+        previousFileId: previousFileIdRef.current,
+        previousSelectedFileId: previousSelectedFileIdRef.current
+      })
+    ) {
       previousFileIdRef.current = fileId;
       return;
     }
@@ -373,40 +421,46 @@ export function GalleryRouteView() {
     previousFileIdRef.current = fileId;
   }, [
     fileId,
-    fileDetailCtl.closeFile,
-    fileDetailCtl.selectedFile,
+    selectedFileId,
+    fileDetailCtl,
     galleryCtl.galleryFiles,
-    openGalleryFile,
+    openGalleryFile
   ]);
 
   useEffect(
     () => () => {
       fileDetailCtl.closeFile({ syncUrl: false });
     },
-    [fileDetailCtl.closeFile],
+    [fileDetailCtl]
   );
 
   useEffect(() => {
     const action = getGalleryDetailSyncAction({
       fileId,
       selectedFileId,
-      hadSelectedFile: Boolean(previousSelectedFileIdRef.current),
+      hadSelectedFile: Boolean(previousSelectedFileIdRef.current)
     });
     if (action.type === 'set') {
       void navigate({
         replace: true,
-        search: (prev) => ({ ...prev, fileId: action.fileId }),
+        search: (prev) => ({ ...prev, fileId: action.fileId })
       });
       return;
     }
     if (action.type === 'clear') {
       clearGalleryDetailUrl();
     }
-  }, [clearGalleryDetailUrl, fileId, selectedFileId]);
+  }, [clearGalleryDetailUrl, fileId, navigate, selectedFileId, fileDetailCtl]);
 
   useEffect(() => {
-    previousSelectedFileIdRef.current = selectedFileId;
-  }, [selectedFileId]);
+    if (!fileId) {
+      previousSelectedFileIdRef.current = undefined;
+      return;
+    }
+    if (selectedFileId !== undefined) {
+      previousSelectedFileIdRef.current = selectedFileId;
+    }
+  }, [fileId, selectedFileId, fileDetailCtl]);
 
   return (
     <>
@@ -417,7 +471,7 @@ export function GalleryRouteView() {
             onFileOpen={(file) => {
               openGalleryFile(file);
               void navigate({
-                search: (prev) => ({ ...prev, fileId: file.id }),
+                search: (prev) => ({ ...prev, fileId: file.id })
               });
             }}
           />
@@ -428,7 +482,8 @@ export function GalleryRouteView() {
         <FileDetailPanel
           {...fileDetailCtl.panelProps}
           onClose={() => {
-            closeGalleryFile();
+            fileDetailCtl.closeFile({ syncUrl: false });
+            clearGalleryDetailUrl();
           }}
         />
       ) : null}
@@ -440,10 +495,19 @@ export function FoldersRouteView() {
   const { foldersCtl, sauceFavoritesCtl } = useAppShellContext();
 
   return (
-    <div className="row g-0 settings-sections">
-      <FoldersListPanel {...foldersCtl.panelProps} />
-      <SauceFavoritesSettings {...sauceFavoritesCtl.settingsProps} />
+    <div className="page-chrome">
+      <div className="row g-0 settings-sections">
+        <FoldersListPanel {...foldersCtl.panelProps} />
+        <SauceFavoritesSettings {...sauceFavoritesCtl.sauceSettingsProps} />
+      </div>
     </div>
+  );
+}
+
+export function FavoritesRouteView() {
+  const { sauceFavoritesCtl } = useAppShellContext();
+  return (
+    <FavoritesAccountsSettings {...sauceFavoritesCtl.favoritesAccountsProps} />
   );
 }
 

--- a/frontend/src/features/shell/AppShell.tsx
+++ b/frontend/src/features/shell/AppShell.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { Link, Outlet, useNavigate, useSearch } from '@tanstack/react-router';
+import { Link, Outlet, useNavigate } from '@tanstack/react-router';
 import {
   createContext,
   useCallback,
@@ -9,22 +9,11 @@ import {
   useRef
 } from 'react';
 
-import {
-  getGalleryDetailSyncAction,
-  shouldApplyFileIdToSelection
-} from './galleryDetailSync';
-
 import { authRequiredEvent, type FileItem } from '@/api';
-import { DuplicatesView } from '@/features/duplicates/DuplicatesView';
 import { useDuplicatesController } from '@/features/duplicates/useDuplicatesController';
-import { FavoritesAccountsSettings } from '@/features/favorites-accounts/FavoritesAccountsSettings';
-import { SauceFavoritesSettings } from '@/features/favorites-sauce/SauceFavoritesSettings';
 import { useSauceFavoritesController } from '@/features/favorites-sauce/useSauceFavoritesController';
-import { FileDetailPanel } from '@/features/file-detail/FileDetailPanel';
 import { useFileDetailController } from '@/features/file-detail/useFileDetailController';
-import { FoldersListPanel } from '@/features/folders/FoldersListPanel';
 import { useFoldersController } from '@/features/folders/useFoldersController';
-import { GalleryView } from '@/features/library/GalleryView';
 import { useGalleryController } from '@/features/library/useGalleryController';
 import { useCurrentUser, useLogout } from '@/hooks/auth';
 import { queryKeys } from '@/lib/query-keys';
@@ -48,7 +37,7 @@ type AppShellContextValue = {
 
 const AppShellContext = createContext<AppShellContextValue | null>(null);
 
-function useAppShellContext() {
+export function useAppShellContext() {
   const value = useContext(AppShellContext);
   if (!value) {
     throw new Error('AppShell context missing');
@@ -378,144 +367,5 @@ export function AppShell() {
         </div>
       </div>
     </AppShellContext.Provider>
-  );
-}
-
-export function GalleryRouteView() {
-  const { galleryCtl, fileDetailCtl, openGalleryFile } = useAppShellContext();
-  const navigate = useNavigate({ from: '/app/gallery' });
-  const { fileId } = useSearch({ from: '/app/gallery' });
-  const previousFileIdRef = useRef<string | undefined>(fileId);
-  const selectedFileId = fileDetailCtl.selectedFile?.id;
-  const previousSelectedFileIdRef = useRef<string | undefined>(selectedFileId);
-  const clearGalleryDetailUrl = useCallback(() => {
-    void navigate({
-      replace: true,
-      search: {}
-    });
-  }, [navigate]);
-
-  useEffect(() => {
-    if (!fileId) {
-      if (previousFileIdRef.current && fileDetailCtl.selectedFile) {
-        fileDetailCtl.closeFile();
-      }
-      previousFileIdRef.current = fileId;
-      return;
-    }
-    if (
-      !shouldApplyFileIdToSelection({
-        fileId,
-        selectedFileId,
-        previousFileId: previousFileIdRef.current,
-        previousSelectedFileId: previousSelectedFileIdRef.current
-      })
-    ) {
-      previousFileIdRef.current = fileId;
-      return;
-    }
-    const match = galleryCtl.galleryFiles.find((file) => file.id === fileId);
-    if (match) {
-      openGalleryFile(match);
-    }
-    previousFileIdRef.current = fileId;
-  }, [
-    fileId,
-    selectedFileId,
-    fileDetailCtl,
-    galleryCtl.galleryFiles,
-    openGalleryFile
-  ]);
-
-  useEffect(
-    () => () => {
-      fileDetailCtl.closeFile({ syncUrl: false });
-    },
-    [fileDetailCtl]
-  );
-
-  useEffect(() => {
-    const action = getGalleryDetailSyncAction({
-      fileId,
-      selectedFileId,
-      hadSelectedFile: Boolean(previousSelectedFileIdRef.current)
-    });
-    if (action.type === 'set') {
-      void navigate({
-        replace: true,
-        search: (prev) => ({ ...prev, fileId: action.fileId })
-      });
-      return;
-    }
-    if (action.type === 'clear') {
-      clearGalleryDetailUrl();
-    }
-  }, [clearGalleryDetailUrl, fileId, navigate, selectedFileId, fileDetailCtl]);
-
-  useEffect(() => {
-    if (!fileId) {
-      previousSelectedFileIdRef.current = undefined;
-      return;
-    }
-    if (selectedFileId !== undefined) {
-      previousSelectedFileIdRef.current = selectedFileId;
-    }
-  }, [fileId, selectedFileId, fileDetailCtl]);
-
-  return (
-    <>
-      {fileDetailCtl.selectedFile ? null : (
-        <div className="row g-4">
-          <GalleryView
-            {...galleryCtl.viewProps}
-            onFileOpen={(file) => {
-              openGalleryFile(file);
-              void navigate({
-                search: (prev) => ({ ...prev, fileId: file.id })
-              });
-            }}
-          />
-        </div>
-      )}
-
-      {fileDetailCtl.selectedFile ? (
-        <FileDetailPanel
-          {...fileDetailCtl.panelProps}
-          onClose={() => {
-            fileDetailCtl.closeFile({ syncUrl: false });
-            clearGalleryDetailUrl();
-          }}
-        />
-      ) : null}
-    </>
-  );
-}
-
-export function FoldersRouteView() {
-  const { foldersCtl, sauceFavoritesCtl } = useAppShellContext();
-
-  return (
-    <div className="page-chrome">
-      <div className="row g-0 settings-sections">
-        <FoldersListPanel {...foldersCtl.panelProps} />
-        <SauceFavoritesSettings {...sauceFavoritesCtl.sauceSettingsProps} />
-      </div>
-    </div>
-  );
-}
-
-export function FavoritesRouteView() {
-  const { sauceFavoritesCtl } = useAppShellContext();
-  return (
-    <FavoritesAccountsSettings {...sauceFavoritesCtl.favoritesAccountsProps} />
-  );
-}
-
-export function DuplicatesRouteView() {
-  const { duplicatesCtl } = useAppShellContext();
-  return (
-    <div className="row g-4">
-      <DuplicatesView {...duplicatesCtl.viewProps} />
-    </div>
   );
 }

--- a/frontend/src/features/shell/galleryDetailSync.test.ts
+++ b/frontend/src/features/shell/galleryDetailSync.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getGalleryDetailSyncAction,
+  shouldApplyFileIdToSelection
+} from './galleryDetailSync';
+
+describe('getGalleryDetailSyncAction', () => {
+  it('sets fileId in URL when selection changes', () => {
+    expect(
+      getGalleryDetailSyncAction({
+        fileId: 'one',
+        selectedFileId: 'two',
+        hadSelectedFile: true
+      })
+    ).toEqual({ type: 'set', fileId: 'two' });
+  });
+
+  it('clears fileId from URL after close', () => {
+    expect(
+      getGalleryDetailSyncAction({
+        fileId: 'one',
+        selectedFileId: undefined,
+        hadSelectedFile: true
+      })
+    ).toEqual({ type: 'clear' });
+  });
+});
+
+describe('shouldApplyFileIdToSelection', () => {
+  it('skips URL hydration while local next/prev is waiting to sync URL', () => {
+    expect(
+      shouldApplyFileIdToSelection({
+        fileId: 'one',
+        selectedFileId: 'two',
+        previousFileId: 'one',
+        previousSelectedFileId: 'one'
+      })
+    ).toBe(false);
+  });
+
+  it('skips URL hydration right after local close', () => {
+    expect(
+      shouldApplyFileIdToSelection({
+        fileId: 'one',
+        selectedFileId: undefined,
+        previousFileId: 'one',
+        previousSelectedFileId: 'one'
+      })
+    ).toBe(false);
+  });
+
+  it('skips URL hydration after close when URL lags behind selection', () => {
+    expect(
+      shouldApplyFileIdToSelection({
+        fileId: 'one',
+        selectedFileId: undefined,
+        previousFileId: 'one',
+        previousSelectedFileId: 'two'
+      })
+    ).toBe(false);
+  });
+
+  it('applies URL hydration for deep-link state without selected file', () => {
+    expect(
+      shouldApplyFileIdToSelection({
+        fileId: 'one',
+        selectedFileId: undefined,
+        previousFileId: 'one',
+        previousSelectedFileId: undefined
+      })
+    ).toBe(true);
+  });
+});

--- a/frontend/src/features/shell/galleryDetailSync.ts
+++ b/frontend/src/features/shell/galleryDetailSync.ts
@@ -4,6 +4,13 @@ export type GalleryDetailSyncInput = {
   hadSelectedFile: boolean;
 };
 
+export type GalleryDetailHydrationInput = {
+  fileId?: string;
+  selectedFileId?: string;
+  previousFileId?: string;
+  previousSelectedFileId?: string;
+};
+
 export type GalleryDetailSyncAction =
   | { type: 'none' }
   | { type: 'set'; fileId: string }
@@ -12,7 +19,7 @@ export type GalleryDetailSyncAction =
 export const getGalleryDetailSyncAction = ({
   fileId,
   selectedFileId,
-  hadSelectedFile,
+  hadSelectedFile
 }: GalleryDetailSyncInput): GalleryDetailSyncAction => {
   if (selectedFileId && selectedFileId !== fileId) {
     return { type: 'set', fileId: selectedFileId };
@@ -21,4 +28,28 @@ export const getGalleryDetailSyncAction = ({
     return { type: 'clear' };
   }
   return { type: 'none' };
+};
+
+export const shouldApplyFileIdToSelection = ({
+  fileId,
+  selectedFileId,
+  previousFileId,
+  previousSelectedFileId
+}: GalleryDetailHydrationInput): boolean => {
+  if (!fileId) return false;
+  if (selectedFileId === fileId) return false;
+
+  if (!selectedFileId && previousSelectedFileId) {
+    // Local close cleared selection; URL clear is pending (fileId may still lag).
+    return false;
+  }
+
+  const fileIdStable = previousFileId === fileId;
+
+  if (fileIdStable && selectedFileId && selectedFileId !== fileId) {
+    // Local next/prev changed selection; URL update effect runs after this.
+    return false;
+  }
+
+  return true;
 };

--- a/frontend/src/hooks/favorites.ts
+++ b/frontend/src/hooks/favorites.ts
@@ -5,7 +5,7 @@ import { queryKeys } from '@/lib/query-keys';
 
 type SyncStatusOptions = {
   enabled?: boolean;
-  refetchInterval?: number | false;
+  refetchInterval?: Parameters<typeof useQuery>[0]['refetchInterval'];
 };
 
 export function useFavoritesSyncStatus(options: SyncStatusOptions = {}) {
@@ -20,12 +20,12 @@ export function useFavoritesSyncStatus(options: SyncStatusOptions = {}) {
 export function useSyncFavorites() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (payload?: {
-      providers?: ('E621' | 'DANBOORU')[];
-      deleteMissing?: boolean;
-    }) => api.syncFavorites(payload),
+    mutationFn: (payload?: { providers?: string[]; deleteMissing?: boolean }) =>
+      api.syncFavorites(payload),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.favorites.syncStatus() });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.favorites.syncStatus()
+      });
       queryClient.invalidateQueries({ queryKey: queryKeys.files.all });
     }
   });
@@ -42,11 +42,12 @@ export function useFavoritesSettings(options: { enabled?: boolean } = {}) {
 export function useUpdateFavoritesSettings() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (
-      settings: Parameters<typeof api.updateFavoritesSettings>[0]
-    ) => api.updateFavoritesSettings(settings),
+    mutationFn: (settings: Parameters<typeof api.updateFavoritesSettings>[0]) =>
+      api.updateFavoritesSettings(settings),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.favorites.settings() });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.favorites.settings()
+      });
     }
   });
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -11,12 +11,12 @@ import {
 import { api, type AuthUser } from '@/api';
 import { LoginRoute } from '@/features/auth/LoginRoute';
 import {
-  AppShell,
   DuplicatesRouteView,
   FavoritesRouteView,
   FoldersRouteView,
   GalleryRouteView
-} from '@/features/shell/AppShell';
+} from '@/features/shell/AppRoutes';
+import { AppShell } from '@/features/shell/AppShell';
 import { queryKeys } from '@/lib/query-keys';
 
 type RouterContext = {

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -5,7 +5,7 @@ import {
   createRootRouteWithContext,
   createRoute,
   createRouter,
-  redirect,
+  redirect
 } from '@tanstack/react-router';
 
 import { api, type AuthUser } from '@/api';
@@ -13,8 +13,9 @@ import { LoginRoute } from '@/features/auth/LoginRoute';
 import {
   AppShell,
   DuplicatesRouteView,
+  FavoritesRouteView,
   FoldersRouteView,
-  GalleryRouteView,
+  GalleryRouteView
 } from '@/features/shell/AppShell';
 import { queryKeys } from '@/lib/query-keys';
 
@@ -23,10 +24,12 @@ type RouterContext = {
 };
 
 const rootRoute = createRootRouteWithContext<RouterContext>()({
-  component: () => <Outlet />,
+  component: () => <Outlet />
 });
 
-const loadCurrentUser = async (queryClient: QueryClient): Promise<AuthUser | null> =>
+const loadCurrentUser = async (
+  queryClient: QueryClient
+): Promise<AuthUser | null> =>
   queryClient.ensureQueryData({
     queryKey: queryKeys.auth.me(),
     queryFn: async () => {
@@ -36,7 +39,7 @@ const loadCurrentUser = async (queryClient: QueryClient): Promise<AuthUser | nul
         return null;
       }
     },
-    staleTime: 60_000,
+    staleTime: 60_000
   });
 
 const indexRoute = createRoute({
@@ -45,14 +48,14 @@ const indexRoute = createRoute({
   beforeLoad: async ({ context }) => {
     const user = await loadCurrentUser(context.queryClient);
     throw redirect({ to: user ? '/app/gallery' : '/login' });
-  },
+  }
 });
 
 const loginRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/login',
   validateSearch: (search: Record<string, unknown>) => ({
-    redirect: typeof search.redirect === 'string' ? search.redirect : undefined,
+    redirect: typeof search.redirect === 'string' ? search.redirect : undefined
   }),
   beforeLoad: async ({ context }) => {
     const user = await loadCurrentUser(context.queryClient);
@@ -60,7 +63,7 @@ const loginRoute = createRoute({
       throw redirect({ to: '/app/gallery' });
     }
   },
-  component: LoginRoute,
+  component: LoginRoute
 });
 
 const appRoute = createRoute({
@@ -72,12 +75,12 @@ const appRoute = createRoute({
       throw redirect({
         to: '/login',
         search: {
-          redirect: location.href,
-        },
+          redirect: location.href
+        }
       });
     }
   },
-  component: AppShell,
+  component: AppShell
 });
 
 const appIndexRoute = createRoute({
@@ -85,28 +88,34 @@ const appIndexRoute = createRoute({
   path: '/',
   beforeLoad: () => {
     throw redirect({ to: '/app/gallery' });
-  },
+  }
 });
 
 const galleryRoute = createRoute({
   getParentRoute: () => appRoute,
   path: 'gallery',
   validateSearch: (search: Record<string, unknown>) => ({
-    fileId: typeof search.fileId === 'string' ? search.fileId : undefined,
+    fileId: typeof search.fileId === 'string' ? search.fileId : undefined
   }),
-  component: GalleryRouteView,
+  component: GalleryRouteView
 });
 
 const foldersRoute = createRoute({
   getParentRoute: () => appRoute,
   path: 'folders',
-  component: FoldersRouteView,
+  component: FoldersRouteView
 });
 
 const duplicatesRoute = createRoute({
   getParentRoute: () => appRoute,
   path: 'duplicates',
-  component: DuplicatesRouteView,
+  component: DuplicatesRouteView
+});
+
+const favoritesRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: 'favorites',
+  component: FavoritesRouteView
 });
 
 const routeTree = rootRoute.addChildren([
@@ -117,14 +126,15 @@ const routeTree = rootRoute.addChildren([
     galleryRoute,
     foldersRoute,
     duplicatesRoute,
-  ]),
+    favoritesRoute
+  ])
 ]);
 
 export const router = createRouter({
   routeTree,
   context: {
-    queryClient: undefined!,
-  },
+    queryClient: undefined!
+  }
 });
 
 declare module '@tanstack/react-router' {

--- a/tests/library-empty.spec.ts
+++ b/tests/library-empty.spec.ts
@@ -12,13 +12,17 @@ test('a freshly-seeded user lands on the gallery view with no files', async ({
   expect(await tiles.count()).toBe(0);
 });
 
-test('navigation roundtrip covers gallery, settings, and duplicates routes', async ({
+test('navigation roundtrip covers gallery, favorites, settings, and duplicates routes', async ({
   page
 }) => {
   await loginUi(page);
+  await page.getByRole('link', { name: 'Favorites' }).click();
+  await expect(page).toHaveURL(/\/app\/favorites$/);
+  await expect(page.getByText('Favorites accounts')).toBeVisible();
+  await expect(page.getByText('Configured sites')).toBeVisible();
   await page.getByRole('link', { name: 'Settings' }).click();
   await expect(page).toHaveURL(/\/app\/folders$/);
-  await expect(page.getByText('Configured booru sources')).toBeVisible();
+  await expect(page.getByText('Library folders')).toBeVisible();
   await page.getByRole('link', { name: 'Duplicates' }).click();
   await expect(page).toHaveURL(/\/app\/duplicates$/);
   await expect(page.getByRole('link', { name: 'Duplicates' })).toBeVisible();
@@ -68,8 +72,9 @@ test('upload and duplicate scan flow works across routes', async ({ page }) => {
 
 test('booru site add form submits after engine detection', async ({ page }) => {
   await loginUi(page);
-  await page.getByRole('link', { name: 'Settings' }).click();
-  await expect(page).toHaveURL(/\/app\/folders$/);
+  await page.getByRole('link', { name: 'Favorites' }).click();
+  await expect(page).toHaveURL(/\/app\/favorites$/);
+  await page.getByRole('button', { name: 'New site' }).click();
 
   const siteName = `Playwright ${Date.now()}`;
   await page.locator('#booru-name').fill(siteName);


### PR DESCRIPTION
## Summary
- add dedicated /app/favorites route for booru accounts and sync controls
- migrate legacy favorites globals into per-site settings
- update favorites sync, reverse delete, and auto-favorite behavior to use per-site flags
- keep /favorites/settings focused on favoritesRootId

Fixes #135

## Verification
- frontend build: npm run build
- frontend targeted tests: bun test frontend/src/features/shell/galleryDetailSync.test.ts frontend/test/galleryDetailSync.test.ts
- backend build: npm run build
- backend full suite: 185/185 passed before frontend-only refactor
- browser check: gallery card click opened detail, URL gained fileId, no console errors
- pre-commit lint-staged passed