### PR TITLE
chore: clear frontend lint debt from issue #103 follow-up

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,7 @@
     "migrate": "tsx src/migrate.ts",
     "start": "node dist/index.js",
     "build": "tsc -p tsconfig.json && node scripts/copy-migrations.mjs",
-    "lint": "eslint src test --ext .ts",
+    "lint": "eslint src test",
     "test": "bash -c 'shopt -s globstar nullglob; tsx --test src/**/*.test.ts test/**/*.test.ts'",
     "test:ci": "bash -c 'shopt -s globstar nullglob; tsx --test --test-reporter=spec src/**/*.test.ts test/**/*.test.ts'",
     "worker": "tsx src/worker.ts"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 5174",
     "build": "vite build",
-    "lint": "eslint src vite.config.ts --ext .ts,.tsx",
+    "lint": "eslint src vite.config.ts",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,39 +1,39 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Slot } from "radix-ui"
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Slot } from 'radix-ui';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  'inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3',
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        default: 'bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
         secondary:
-          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+          'bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
         destructive:
-          "bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+          'bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90',
         outline:
-          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 [a&]:hover:underline",
-      },
+          'border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        ghost: '[a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 [a&]:hover:underline'
+      }
     },
     defaultVariants: {
-      variant: "default",
-    },
+      variant: 'default'
+    }
   }
-)
+);
 
 function Badge({
   className,
-  variant = "default",
+  variant = 'default',
   asChild = false,
   ...props
-}: React.ComponentProps<"span"> &
+}: React.ComponentProps<'span'> &
   VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot.Root : "span"
+  const Comp = asChild ? Slot.Root : 'span';
 
   return (
     <Comp
@@ -42,7 +42,7 @@ function Badge({
       className={cn(badgeVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,54 +1,54 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Slot } from "radix-ui"
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Slot } from 'radix-ui';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
   "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline'
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
         xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-8",
-        "icon-lg": "size-10",
-      },
+        sm: 'h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
+        'icon-xs': "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        'icon-sm': 'size-8',
+        'icon-lg': 'size-10'
+      }
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
+      variant: 'default',
+      size: 'default'
+    }
   }
-)
+);
 
 function Button({
   className,
-  variant = "default",
-  size = "default",
+  variant = 'default',
+  size = 'default',
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
+}: React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot.Root : "button"
+  const Comp = asChild ? Slot.Root : 'button';
 
   return (
     <Comp
@@ -58,7 +58,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -1,10 +1,10 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import { CheckIcon } from "lucide-react"
-import { Checkbox as CheckboxPrimitive } from "radix-ui"
+import { CheckIcon } from 'lucide-react';
+import { Checkbox as CheckboxPrimitive } from 'radix-ui';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Checkbox({
   className,
@@ -14,7 +14,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+        'peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary',
         className
       )}
       {...props}
@@ -26,7 +26,7 @@ function Checkbox({
         <CheckIcon className="size-3.5" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
-  )
+  );
 }
 
-export { Checkbox }
+export { Checkbox };

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,34 +1,34 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import { XIcon } from "lucide-react"
-import { Dialog as DialogPrimitive } from "radix-ui"
+import { XIcon } from 'lucide-react';
+import { Dialog as DialogPrimitive } from 'radix-ui';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 function Dialog({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
 function DialogTrigger({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
 function DialogPortal({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
 function DialogClose({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Close>) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
 function DialogOverlay({
@@ -39,12 +39,12 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        'fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogContent({
@@ -53,7 +53,7 @@ function DialogContent({
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
@@ -61,7 +61,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
           className
         )}
         {...props}
@@ -78,17 +78,17 @@ function DialogContent({
         )}
       </DialogPrimitive.Content>
     </DialogPortal>
-  )
+  );
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
       {...props}
     />
-  )
+  );
 }
 
 function DialogFooter({
@@ -96,14 +96,14 @@ function DialogFooter({
   showCloseButton = false,
   children,
   ...props
-}: React.ComponentProps<"div"> & {
-  showCloseButton?: boolean
+}: React.ComponentProps<'div'> & {
+  showCloseButton?: boolean;
 }) {
   return (
     <div
       data-slot="dialog-footer"
       className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
         className
       )}
       {...props}
@@ -115,7 +115,7 @@ function DialogFooter({
         </DialogPrimitive.Close>
       )}
     </div>
-  )
+  );
 }
 
 function DialogTitle({
@@ -125,10 +125,10 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn('text-lg leading-none font-semibold', className)}
       {...props}
     />
-  )
+  );
 }
 
 function DialogDescription({
@@ -138,10 +138,10 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -154,5 +154,5 @@ export {
   DialogOverlay,
   DialogPortal,
   DialogTitle,
-  DialogTrigger,
-}
+  DialogTrigger
+};

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,13 +1,13 @@
-import * as React from "react"
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
-import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
+import { DropdownMenu as DropdownMenuPrimitive } from 'radix-ui';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function DropdownMenu({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
-  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
 }
 
 function DropdownMenuPortal({
@@ -15,7 +15,7 @@ function DropdownMenuPortal({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
   return (
     <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
-  )
+  );
 }
 
 function DropdownMenuTrigger({
@@ -26,7 +26,7 @@ function DropdownMenuTrigger({
       data-slot="dropdown-menu-trigger"
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuContent({
@@ -40,13 +40,13 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          'z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           className
         )}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>
-  )
+  );
 }
 
 function DropdownMenuGroup({
@@ -54,17 +54,17 @@ function DropdownMenuGroup({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
   return (
     <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
-  )
+  );
 }
 
 function DropdownMenuItem({
   className,
   inset,
-  variant = "default",
+  variant = 'default',
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
-  inset?: boolean
-  variant?: "default" | "destructive"
+  inset?: boolean;
+  variant?: 'default' | 'destructive';
 }) {
   return (
     <DropdownMenuPrimitive.Item
@@ -77,7 +77,7 @@ function DropdownMenuItem({
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuCheckboxItem({
@@ -103,7 +103,7 @@ function DropdownMenuCheckboxItem({
       </span>
       {children}
     </DropdownMenuPrimitive.CheckboxItem>
-  )
+  );
 }
 
 function DropdownMenuRadioGroup({
@@ -114,7 +114,7 @@ function DropdownMenuRadioGroup({
       data-slot="dropdown-menu-radio-group"
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuRadioItem({
@@ -138,7 +138,7 @@ function DropdownMenuRadioItem({
       </span>
       {children}
     </DropdownMenuPrimitive.RadioItem>
-  )
+  );
 }
 
 function DropdownMenuLabel({
@@ -146,19 +146,19 @@ function DropdownMenuLabel({
   inset,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(
-        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        'px-2 py-1.5 text-sm font-medium data-[inset]:pl-8',
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuSeparator({
@@ -168,32 +168,32 @@ function DropdownMenuSeparator({
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
-      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuShortcut({
   className,
   ...props
-}: React.ComponentProps<"span">) {
+}: React.ComponentProps<'span'>) {
   return (
     <span
       data-slot="dropdown-menu-shortcut"
       className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground",
+        'ml-auto text-xs tracking-widest text-muted-foreground',
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuSub({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
-  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
 }
 
 function DropdownMenuSubTrigger({
@@ -202,7 +202,7 @@ function DropdownMenuSubTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <DropdownMenuPrimitive.SubTrigger
@@ -217,7 +217,7 @@ function DropdownMenuSubTrigger({
       {children}
       <ChevronRightIcon className="ml-auto size-4" />
     </DropdownMenuPrimitive.SubTrigger>
-  )
+  );
 }
 
 function DropdownMenuSubContent({
@@ -228,12 +228,12 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        'z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -251,5 +251,5 @@ export {
   DropdownMenuShortcut,
   DropdownMenuSub,
   DropdownMenuSubTrigger,
-  DropdownMenuSubContent,
-}
+  DropdownMenuSubContent
+};

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { Label as LabelPrimitive } from "radix-ui"
+import { Label as LabelPrimitive } from 'radix-ui';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Label({
   className,
@@ -11,12 +11,12 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Label }
+export { Label };

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,23 +1,23 @@
-import * as React from "react"
-import { Popover as PopoverPrimitive } from "radix-ui"
+import { Popover as PopoverPrimitive } from 'radix-ui';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Popover({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
-  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
 function PopoverTrigger({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
-  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
 }
 
 function PopoverContent({
   className,
-  align = "center",
+  align = 'center',
   sideOffset = 4,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
@@ -28,52 +28,52 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          'z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           className
         )}
         {...props}
       />
     </PopoverPrimitive.Portal>
-  )
+  );
 }
 
 function PopoverAnchor({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
-  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
 }
 
-function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="popover-header"
-      className={cn("flex flex-col gap-1 text-sm", className)}
+      className={cn('flex flex-col gap-1 text-sm', className)}
       {...props}
     />
-  )
+  );
 }
 
-function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+function PopoverTitle({ className, ...props }: React.ComponentProps<'h2'>) {
   return (
     <div
       data-slot="popover-title"
-      className={cn("font-medium", className)}
+      className={cn('font-medium', className)}
       {...props}
     />
-  )
+  );
 }
 
 function PopoverDescription({
   className,
   ...props
-}: React.ComponentProps<"p">) {
+}: React.ComponentProps<'p'>) {
   return (
     <p
       data-slot="popover-description"
-      className={cn("text-muted-foreground", className)}
+      className={cn('text-muted-foreground', className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -83,5 +83,5 @@ export {
   PopoverAnchor,
   PopoverHeader,
   PopoverTitle,
-  PopoverDescription,
-}
+  PopoverDescription
+};

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -1,9 +1,9 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import { Progress as ProgressPrimitive } from "radix-ui"
+import { Progress as ProgressPrimitive } from 'radix-ui';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Progress({
   className,
@@ -14,7 +14,7 @@ function Progress({
     <ProgressPrimitive.Root
       data-slot="progress"
       className={cn(
-        "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+        'relative h-2 w-full overflow-hidden rounded-full bg-primary/20',
         className
       )}
       {...props}
@@ -25,7 +25,7 @@ function Progress({
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>
-  )
+  );
 }
 
-export { Progress }
+export { Progress };

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,36 +1,36 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
-import { Select as SelectPrimitive } from "radix-ui"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+import { Select as SelectPrimitive } from 'radix-ui';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Select({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
 }
 
 function SelectGroup({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Group>) {
-  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
 }
 
 function SelectValue({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Value>) {
-  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
 }
 
 function SelectTrigger({
   className,
-  size = "default",
+  size = 'default',
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: "sm" | "default"
+  size?: 'sm' | 'default';
 }) {
   return (
     <SelectPrimitive.Trigger
@@ -47,14 +47,14 @@ function SelectTrigger({
         <ChevronDownIcon className="size-4 opacity-50" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
-  )
+  );
 }
 
 function SelectContent({
   className,
   children,
-  position = "item-aligned",
-  align = "center",
+  position = 'item-aligned',
+  align = 'center',
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
   return (
@@ -62,9 +62,9 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
-          position === "popper" &&
-            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          position === 'popper' &&
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className
         )}
         position={position}
@@ -74,9 +74,9 @@ function SelectContent({
         <SelectScrollUpButton />
         <SelectPrimitive.Viewport
           className={cn(
-            "p-1",
-            position === "popper" &&
-              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1'
           )}
         >
           {children}
@@ -84,7 +84,7 @@ function SelectContent({
         <SelectScrollDownButton />
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
-  )
+  );
 }
 
 function SelectLabel({
@@ -94,10 +94,10 @@ function SelectLabel({
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      className={cn('px-2 py-1.5 text-xs text-muted-foreground', className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectItem({
@@ -124,7 +124,7 @@ function SelectItem({
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
     </SelectPrimitive.Item>
-  )
+  );
 }
 
 function SelectSeparator({
@@ -134,10 +134,10 @@ function SelectSeparator({
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
-      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      className={cn('pointer-events-none -mx-1 my-1 h-px bg-border', className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectScrollUpButton({
@@ -148,14 +148,14 @@ function SelectScrollUpButton({
     <SelectPrimitive.ScrollUpButton
       data-slot="select-scroll-up-button"
       className={cn(
-        "flex cursor-default items-center justify-center py-1",
+        'flex cursor-default items-center justify-center py-1',
         className
       )}
       {...props}
     >
       <ChevronUpIcon className="size-4" />
     </SelectPrimitive.ScrollUpButton>
-  )
+  );
 }
 
 function SelectScrollDownButton({
@@ -166,14 +166,14 @@ function SelectScrollDownButton({
     <SelectPrimitive.ScrollDownButton
       data-slot="select-scroll-down-button"
       className={cn(
-        "flex cursor-default items-center justify-center py-1",
+        'flex cursor-default items-center justify-center py-1',
         className
       )}
       {...props}
     >
       <ChevronDownIcon className="size-4" />
     </SelectPrimitive.ScrollDownButton>
-  )
+  );
 }
 
 export {
@@ -186,5 +186,5 @@ export {
   SelectScrollUpButton,
   SelectSeparator,
   SelectTrigger,
-  SelectValue,
-}
+  SelectValue
+};

--- a/frontend/src/components/ui/separator.tsx
+++ b/frontend/src/components/ui/separator.tsx
@@ -1,13 +1,13 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import { Separator as SeparatorPrimitive } from "radix-ui"
+import { Separator as SeparatorPrimitive } from 'radix-ui';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Separator({
   className,
-  orientation = "horizontal",
+  orientation = 'horizontal',
   decorative = true,
   ...props
 }: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
@@ -17,12 +17,12 @@ function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        'shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Separator }
+export { Separator };

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -1,21 +1,21 @@
-import * as React from "react"
-import { Switch as SwitchPrimitive } from "radix-ui"
+import { Switch as SwitchPrimitive } from 'radix-ui';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Switch({
   className,
-  size = "default",
+  size = 'default',
   ...props
 }: React.ComponentProps<typeof SwitchPrimitive.Root> & {
-  size?: "sm" | "default"
+  size?: 'sm' | 'default';
 }) {
   return (
     <SwitchPrimitive.Root
       data-slot="switch"
       data-size={size}
       className={cn(
-        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+        'peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80',
         className
       )}
       {...props}
@@ -23,11 +23,11 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground"
+          'pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground'
         )}
       />
     </SwitchPrimitive.Root>
-  )
+  );
 }
 
-export { Switch }
+export { Switch };

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,12 +1,12 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Tabs as TabsPrimitive } from "radix-ui"
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Tabs as TabsPrimitive } from 'radix-ui';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Tabs({
   className,
-  orientation = "horizontal",
+  orientation = 'horizontal',
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.Root>) {
   return (
@@ -15,32 +15,32 @@ function Tabs({
       data-orientation={orientation}
       orientation={orientation}
       className={cn(
-        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
+        'group/tabs flex gap-2 data-[orientation=horizontal]:flex-col',
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  'group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none',
   {
     variants: {
       variant: {
-        default: "bg-muted",
-        line: "gap-1 bg-transparent",
-      },
+        default: 'bg-muted',
+        line: 'gap-1 bg-transparent'
+      }
     },
     defaultVariants: {
-      variant: "default",
-    },
+      variant: 'default'
+    }
   }
-)
+);
 
 function TabsList({
   className,
-  variant = "default",
+  variant = 'default',
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.List> &
   VariantProps<typeof tabsListVariants>) {
@@ -51,7 +51,7 @@ function TabsList({
       className={cn(tabsListVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
 function TabsTrigger({
@@ -63,14 +63,14 @@ function TabsTrigger({
       data-slot="tabs-trigger"
       className={cn(
         "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
-        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
-        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent',
+        'data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground',
+        'after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100',
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TabsContent({
@@ -80,10 +80,10 @@ function TabsContent({
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn("flex-1 outline-none", className)}
+      className={cn('flex-1 outline-none', className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,9 +1,9 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import { Tooltip as TooltipPrimitive } from "radix-ui"
+import { Tooltip as TooltipPrimitive } from 'radix-ui';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function TooltipProvider({
   delayDuration = 0,
@@ -15,19 +15,19 @@ function TooltipProvider({
       delayDuration={delayDuration}
       {...props}
     />
-  )
+  );
 }
 
 function Tooltip({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
 function TooltipTrigger({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
 function TooltipContent({
@@ -42,7 +42,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          'z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
           className
         )}
         {...props}
@@ -51,7 +51,7 @@ function TooltipContent({
         <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
-  )
+  );
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/frontend/src/features/auth/AuthForm.tsx
+++ b/frontend/src/features/auth/AuthForm.tsx
@@ -1,6 +1,6 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
 
 import { buildAuthFormSchema } from './authSchemas';
 
@@ -20,41 +20,56 @@ type Props = {
   onSubmit: (values: AuthFormValues) => Promise<void>;
 };
 
-export function AuthForm({ mode, loading, error, onModeChange, onSubmit }: Props) {
+export function AuthForm({
+  mode,
+  loading,
+  error,
+  onModeChange,
+  onSubmit
+}: Props) {
   const schema = useMemo(() => buildAuthFormSchema(mode), [mode]);
   const form = useForm<AuthFormValues>({
     resolver: zodResolver(schema),
     defaultValues: {
       username: '',
       password: '',
-      confirmPassword: '',
-    },
+      confirmPassword: ''
+    }
   });
   const {
     register,
     reset,
     formState: { errors },
-    handleSubmit,
+    handleSubmit
   } = form;
 
   useEffect(() => {
     reset({
       username: '',
       password: '',
-      confirmPassword: '',
+      confirmPassword: ''
     });
   }, [mode, reset]);
 
   return (
     <div className="bg-background text-foreground min-h-screen flex items-center justify-center px-4">
-      <div className="card bg-black text-foreground border-secondary" style={{ width: '100%', maxWidth: 420 }}>
+      <div
+        className="card bg-black text-foreground border-secondary"
+        style={{ width: '100%', maxWidth: 420 }}
+      >
         <div className="card-body p-6">
           <div className="flex justify-between items-start mb-4">
             <div>
               <h1 className="h3 mb-1">GoonCave</h1>
-              <div className="text-muted-foreground text-sm">Local-network sign-in</div>
+              <div className="text-muted-foreground text-sm">
+                Local-network sign-in
+              </div>
             </div>
-            <div className="btn-group btn-group-sm" role="group" aria-label="auth mode">
+            <div
+              className="btn-group btn-group-sm"
+              role="group"
+              aria-label="auth mode"
+            >
               <button
                 type="button"
                 className={`btn btn-${mode === 'login' ? 'primary' : 'outline-light'}`}
@@ -77,12 +92,14 @@ export function AuthForm({ mode, loading, error, onModeChange, onSubmit }: Props
               reset({
                 username: '',
                 password: '',
-                confirmPassword: '',
+                confirmPassword: ''
               });
             })}
           >
             <div className="mb-4">
-              <label className="form-label" htmlFor="auth-username">Username</label>
+              <label className="form-label" htmlFor="auth-username">
+                Username
+              </label>
               <input
                 id="auth-username"
                 name="username"
@@ -92,26 +109,36 @@ export function AuthForm({ mode, loading, error, onModeChange, onSubmit }: Props
                 autoComplete="username"
               />
               {errors.username ? (
-                <div className="text-destructive text-sm mt-1">{errors.username.message}</div>
+                <div className="text-destructive text-sm mt-1">
+                  {errors.username.message}
+                </div>
               ) : null}
             </div>
             <div className="mb-4">
-              <label className="form-label" htmlFor="auth-password">Password</label>
+              <label className="form-label" htmlFor="auth-password">
+                Password
+              </label>
               <input
                 id="auth-password"
                 name="password"
                 className="form-control bg-background text-foreground border-secondary"
                 type="password"
                 {...register('password')}
-                autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
+                autoComplete={
+                  mode === 'login' ? 'current-password' : 'new-password'
+                }
               />
               {errors.password ? (
-                <div className="text-destructive text-sm mt-1">{errors.password.message}</div>
+                <div className="text-destructive text-sm mt-1">
+                  {errors.password.message}
+                </div>
               ) : null}
             </div>
             {mode === 'register' ? (
               <div className="mb-4">
-                <label className="form-label" htmlFor="auth-confirm-password">Confirm password</label>
+                <label className="form-label" htmlFor="auth-confirm-password">
+                  Confirm password
+                </label>
                 <input
                   id="auth-confirm-password"
                   name="confirm-password"
@@ -127,9 +154,19 @@ export function AuthForm({ mode, loading, error, onModeChange, onSubmit }: Props
                 ) : null}
               </div>
             ) : null}
-            {error ? <div className="alert alert-danger py-2">{error}</div> : null}
-            <button className="btn btn-primary w-full" type="submit" disabled={loading}>
-              {loading ? 'Working…' : mode === 'login' ? 'Login' : 'Create account'}
+            {error ? (
+              <div className="alert alert-danger py-2">{error}</div>
+            ) : null}
+            <button
+              className="btn btn-primary w-full"
+              type="submit"
+              disabled={loading}
+            >
+              {loading
+                ? 'Working…'
+                : mode === 'login'
+                  ? 'Login'
+                  : 'Create account'}
             </button>
           </form>
         </div>

--- a/frontend/src/features/auth/LoginRoute.tsx
+++ b/frontend/src/features/auth/LoginRoute.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
 import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useEffect } from 'react';
 
 import { AuthForm } from '@/features/auth/AuthForm';
 import { useAuthController } from '@/features/auth/useAuthController';
@@ -19,7 +19,7 @@ export function LoginRoute() {
           ? search.redirect
           : '/app/gallery';
       void navigate({ to: target, replace: true });
-    },
+    }
   });
 
   useEffect(() => {

--- a/frontend/src/features/auth/useAuthController.ts
+++ b/frontend/src/features/auth/useAuthController.ts
@@ -16,10 +16,10 @@
 
 import { useState } from 'react';
 
-import { useCurrentUser, useLogin, useLogout, useRegister } from '@/hooks/auth';
 import type { AuthUser } from '@/api';
 import type { AuthMode } from '@/features/auth/AuthForm';
 import { toAuthSubmitPayload } from '@/features/auth/authSchemas';
+import { useCurrentUser, useLogin, useLogout, useRegister } from '@/hooks/auth';
 
 export type AuthControllerResult = {
   authUser: AuthUser | null;
@@ -88,7 +88,7 @@ export function useAuthController(options?: {
     } catch (err) {
       // Server session may already be gone. Caller tears down local state
       // regardless; surface the warning so a real failure isn't silent.
-      // eslint-disable-next-line no-console
+
       console.warn('logout request failed; clearing local state anyway', err);
     } finally {
       options?.onLogoutSuccess?.();

--- a/frontend/src/features/booru-sites/formSchemas.ts
+++ b/frontend/src/features/booru-sites/formSchemas.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod';
 
-import type { BooruEngineType } from '@/api';
 import { ensureHttps } from '../../urlUtils';
+
+import type { BooruEngineType } from '@/api';
 
 const capabilitiesSchema = z.object({
   capFavorites: z.boolean(),
   capTags: z.boolean(),
-  capSourceMatch: z.boolean(),
+  capSourceMatch: z.boolean()
 });
 
 const normalizedUrlSchema = z
@@ -27,7 +28,7 @@ export const booruSiteAddSchema = z.object({
   baseUrl: normalizedUrlSchema,
   username: trimStringSchema,
   apiKey: trimStringSchema,
-  capabilities: capabilitiesSchema,
+  capabilities: capabilitiesSchema
 });
 
 export type BooruSiteAddFormValues = z.infer<typeof booruSiteAddSchema>;
@@ -35,10 +36,11 @@ export type BooruSiteAddFormValues = z.infer<typeof booruSiteAddSchema>;
 export const createBooruCredentialSchema = (credentialSchema: string) =>
   z.object({
     username:
-      credentialSchema === 'username+apikey' || credentialSchema === 'userid+apikey'
+      credentialSchema === 'username+apikey' ||
+      credentialSchema === 'userid+apikey'
         ? trimStringSchema
         : z.string().default(''),
-    apiKey: trimStringSchema,
+    apiKey: trimStringSchema
   });
 
 export type BooruCredentialFormValues = z.infer<
@@ -52,7 +54,7 @@ const toNullableTrimmed = (value: string): string | null => {
 
 export const toBooruSiteCreatePayload = (
   values: BooruSiteAddFormValues,
-  engine: BooruEngineType,
+  engine: BooruEngineType
 ) => ({
   name: values.name.trim(),
   engine,
@@ -62,10 +64,12 @@ export const toBooruSiteCreatePayload = (
   capFavorites: values.capabilities.capFavorites,
   capTags: values.capabilities.capTags,
   capSourceMatch: values.capabilities.capSourceMatch,
-  enabled: true,
+  enabled: true
 });
 
-export const toBooruCredentialUpdatePayload = (values: BooruCredentialFormValues) => ({
+export const toBooruCredentialUpdatePayload = (
+  values: BooruCredentialFormValues
+) => ({
   username: toNullableTrimmed(values.username),
-  apiKey: toNullableTrimmed(values.apiKey),
+  apiKey: toNullableTrimmed(values.apiKey)
 });

--- a/frontend/src/features/duplicates/DuplicatesView.tsx
+++ b/frontend/src/features/duplicates/DuplicatesView.tsx
@@ -1,10 +1,11 @@
 import type React from 'react';
+
 import type {
   DuplicateFile,
   DuplicateScanOptions,
   DuplicateScanStats,
   DuplicateScanStatus,
-  DuplicateSettings,
+  DuplicateSettings
 } from '@/api';
 import { API_BASE } from '@/api';
 import { basenameFromPath, fileTypeFromPath, formatSizeMb } from '@/lib/format';
@@ -41,7 +42,9 @@ export interface DuplicatesViewProps {
 
   // scan options (controlled by parent)
   duplicateOptions: DuplicateScanOptions;
-  setDuplicateOptions: React.Dispatch<React.SetStateAction<DuplicateScanOptions>>;
+  setDuplicateOptions: React.Dispatch<
+    React.SetStateAction<DuplicateScanOptions>
+  >;
 
   // scan state
   duplicateState: FetchState;
@@ -65,7 +68,7 @@ export interface DuplicatesViewProps {
 function DuplicateCard({
   file,
   suggested,
-  reason,
+  reason
 }: {
   file: DuplicateFile;
   suggested: boolean;
@@ -75,26 +78,49 @@ function DuplicateCard({
     <div className={`duplicate-card${suggested ? ' is-suggested' : ''}`}>
       <div className="duplicate-thumb">
         {file.thumbUrl ? (
-          <img src={`${API_BASE}${file.thumbUrl}`} alt={file.path} loading="lazy" decoding="async" />
+          <img
+            src={`${API_BASE}${file.thumbUrl}`}
+            alt={file.path}
+            loading="lazy"
+            decoding="async"
+          />
         ) : (
-          <div className="text-muted-foreground text-sm">{file.mediaType.toLowerCase()}</div>
+          <div className="text-muted-foreground text-sm">
+            {file.mediaType.toLowerCase()}
+          </div>
         )}
       </div>
       <div className="flex justify-between items-center">
-        <div className="font-semibold truncate">{basenameFromPath(file.path)}</div>
-        {suggested ? <span className="badge bg-success duplicate-suggested-badge">Suggested</span> : null}
+        <div className="font-semibold truncate">
+          {basenameFromPath(file.path)}
+        </div>
+        {suggested ? (
+          <span className="badge bg-success duplicate-suggested-badge">
+            Suggested
+          </span>
+        ) : null}
       </div>
       <div className="text-muted-foreground text-sm">
-        {fileTypeFromPath(file.path, file.mediaType)} · {formatSizeMb(file.sizeBytes)}
+        {fileTypeFromPath(file.path, file.mediaType)} ·{' '}
+        {formatSizeMb(file.sizeBytes)}
         {file.width && file.height ? ` · ${file.width}×${file.height}` : ''}
       </div>
       {file.favoriteProviders?.length ? (
         <div className="text-muted-foreground text-sm">
-          favorites: {file.favoriteProviders.map((provider) => provider.toLowerCase()).join(', ')}
+          favorites:{' '}
+          {file.favoriteProviders
+            .map((provider) => provider.toLowerCase())
+            .join(', ')}
         </div>
       ) : null}
-      {suggested ? <div className="text-success text-sm duplicate-suggested-reason">{reason}</div> : null}
-      <div className="text-muted-foreground text-sm duplicate-path">{file.path}</div>
+      {suggested ? (
+        <div className="text-success text-sm duplicate-suggested-reason">
+          {reason}
+        </div>
+      ) : null}
+      <div className="text-muted-foreground text-sm duplicate-path">
+        {file.path}
+      </div>
     </div>
   );
 }
@@ -114,7 +140,7 @@ export function DuplicatesView({
   duplicateStats,
   duplicateAction,
   resolveDuplicateChoice,
-  resolveDuplicateKeepBoth,
+  resolveDuplicateKeepBoth
 }: DuplicatesViewProps) {
   return (
     <div className="col-12">
@@ -122,11 +148,14 @@ export function DuplicatesView({
         <div className="card-body">
           <div className="flex justify-between items-center mb-4">
             {duplicateStats ? (
-              <span className="text-muted-foreground text-sm">{duplicatePairs.length} groups</span>
+              <span className="text-muted-foreground text-sm">
+                {duplicatePairs.length} groups
+              </span>
             ) : null}
           </div>
           <p className="text-muted-foreground text-sm mb-4">
-            Groups files by media type and dimensions, then compares downscaled pixels (videos use sampled frames).
+            Groups files by media type and dimensions, then compares downscaled
+            pixels (videos use sampled frames).
           </p>
           <div className="form-check form-switch mb-4">
             <input
@@ -134,7 +163,9 @@ export function DuplicatesView({
               type="checkbox"
               id="duplicate-auto-resolve-toggle"
               checked={duplicateSettings.autoResolve}
-              onChange={(event) => updateDuplicateSettings({ autoResolve: event.target.checked })}
+              onChange={(event) =>
+                updateDuplicateSettings({ autoResolve: event.target.checked })
+              }
               disabled={duplicateSettingsState.loading}
             />
             <label
@@ -145,7 +176,9 @@ export function DuplicatesView({
             </label>
           </div>
           {duplicateSettingsState.error ? (
-            <div className="text-destructive mb-2">Settings error: {duplicateSettingsState.error}</div>
+            <div className="text-destructive mb-2">
+              Settings error: {duplicateSettingsState.error}
+            </div>
           ) : null}
           <div className="flex flex-wrap gap-4 items-end mb-4">
             <div>
@@ -156,7 +189,8 @@ export function DuplicatesView({
                 onChange={(event) =>
                   setDuplicateOptions((prev) => ({
                     ...prev,
-                    mediaType: event.target.value as DuplicateScanOptions['mediaType'],
+                    mediaType: event.target
+                      .value as DuplicateScanOptions['mediaType']
                   }))
                 }
               >
@@ -174,7 +208,9 @@ export function DuplicatesView({
             </button>
           </div>
           <details className="mb-4">
-            <summary className="text-muted-foreground text-sm">Advanced</summary>
+            <summary className="text-muted-foreground text-sm">
+              Advanced
+            </summary>
             <div className="flex flex-wrap gap-4 items-end mt-2">
               <div>
                 <label
@@ -196,10 +232,13 @@ export function DuplicatesView({
                     setDuplicateOptions((prev) => ({
                       ...prev,
                       pixelThreshold: clamp(
-                        toNumberOr(event.target.value, prev.pixelThreshold ?? 0.005),
+                        toNumberOr(
+                          event.target.value,
+                          prev.pixelThreshold ?? 0.005
+                        ),
                         0,
                         0.2
-                      ),
+                      )
                     }))
                   }
                 />
@@ -224,10 +263,11 @@ export function DuplicatesView({
                     setDuplicateOptions((prev) => ({
                       ...prev,
                       sampleSize: clamp(
-                        Number.parseInt(event.target.value, 10) || (prev.sampleSize ?? 96),
+                        Number.parseInt(event.target.value, 10) ||
+                          (prev.sampleSize ?? 96),
                         8,
                         256
-                      ),
+                      )
                     }))
                   }
                 />
@@ -252,10 +292,11 @@ export function DuplicatesView({
                     setDuplicateOptions((prev) => ({
                       ...prev,
                       videoFrames: clamp(
-                        Number.parseInt(event.target.value, 10) || (prev.videoFrames ?? 3),
+                        Number.parseInt(event.target.value, 10) ||
+                          (prev.videoFrames ?? 3),
                         1,
                         8
-                      ),
+                      )
                     }))
                   }
                 />
@@ -280,10 +321,11 @@ export function DuplicatesView({
                     setDuplicateOptions((prev) => ({
                       ...prev,
                       maxComparisons: clamp(
-                        Number.parseInt(event.target.value, 10) || (prev.maxComparisons ?? 2000),
+                        Number.parseInt(event.target.value, 10) ||
+                          (prev.maxComparisons ?? 2000),
                         1,
                         100000
-                      ),
+                      )
                     }))
                   }
                 />
@@ -291,7 +333,9 @@ export function DuplicatesView({
             </div>
           </details>
           {duplicateState.error ? (
-            <div className="text-destructive mb-2">Error: {duplicateState.error}</div>
+            <div className="text-destructive mb-2">
+              Error: {duplicateState.error}
+            </div>
           ) : null}
           {duplicateState.loading && duplicateScanStatus?.progress ? (
             <div className="mb-4">
@@ -329,26 +373,31 @@ export function DuplicatesView({
                                 100
                             )
                           )}%`
-                        : '100%',
+                        : '100%'
                   }}
                 />
               </div>
               <div className="text-muted-foreground text-sm mt-1">
                 Phase: {duplicateScanStatus.progress.phase} · Processed{' '}
-                {duplicateScanStatus.progress.processed}/{duplicateScanStatus.progress.total} ·
-                Comparisons {duplicateScanStatus.progress.comparisons} · Groups{' '}
+                {duplicateScanStatus.progress.processed}/
+                {duplicateScanStatus.progress.total} · Comparisons{' '}
+                {duplicateScanStatus.progress.comparisons} · Groups{' '}
                 {duplicateScanStatus.progress.groups} · Skipped{' '}
                 {duplicateScanStatus.progress.skippedNoSignature}
               </div>
             </div>
           ) : null}
           {duplicateAction.error ? (
-            <div className="text-destructive mb-2">Delete error: {duplicateAction.error}</div>
+            <div className="text-destructive mb-2">
+              Delete error: {duplicateAction.error}
+            </div>
           ) : null}
           {duplicateStats ? (
             <div className="text-muted-foreground text-sm mb-4">
-              Eligible: {duplicateStats.eligibleFiles}/{duplicateStats.totalFiles} · Compared:{' '}
-              {duplicateStats.comparedFiles} · Comparisons: {duplicateStats.comparisons} · Skipped:{' '}
+              Eligible: {duplicateStats.eligibleFiles}/
+              {duplicateStats.totalFiles} · Compared:{' '}
+              {duplicateStats.comparedFiles} · Comparisons:{' '}
+              {duplicateStats.comparisons} · Skipped:{' '}
               {duplicateStats.skippedNoSignature}
             </div>
           ) : null}
@@ -362,9 +411,11 @@ export function DuplicatesView({
             </p>
           ) : (
             duplicatePairs.map((pair, index) => {
-              const leftSuggested = !!pair.suggestedKeepId && pair.suggestedKeepId === pair.left.id;
+              const leftSuggested =
+                !!pair.suggestedKeepId && pair.suggestedKeepId === pair.left.id;
               const rightSuggested =
-                !!pair.suggestedKeepId && pair.suggestedKeepId === pair.right.id;
+                !!pair.suggestedKeepId &&
+                pair.suggestedKeepId === pair.right.id;
               const suggestedSide = pair.suggestedKeepId
                 ? leftSuggested
                   ? 'left'
@@ -374,16 +425,25 @@ export function DuplicatesView({
                 duplicateAction.loadingId === pair.left.id ||
                 duplicateAction.loadingId === pair.right.id;
               return (
-                <div key={pair.key} className="duplicate-pair border border-secondary rounded p-4 mb-4">
+                <div
+                  key={pair.key}
+                  className="duplicate-pair border border-secondary rounded p-4 mb-4"
+                >
                   <div className="flex justify-between items-center mb-2">
-                    <div className="text-muted-foreground text-sm">Pair {index + 1}</div>
+                    <div className="text-muted-foreground text-sm">
+                      Pair {index + 1}
+                    </div>
                     <div className="text-muted-foreground text-sm">
                       Suggested: keep {suggestedSide} ({pair.reason})
                     </div>
                   </div>
                   <div className="row g-3">
                     <div className="col-md-6">
-                      <DuplicateCard file={pair.left} suggested={leftSuggested} reason={pair.reason} />
+                      <DuplicateCard
+                        file={pair.left}
+                        suggested={leftSuggested}
+                        reason={pair.reason}
+                      />
                     </div>
                     <div className="col-md-6">
                       <DuplicateCard
@@ -396,14 +456,18 @@ export function DuplicatesView({
                   <div className="flex flex-wrap gap-2 mt-4">
                     <button
                       className="btn btn-success btn-sm"
-                      onClick={() => resolveDuplicateChoice(pair.left, pair.right)}
+                      onClick={() =>
+                        resolveDuplicateChoice(pair.left, pair.right)
+                      }
                       disabled={actionBusy}
                     >
                       Keep left
                     </button>
                     <button
                       className="btn btn-success btn-sm"
-                      onClick={() => resolveDuplicateChoice(pair.right, pair.left)}
+                      onClick={() =>
+                        resolveDuplicateChoice(pair.right, pair.left)
+                      }
                       disabled={actionBusy}
                     >
                       Keep right

--- a/frontend/src/features/duplicates/useDuplicatesController.ts
+++ b/frontend/src/features/duplicates/useDuplicatesController.ts
@@ -1,25 +1,25 @@
 import { useCallback, useMemo, useState } from 'react';
 
-import {
-  useDuplicateSettings,
-  useDuplicateScanStatus,
-  useStartDuplicateScan,
-  useUpdateDuplicateSettings,
-} from '@/hooks/duplicates';
-import { useDeleteFile } from '@/hooks/files';
-import { basenameFromPath } from '@/lib/format';
-import { useDuplicatesUiStore } from '@/stores/duplicatesUiStore';
+import type { DuplicatePair, DuplicatesViewProps } from './DuplicatesView';
+
 import type {
   AuthUser,
   DuplicateFile,
   DuplicateGroup,
-  DuplicateScanOptions,
   DuplicateScanStats,
   DuplicateScanStatus,
-  DuplicateSettings,
+  DuplicateSettings
 } from '@/api';
 import { api } from '@/api';
-import type { DuplicatePair, DuplicatesViewProps } from './DuplicatesView';
+import {
+  useDuplicateSettings,
+  useDuplicateScanStatus,
+  useStartDuplicateScan,
+  useUpdateDuplicateSettings
+} from '@/hooks/duplicates';
+import { useDeleteFile } from '@/hooks/files';
+import { basenameFromPath } from '@/lib/format';
+import { useDuplicatesUiStore } from '@/stores/duplicatesUiStore';
 
 // ── helpers (pure, module-scope) ──────────────────────────────────────────────
 
@@ -45,14 +45,20 @@ const resolveFavoriteLabel = (file: DuplicateFile): string | null => {
   return providers.map((p) => p.toLowerCase()).join(', ');
 };
 
-const resolveFavoriteOverlap = (a: DuplicateFile, b: DuplicateFile): boolean => {
+const resolveFavoriteOverlap = (
+  a: DuplicateFile,
+  b: DuplicateFile
+): boolean => {
   const pa = a.favoriteProviders ?? [];
   const pb = b.favoriteProviders ?? [];
   if (!pa.length || !pb.length) return true;
   return pa.some((p) => pb.includes(p));
 };
 
-const compareDuplicateQuality = (a: DuplicateFile, b: DuplicateFile): number => {
+const compareDuplicateQuality = (
+  a: DuplicateFile,
+  b: DuplicateFile
+): number => {
   const areaA = resolveArea(a);
   const areaB = resolveArea(b);
   if (areaA !== areaB) return areaB - areaA;
@@ -60,7 +66,10 @@ const compareDuplicateQuality = (a: DuplicateFile, b: DuplicateFile): number => 
   return a.path.localeCompare(b.path);
 };
 
-const compareDuplicatePreference = (a: DuplicateFile, b: DuplicateFile): number => {
+const compareDuplicatePreference = (
+  a: DuplicateFile,
+  b: DuplicateFile
+): number => {
   const rankA = resolveFavoriteRank(a);
   const rankB = resolveFavoriteRank(b);
   if (rankA !== rankB) return rankB - rankA;
@@ -76,7 +85,10 @@ const pickDuplicateSuggestion = (
     (b.favoriteProviders?.length ?? 0) > 0 &&
     !resolveFavoriteOverlap(a, b);
   if (conflict) {
-    return { keepId: null, reason: 'favorites from different sources (keep both)' };
+    return {
+      keepId: null,
+      reason: 'favorites from different sources (keep both)'
+    };
   }
   const rankA = resolveFavoriteRank(a);
   const rankB = resolveFavoriteRank(b);
@@ -86,12 +98,12 @@ const pickDuplicateSuggestion = (
     if (rankA > 0 && rankB > 0) {
       return {
         keepId: winner.id,
-        reason: `preferred favorite source (${winnerLabel ?? 'favorite'})`,
+        reason: `preferred favorite source (${winnerLabel ?? 'favorite'})`
       };
     }
     return {
       keepId: winner.id,
-      reason: `synced favorite (${winnerLabel ?? 'favorite'})`,
+      reason: `synced favorite (${winnerLabel ?? 'favorite'})`
     };
   }
   const areaA = resolveArea(a);
@@ -100,7 +112,10 @@ const pickDuplicateSuggestion = (
     return { keepId: areaA > areaB ? a.id : b.id, reason: 'larger resolution' };
   }
   if (a.sizeBytes !== b.sizeBytes) {
-    return { keepId: a.sizeBytes > b.sizeBytes ? a.id : b.id, reason: 'larger file size' };
+    return {
+      keepId: a.sizeBytes > b.sizeBytes ? a.id : b.id,
+      reason: 'larger file size'
+    };
   }
   const label = resolveFavoriteLabel(a);
   if (label) {
@@ -109,7 +124,8 @@ const pickDuplicateSuggestion = (
   return { keepId: a.id, reason: 'same resolution & size' };
 };
 
-const wait = (ms: number) => new Promise<void>((resolve) => window.setTimeout(resolve, ms));
+const wait = (ms: number) =>
+  new Promise<void>((resolve) => window.setTimeout(resolve, ms));
 
 // ── types ─────────────────────────────────────────────────────────────────────
 
@@ -140,7 +156,7 @@ export function useDuplicatesController(
   // TanStack: scan status — refetch only while a scan is running
   const scanStatusQuery = useDuplicateScanStatus({
     enabled: authenticated,
-    refetchInterval: false, // controller drives polling via loadDuplicates loop
+    refetchInterval: false // controller drives polling via loadDuplicates loop
   });
 
   // TanStack: mutations
@@ -151,30 +167,43 @@ export function useDuplicatesController(
   // ── local state ──────────────────────────────────────────────────────────
 
   const [duplicateGroups, setDuplicateGroups] = useState<DuplicateGroup[]>([]);
-  const [duplicateStats, setDuplicateStats] = useState<DuplicateScanStats | null>(null);
+  const [duplicateStats, setDuplicateStats] =
+    useState<DuplicateScanStats | null>(null);
   const [duplicateState, setDuplicateState] = useState<FetchState>({
     loading: false,
-    error: null,
+    error: null
   });
-  const [duplicateScanStatus, setDuplicateScanStatus] = useState<DuplicateScanStatus | null>(null);
+  const [duplicateScanStatus, setDuplicateScanStatus] =
+    useState<DuplicateScanStatus | null>(null);
   const [duplicateAction, setDuplicateAction] = useState<{
     loadingId: string | null;
     error: string | null;
   }>({ loadingId: null, error: null });
-  const [duplicateSettingsState, setDuplicateSettingsState] = useState<FetchState>({
-    loading: false,
-    error: null,
-  });
-  const duplicateResolvedKeys = useDuplicatesUiStore((state) => state.duplicateResolvedKeys);
-  const setDuplicateResolvedKeys = useDuplicatesUiStore((state) => state.setDuplicateResolvedKeys);
-  const duplicateOptions = useDuplicatesUiStore((state) => state.duplicateOptions);
-  const setDuplicateOptions = useDuplicatesUiStore((state) => state.setDuplicateOptions);
+  const [duplicateSettingsState, setDuplicateSettingsState] =
+    useState<FetchState>({
+      loading: false,
+      error: null
+    });
+  const duplicateResolvedKeys = useDuplicatesUiStore(
+    (state) => state.duplicateResolvedKeys
+  );
+  const setDuplicateResolvedKeys = useDuplicatesUiStore(
+    (state) => state.setDuplicateResolvedKeys
+  );
+  const duplicateOptions = useDuplicatesUiStore(
+    (state) => state.duplicateOptions
+  );
+  const setDuplicateOptions = useDuplicatesUiStore(
+    (state) => state.setDuplicateOptions
+  );
 
   // Reflect TanStack settings query into FetchState + settings value
-  const duplicateSettings: DuplicateSettings = settingsQuery.data ?? { autoResolve: false };
+  const duplicateSettings: DuplicateSettings = settingsQuery.data ?? {
+    autoResolve: false
+  };
   const settingsLoadingState: FetchState = {
     loading: settingsQuery.isLoading,
-    error: (settingsQuery.error as Error | null)?.message ?? null,
+    error: (settingsQuery.error as Error | null)?.message ?? null
   };
   // Merge TanStack-driven state with manual settingsState (covers mutation path)
   const mergedSettingsState: FetchState = duplicateSettingsState.loading
@@ -200,7 +229,7 @@ export function useDuplicatesController(
           left: primary,
           right: other,
           suggestedKeepId: suggestion.keepId,
-          reason: suggestion.reason,
+          reason: suggestion.reason
         });
       });
     });
@@ -216,7 +245,10 @@ export function useDuplicatesController(
         await updateSettingsMutation.mutateAsync(updates);
         setDuplicateSettingsState({ loading: false, error: null });
       } catch (err) {
-        setDuplicateSettingsState({ loading: false, error: (err as Error).message });
+        setDuplicateSettingsState({
+          loading: false,
+          error: (err as Error).message
+        });
       }
     },
     [updateSettingsMutation]
@@ -261,7 +293,9 @@ export function useDuplicatesController(
           lastUpdatedAt = status.updatedAt;
           staleSince = Date.now();
         } else if (Date.now() - staleSince > STALE_TIMEOUT_MS) {
-          throw new Error('Duplicate scan timed out (no progress for 5 minutes)');
+          throw new Error(
+            'Duplicate scan timed out (no progress for 5 minutes)'
+          );
         }
         await wait(800);
         status = await api.getDuplicateScanStatus();
@@ -281,7 +315,11 @@ export function useDuplicatesController(
       options: { confirm?: boolean } = {}
     ) => {
       if (options.confirm !== false) {
-        if (!window.confirm(`Delete "${basenameFromPath(discard.path)}"? This cannot be undone.`)) {
+        if (
+          !window.confirm(
+            `Delete "${basenameFromPath(discard.path)}"? This cannot be undone.`
+          )
+        ) {
           return;
         }
       }
@@ -292,7 +330,7 @@ export function useDuplicatesController(
           prev
             .map((group) => ({
               ...group,
-              files: group.files.filter((file) => file.id !== discard.id),
+              files: group.files.filter((file) => file.id !== discard.id)
             }))
             .filter((group) => group.files.length > 1)
         );
@@ -304,15 +342,24 @@ export function useDuplicatesController(
     [deleteFileMutation]
   );
 
-  const resolveDuplicateKeepBoth = useCallback((pairKey: string) => {
-    setDuplicateResolvedKeys((prev) => (prev.includes(pairKey) ? prev : [...prev, pairKey]));
-  }, []);
+  const resolveDuplicateKeepBoth = useCallback(
+    (pairKey: string) => {
+      setDuplicateResolvedKeys((prev) =>
+        prev.includes(pairKey) ? prev : [...prev, pairKey]
+      );
+    },
+    [setDuplicateResolvedKeys]
+  );
 
   const autoResolveDuplicates = useCallback(
     async (groups: DuplicateGroup[]) => {
       const candidates = groups.filter((group) => group.files.length > 1);
       if (!candidates.length) return;
-      const discardPairs: { keep: DuplicateFile; discard: DuplicateFile; key: string }[] = [];
+      const discardPairs: {
+        keep: DuplicateFile;
+        discard: DuplicateFile;
+        key: string;
+      }[] = [];
       const keepBothKeys: string[] = [];
       for (const group of candidates) {
         const sorted = [...group.files].sort(compareDuplicatePreference);
@@ -332,7 +379,9 @@ export function useDuplicatesController(
       }
       if (!discardPairs.length && keepBothKeys.length === 0) return;
       if (keepBothKeys.length > 0) {
-        setDuplicateResolvedKeys((prev) => Array.from(new Set([...prev, ...keepBothKeys])));
+        setDuplicateResolvedKeys((prev) =>
+          Array.from(new Set([...prev, ...keepBothKeys]))
+        );
       }
       if (!discardPairs.length) return;
       const confirmed = window.confirm(
@@ -341,17 +390,22 @@ export function useDuplicatesController(
       if (!confirmed) return;
       for (const pair of discardPairs) {
         try {
-          await resolveDuplicateChoice(pair.keep, pair.discard, { confirm: false });
+          await resolveDuplicateChoice(pair.keep, pair.discard, {
+            confirm: false
+          });
           setDuplicateResolvedKeys((prev) =>
             prev.includes(pair.key) ? prev : [...prev, pair.key]
           );
         } catch (err) {
-          setDuplicateAction({ loadingId: null, error: (err as Error).message });
+          setDuplicateAction({
+            loadingId: null,
+            error: (err as Error).message
+          });
           break;
         }
       }
     },
-    [resolveDuplicateChoice]
+    [resolveDuplicateChoice, setDuplicateResolvedKeys]
   );
 
   // ── assemble viewProps ────────────────────────────────────────────────────
@@ -372,12 +426,13 @@ export function useDuplicatesController(
     duplicateStats,
 
     duplicateAction,
-    resolveDuplicateChoice: (keep, discard) => void resolveDuplicateChoice(keep, discard),
-    resolveDuplicateKeepBoth,
+    resolveDuplicateChoice: (keep, discard) =>
+      void resolveDuplicateChoice(keep, discard),
+    resolveDuplicateKeepBoth
   };
 
   return {
     viewProps,
-    duplicateScanStatus: duplicateScanStatus ?? scanStatusQuery.data ?? null,
+    duplicateScanStatus: duplicateScanStatus ?? scanStatusQuery.data ?? null
   };
 }

--- a/frontend/src/features/file-detail/FileDetailPanel.tsx
+++ b/frontend/src/features/file-detail/FileDetailPanel.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+
+import { FileDetailPreview } from './FileDetailPreview';
+
 import type { FileItem } from '@/api';
 import { formatDateTime } from '@/lib/format';
-import { FileDetailPreview } from './FileDetailPreview';
 
 export type FetchState = {
   loading: boolean;
@@ -150,7 +152,7 @@ export function FileDetailPanel(props: Props): React.ReactElement {
     onDeleteFile,
     onClose,
     onGoRelative,
-    renderFileMedia,
+    renderFileMedia
   } = props;
 
   return (
@@ -164,13 +166,26 @@ export function FileDetailPanel(props: Props): React.ReactElement {
     >
       <div
         className={`file-detail-track${detailSwipeTransition ? ' is-transitioning' : ''}`}
-        style={{ transform: `translate3d(calc(-100% + ${detailSwipeOffset}px), 0, 0)` }}
+        style={{
+          transform: `translate3d(calc(-100% + ${detailSwipeOffset}px), 0, 0)`
+        }}
       >
         <FileDetailPreview file={prevLoadedFile} direction="prev" />
-        <div className={`file-detail-panel file-detail-panel-current file-detail-layer text-foreground${selectedFile.mediaType === 'VIDEO' ? ' is-video' : ''}`}>
+        <div
+          className={`file-detail-panel file-detail-panel-current file-detail-layer text-foreground${selectedFile.mediaType === 'VIDEO' ? ' is-video' : ''}`}
+        >
           <div className="container file-detail-back-bar">
             <button className="file-detail-back-btn" onClick={onClose}>
-              <svg className="file-detail-back-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <svg
+                className="file-detail-back-icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
                 <path d="M15 18l-6-6 6-6" />
               </svg>
               Back to gallery
@@ -197,7 +212,8 @@ export function FileDetailPanel(props: Props): React.ReactElement {
           <div
             className={`file-detail-media-wrap${mediaFullscreen ? ' is-fullscreen' : ''}`}
             onClick={(e) => {
-              if (mediaFullscreen && e.target === e.currentTarget) onToggleFullscreen();
+              if (mediaFullscreen && e.target === e.currentTarget)
+                onToggleFullscreen();
             }}
           >
             <button
@@ -220,10 +236,21 @@ export function FileDetailPanel(props: Props): React.ReactElement {
             <button
               className="file-detail-fullscreen-btn"
               onClick={onToggleFullscreen}
-              aria-label={mediaFullscreen ? 'Exit fullscreen' : 'View fullscreen'}
+              aria-label={
+                mediaFullscreen ? 'Exit fullscreen' : 'View fullscreen'
+              }
               title={mediaFullscreen ? 'Exit fullscreen' : 'View fullscreen'}
             >
-              <svg className="file-detail-fullscreen-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <svg
+                className="file-detail-fullscreen-icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
                 {mediaFullscreen ? (
                   <>
                     <path d="M8 3v3a2 2 0 0 1-2 2H3" />
@@ -243,314 +270,391 @@ export function FileDetailPanel(props: Props): React.ReactElement {
             </button>
           </div>
           <div className="container file-detail-body">
-        <div className="file-detail-section mb-4">
-          <div className="file-detail-section-head">
-            <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
-              File info
-            </div>
-            <div className="file-detail-section-actions">
-              <button
-                className="btn btn-outline-light btn-sm file-detail-download-button file-detail-icon-button"
-                disabled={shareState.loading}
-                onClick={() => void onDownloadFile()}
-                aria-label="Download file"
-                title="Download file"
-              >
-                <svg
-                  className="file-detail-download-icon"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.8"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M12 3v10" />
-                  <path d="M8 9l4 4 4-4" />
-                  <path d="M5 21h14" />
-                </svg>
-                <span className="file-detail-button-text">Download</span>
-              </button>
-              <button
-                className={`btn btn-outline-warning btn-sm file-detail-favorite-button file-detail-icon-button${
-                  selectedFileFavorite ? ' is-favorite' : ''
-                }`}
-                disabled={favoriteState.loading}
-                onClick={() => void onToggleFavorite()}
-                aria-label={selectedFileFavorite ? 'Unfavorite file' : 'Favorite file'}
-                aria-pressed={selectedFileFavorite}
-                title={selectedFileFavorite ? 'Unfavorite file' : 'Favorite file'}
-              >
-                <svg
-                  className="file-detail-favorite-icon file-detail-favorite-icon-outline"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.6"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M12 3.5l2.95 5.98 6.6.96-4.77 4.65 1.12 6.53L12 17.8l-5.9 3.32 1.12-6.53-4.77-4.65 6.6-.96L12 3.5z" />
-                </svg>
-                <svg
-                  className="file-detail-favorite-icon file-detail-favorite-icon-filled"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  stroke="currentColor"
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M12 3.5l2.95 5.98 6.6.96-4.77 4.65 1.12 6.53L12 17.8l-5.9 3.32 1.12-6.53-4.77-4.65 6.6-.96L12 3.5z" />
-                </svg>
-                <span className="file-detail-button-text">Favorite</span>
-              </button>
-              <button
-                className="btn btn-outline-danger btn-sm file-detail-delete-button file-detail-icon-button"
-                disabled={deleteState.loading}
-                onClick={() => void onDeleteFile(selectedFile.id)}
-                aria-label={deleteState.loading ? 'Deleting file' : 'Delete file'}
-                title="Delete file"
-              >
-                <svg
-                  className="file-detail-delete-icon"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.8"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M3 6h18" />
-                  <path d="M8 6V4h8v2" />
-                  <path d="M6 6l1 14h10l1-14" />
-                  <path d="M10 11v6" />
-                  <path d="M14 11v6" />
-                </svg>
-                <span className="file-detail-button-text">Delete file</span>
-              </button>
-            </div>
-          </div>
-          <div className="text-muted-foreground text-sm">
-            <span className="font-semibold file-detail-label">File name:</span> {selectedFileName}
-            <br />
-            {selectedFile.durationMs ? `${(selectedFile.durationMs / 1000).toFixed(1)}s` : ''}
-            {selectedFile.durationMs ? <br /> : null}
-            <span className="font-semibold file-detail-label">Type:</span> {selectedFileType}
-            <br />
-            <span className="font-semibold file-detail-label">Size:</span>{' '}
-            {(selectedFile.sizeBytes / 1024 / 1024).toFixed(2)} MB
-            {selectedFile.width && selectedFile.height ? ` (${selectedFile.width}×${selectedFile.height})` : ''}
-            <br />
-            <span className="font-semibold file-detail-label">Modified:</span> {formatDateTime(selectedFile.mtime)}
-          </div>
-        </div>
-        <div className="file-detail-section-divider" />
-        <div className="file-detail-tags file-detail-section mb-4">
-          <div className="flex justify-between items-center mb-2">
-            <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
-              Tags
-            </div>
-            <div className="flex gap-2">
-              <button
-                className={`btn btn-outline-light btn-sm file-detail-refresh-button file-detail-icon-button${
-                  tagState.loading ? ' is-loading' : ''
-                }`}
-                onClick={() => void onRefreshTags()}
-                disabled={tagState.loading}
-                aria-label="Refresh tags"
-              >
-                <svg
-                  className="file-detail-refresh-icon"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.8"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M21 12a9 9 0 1 1-2.64-6.36" />
-                  <path d="M21 3v6h-6" />
-                </svg>
-                <span className="file-detail-button-text">Refresh</span>
-              </button>
-            </div>
-          </div>
-          <div className="flex flex-wrap gap-2 items-center mb-2">
-            <input
-              className="form-control form-control-sm bg-background text-foreground border-secondary"
-              style={{ maxWidth: 220 }}
-              placeholder="Add tag"
-              value={manualTagInput}
-              onChange={(event) => onManualTagInputChange(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter') {
-                  event.preventDefault();
-                  void onAddManualTag();
-                }
-              }}
-            />
-            <select
-              className="form-select form-select-sm bg-background text-foreground border-secondary"
-              style={{ maxWidth: 160 }}
-              value={manualTagCategory}
-              onChange={(event) => onManualTagCategoryChange(event.target.value)}
-            >
-              <option value="general">general</option>
-              <option value="artist">artist</option>
-              <option value="character">character</option>
-              <option value="copyright">copyright</option>
-              <option value="species">species</option>
-              <option value="meta">meta</option>
-              <option value="lore">lore</option>
-              <option value="invalid">invalid</option>
-            </select>
-            <button className="btn btn-outline-light btn-sm" onClick={() => void onAddManualTag()}>
-              Add
-            </button>
-          </div>
-          {tagState.error ? <div className="text-destructive text-sm mb-2">{tagState.error}</div> : null}
-          {tagState.loading ? <div className="text-muted-foreground text-sm mb-2">Updating tags…</div> : null}
-          {tagGroups.length === 0 ? (
-            <div className="text-muted-foreground text-sm">No tags yet.</div>
-          ) : (
-            tagGroups.map((group) => (
-              <div key={group.category} className="mb-2">
-                <div className="text-sm font-semibold uppercase mb-1 file-detail-subtitle">
-                  {group.category}
+            <div className="file-detail-section mb-4">
+              <div className="file-detail-section-head">
+                <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
+                  File info
                 </div>
-                <div className="flex flex-wrap gap-2">
-                  {group.tags.map((tag) => {
-                    const sources = Array.from(tag.sources).join(', ');
-                    const scoreText = tag.score !== null ? `score ${tag.score}` : 'score n/a';
-                    return (
-                      <span
-                        key={`${group.category}-${tag.tag}`}
-                        className="badge bg-secondary text-foreground file-tag-pill"
-                        title={`${sources} • ${scoreText}`}
-                      >
-                        {tag.tag}
-                        {tag.hasManual ? (
-                          <button
-                            className="btn btn-link btn-sm p-0 ml-2 text-foreground file-tag-remove"
-                            onClick={() => void onRemoveManualTag(tag.tag, group.category)}
-                            aria-label={`Remove ${tag.tag}`}
-                          >
-                            ×
-                          </button>
-                        ) : null}
-                      </span>
-                    );
-                  })}
+                <div className="file-detail-section-actions">
+                  <button
+                    className="btn btn-outline-light btn-sm file-detail-download-button file-detail-icon-button"
+                    disabled={shareState.loading}
+                    onClick={() => void onDownloadFile()}
+                    aria-label="Download file"
+                    title="Download file"
+                  >
+                    <svg
+                      className="file-detail-download-icon"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M12 3v10" />
+                      <path d="M8 9l4 4 4-4" />
+                      <path d="M5 21h14" />
+                    </svg>
+                    <span className="file-detail-button-text">Download</span>
+                  </button>
+                  <button
+                    className={`btn btn-outline-warning btn-sm file-detail-favorite-button file-detail-icon-button${
+                      selectedFileFavorite ? ' is-favorite' : ''
+                    }`}
+                    disabled={favoriteState.loading}
+                    onClick={() => void onToggleFavorite()}
+                    aria-label={
+                      selectedFileFavorite ? 'Unfavorite file' : 'Favorite file'
+                    }
+                    aria-pressed={selectedFileFavorite}
+                    title={
+                      selectedFileFavorite ? 'Unfavorite file' : 'Favorite file'
+                    }
+                  >
+                    <svg
+                      className="file-detail-favorite-icon file-detail-favorite-icon-outline"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.6"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M12 3.5l2.95 5.98 6.6.96-4.77 4.65 1.12 6.53L12 17.8l-5.9 3.32 1.12-6.53-4.77-4.65 6.6-.96L12 3.5z" />
+                    </svg>
+                    <svg
+                      className="file-detail-favorite-icon file-detail-favorite-icon-filled"
+                      viewBox="0 0 24 24"
+                      fill="currentColor"
+                      stroke="currentColor"
+                      strokeWidth="1.2"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M12 3.5l2.95 5.98 6.6.96-4.77 4.65 1.12 6.53L12 17.8l-5.9 3.32 1.12-6.53-4.77-4.65 6.6-.96L12 3.5z" />
+                    </svg>
+                    <span className="file-detail-button-text">Favorite</span>
+                  </button>
+                  <button
+                    className="btn btn-outline-danger btn-sm file-detail-delete-button file-detail-icon-button"
+                    disabled={deleteState.loading}
+                    onClick={() => void onDeleteFile(selectedFile.id)}
+                    aria-label={
+                      deleteState.loading ? 'Deleting file' : 'Delete file'
+                    }
+                    title="Delete file"
+                  >
+                    <svg
+                      className="file-detail-delete-icon"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M3 6h18" />
+                      <path d="M8 6V4h8v2" />
+                      <path d="M6 6l1 14h10l1-14" />
+                      <path d="M10 11v6" />
+                      <path d="M14 11v6" />
+                    </svg>
+                    <span className="file-detail-button-text">Delete file</span>
+                  </button>
                 </div>
               </div>
-            ))
-          )}
-          <div className="text-muted-foreground text-sm mt-2">
-            <span className="file-detail-label">Sources:</span> {tagSourceSummary}
-          </div>
-        </div>
-        <div className="file-detail-section-divider" />
-        <div className="file-detail-section mb-4">
-          <div className="file-detail-section-head">
-            <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
-              Sauces
+              <div className="text-muted-foreground text-sm">
+                <span className="font-semibold file-detail-label">
+                  File name:
+                </span>{' '}
+                {selectedFileName}
+                <br />
+                {selectedFile.durationMs
+                  ? `${(selectedFile.durationMs / 1000).toFixed(1)}s`
+                  : ''}
+                {selectedFile.durationMs ? <br /> : null}
+                <span className="font-semibold file-detail-label">
+                  Type:
+                </span>{' '}
+                {selectedFileType}
+                <br />
+                <span className="font-semibold file-detail-label">
+                  Size:
+                </span>{' '}
+                {(selectedFile.sizeBytes / 1024 / 1024).toFixed(2)} MB
+                {selectedFile.width && selectedFile.height
+                  ? ` (${selectedFile.width}×${selectedFile.height})`
+                  : ''}
+                <br />
+                <span className="font-semibold file-detail-label">
+                  Modified:
+                </span>{' '}
+                {formatDateTime(selectedFile.mtime)}
+              </div>
             </div>
-            <button
-              className="btn btn-outline-light btn-sm file-detail-scan-button file-detail-icon-button"
-              disabled={providerState.loading}
-              onClick={() => void onRunAllProviders()}
-              aria-label="Scan with SauceNAO and Fluffle"
-            >
-              <svg
-                className="file-detail-scan-icon"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.8"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                <circle cx="11" cy="11" r="6" />
-                <path d="M16 16l5 5" />
-              </svg>
-              <span className="file-detail-button-text">Scan</span>
-            </button>
-          </div>
-          <div className="text-muted-foreground text-sm mb-4">
-            <div>
-              <span className="font-semibold file-detail-label">Provider scans:</span>{' '}
-              {providerMeta?.hasRuns ? `last run ${formatDateTime(providerMeta.latestRunAt)}` : 'never run yet'}
+            <div className="file-detail-section-divider" />
+            <div className="file-detail-tags file-detail-section mb-4">
+              <div className="flex justify-between items-center mb-2">
+                <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
+                  Tags
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    className={`btn btn-outline-light btn-sm file-detail-refresh-button file-detail-icon-button${
+                      tagState.loading ? ' is-loading' : ''
+                    }`}
+                    onClick={() => void onRefreshTags()}
+                    disabled={tagState.loading}
+                    aria-label="Refresh tags"
+                  >
+                    <svg
+                      className="file-detail-refresh-icon"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+                      <path d="M21 3v6h-6" />
+                    </svg>
+                    <span className="file-detail-button-text">Refresh</span>
+                  </button>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2 items-center mb-2">
+                <input
+                  className="form-control form-control-sm bg-background text-foreground border-secondary"
+                  style={{ maxWidth: 220 }}
+                  placeholder="Add tag"
+                  value={manualTagInput}
+                  onChange={(event) =>
+                    onManualTagInputChange(event.target.value)
+                  }
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.preventDefault();
+                      void onAddManualTag();
+                    }
+                  }}
+                />
+                <select
+                  className="form-select form-select-sm bg-background text-foreground border-secondary"
+                  style={{ maxWidth: 160 }}
+                  value={manualTagCategory}
+                  onChange={(event) =>
+                    onManualTagCategoryChange(event.target.value)
+                  }
+                >
+                  <option value="general">general</option>
+                  <option value="artist">artist</option>
+                  <option value="character">character</option>
+                  <option value="copyright">copyright</option>
+                  <option value="species">species</option>
+                  <option value="meta">meta</option>
+                  <option value="lore">lore</option>
+                  <option value="invalid">invalid</option>
+                </select>
+                <button
+                  className="btn btn-outline-light btn-sm"
+                  onClick={() => void onAddManualTag()}
+                >
+                  Add
+                </button>
+              </div>
+              {tagState.error ? (
+                <div className="text-destructive text-sm mb-2">
+                  {tagState.error}
+                </div>
+              ) : null}
+              {tagState.loading ? (
+                <div className="text-muted-foreground text-sm mb-2">
+                  Updating tags…
+                </div>
+              ) : null}
+              {tagGroups.length === 0 ? (
+                <div className="text-muted-foreground text-sm">
+                  No tags yet.
+                </div>
+              ) : (
+                tagGroups.map((group) => (
+                  <div key={group.category} className="mb-2">
+                    <div className="text-sm font-semibold uppercase mb-1 file-detail-subtitle">
+                      {group.category}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {group.tags.map((tag) => {
+                        const sources = Array.from(tag.sources).join(', ');
+                        const scoreText =
+                          tag.score !== null
+                            ? `score ${tag.score}`
+                            : 'score n/a';
+                        return (
+                          <span
+                            key={`${group.category}-${tag.tag}`}
+                            className="badge bg-secondary text-foreground file-tag-pill"
+                            title={`${sources} • ${scoreText}`}
+                          >
+                            {tag.tag}
+                            {tag.hasManual ? (
+                              <button
+                                className="btn btn-link btn-sm p-0 ml-2 text-foreground file-tag-remove"
+                                onClick={() =>
+                                  void onRemoveManualTag(
+                                    tag.tag,
+                                    group.category
+                                  )
+                                }
+                                aria-label={`Remove ${tag.tag}`}
+                              >
+                                ×
+                              </button>
+                            ) : null}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))
+              )}
+              <div className="text-muted-foreground text-sm mt-2">
+                <span className="file-detail-label">Sources:</span>{' '}
+                {tagSourceSummary}
+              </div>
             </div>
-            {providerMeta?.missingProviders.length ? (
-              <div>
-                <span className="font-semibold file-detail-label">Missing:</span>{' '}
-                {providerMeta.missingProviders.join(', ')}
+            <div className="file-detail-section-divider" />
+            <div className="file-detail-section mb-4">
+              <div className="file-detail-section-head">
+                <div className="uppercase font-semibold file-detail-section-title file-detail-section-title-accent">
+                  Sauces
+                </div>
+                <button
+                  className="btn btn-outline-light btn-sm file-detail-scan-button file-detail-icon-button"
+                  disabled={providerState.loading}
+                  onClick={() => void onRunAllProviders()}
+                  aria-label="Scan with SauceNAO and Fluffle"
+                >
+                  <svg
+                    className="file-detail-scan-icon"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <circle cx="11" cy="11" r="6" />
+                    <path d="M16 16l5 5" />
+                  </svg>
+                  <span className="file-detail-button-text">Scan</span>
+                </button>
+              </div>
+              <div className="text-muted-foreground text-sm mb-4">
+                <div>
+                  <span className="font-semibold file-detail-label">
+                    Provider scans:
+                  </span>{' '}
+                  {providerMeta?.hasRuns
+                    ? `last run ${formatDateTime(providerMeta.latestRunAt)}`
+                    : 'never run yet'}
+                </div>
+                {providerMeta?.missingProviders.length ? (
+                  <div>
+                    <span className="font-semibold file-detail-label">
+                      Missing:
+                    </span>{' '}
+                    {providerMeta.missingProviders.join(', ')}
+                  </div>
+                ) : null}
+                <div>
+                  <span className="font-semibold file-detail-label">
+                    Next auto-scan:
+                  </span>{' '}
+                  {nextAutoScanText}
+                </div>
+              </div>
+            </div>
+            {providerState.error ? (
+              <div className="text-destructive text-sm mb-2">
+                {providerState.error}
               </div>
             ) : null}
-            <div>
-              <span className="font-semibold file-detail-label">Next auto-scan:</span> {nextAutoScanText}
+            {favoriteState.error ? (
+              <div className="text-destructive text-sm mb-2">
+                {favoriteState.error}
+              </div>
+            ) : null}
+            {deleteState.error ? (
+              <div className="text-destructive text-sm mb-2">
+                {deleteState.error}
+              </div>
+            ) : null}
+            <div className="file-detail-topmatches mb-4">
+              {matchRemoveState.error ? (
+                <div className="text-destructive text-sm mb-2">
+                  {matchRemoveState.error}
+                </div>
+              ) : null}
+              {providerHighlights.length ? (
+                <div className="file-detail-topmatches-list">
+                  {providerHighlights.map((item) => (
+                    <a
+                      key={item.id}
+                      className="file-detail-topmatches-card text-decoration-none border border-secondary rounded p-2 bg-background text-foreground"
+                      href={item.sourceUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      <button
+                        type="button"
+                        className="file-detail-topmatches-remove"
+                        onClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          void onRemoveTopMatch(item.sourceUrl);
+                        }}
+                        disabled={matchRemoveState.loading}
+                        aria-label={`Remove ${item.sourceName}`}
+                      >
+                        ×
+                      </button>
+                      <div className="text-muted-foreground text-sm">
+                        {item.provider}
+                      </div>
+                      <div
+                        className="font-semibold truncate"
+                        title={item.sourceName}
+                      >
+                        {item.sourceName}
+                      </div>
+                      <div className="text-muted-foreground text-sm">
+                        {(() => {
+                          const value = item.score;
+                          const label = 'score';
+                          return value !== null
+                            ? `${label} ${value}`
+                            : `${label} n/a`;
+                        })()}
+                      </div>
+                    </a>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-muted-foreground text-sm">
+                  {!providerMeta?.hasRuns
+                    ? 'No scan results yet.'
+                    : displayFilterActive
+                      ? 'No matches for selected sauces yet.'
+                      : 'No high-confidence matches yet.'}
+                </div>
+              )}
             </div>
-          </div>
-        </div>
-        {providerState.error ? <div className="text-destructive text-sm mb-2">{providerState.error}</div> : null}
-        {favoriteState.error ? <div className="text-destructive text-sm mb-2">{favoriteState.error}</div> : null}
-        {deleteState.error ? <div className="text-destructive text-sm mb-2">{deleteState.error}</div> : null}
-        <div className="file-detail-topmatches mb-4">
-          {matchRemoveState.error ? (
-            <div className="text-destructive text-sm mb-2">{matchRemoveState.error}</div>
-          ) : null}
-          {providerHighlights.length ? (
-            <div className="file-detail-topmatches-list">
-              {providerHighlights.map((item) => (
-                <a
-                  key={item.id}
-                  className="file-detail-topmatches-card text-decoration-none border border-secondary rounded p-2 bg-background text-foreground"
-                  href={item.sourceUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  <button
-                    type="button"
-                    className="file-detail-topmatches-remove"
-                    onClick={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      void onRemoveTopMatch(item.sourceUrl);
-                    }}
-                    disabled={matchRemoveState.loading}
-                    aria-label={`Remove ${item.sourceName}`}
-                  >
-                    ×
-                  </button>
-                  <div className="text-muted-foreground text-sm">{item.provider}</div>
-                  <div className="font-semibold truncate" title={item.sourceName}>
-                    {item.sourceName}
-                  </div>
-                  <div className="text-muted-foreground text-sm">
-                    {(() => {
-                      const value = item.score;
-                      const label = 'score';
-                      return value !== null ? `${label} ${value}` : `${label} n/a`;
-                    })()}
-                  </div>
-                </a>
-              ))}
-            </div>
-          ) : (
-            <div className="text-muted-foreground text-sm">
-              {!providerMeta?.hasRuns
-                ? 'No scan results yet.'
-                : displayFilterActive
-                  ? 'No matches for selected sauces yet.'
-                  : 'No high-confidence matches yet.'}
-            </div>
-          )}
-        </div>
           </div>
         </div>
         <FileDetailPreview file={nextLoadedFile} direction="next" />

--- a/frontend/src/features/file-detail/FileDetailPreview.tsx
+++ b/frontend/src/features/file-detail/FileDetailPreview.tsx
@@ -1,13 +1,23 @@
 import React from 'react';
+
+import {
+  basenameFromPath,
+  fileTypeFromPath,
+  formatDateTime,
+  formatSizeMb
+} from './utils';
+
 import { API_BASE, type FileItem } from '@/api';
-import { basenameFromPath, fileTypeFromPath, formatDateTime, formatSizeMb } from './utils';
 
 interface Props {
   file: FileItem | null;
   direction: 'prev' | 'next';
 }
 
-export function FileDetailPreview({ file, direction }: Props): React.ReactElement {
+export function FileDetailPreview({
+  file,
+  direction
+}: Props): React.ReactElement {
   if (!file) {
     return (
       <div
@@ -182,19 +192,29 @@ export function FileDetailPreview({ file, direction }: Props): React.ReactElemen
               </div>
             </div>
             <div className="text-muted-foreground text-sm">
-              <span className="font-semibold file-detail-label">File name:</span>{' '}
+              <span className="font-semibold file-detail-label">
+                File name:
+              </span>{' '}
               {basenameFromPath(file.path) || file.path}
               <br />
               {file.durationMs ? `${(file.durationMs / 1000).toFixed(1)}s` : ''}
               {file.durationMs ? <br /> : null}
-              <span className="font-semibold file-detail-label">Type:</span>{' '}
+              <span className="font-semibold file-detail-label">
+                Type:
+              </span>{' '}
               {fileTypeFromPath(file.path, file.mediaType)}
               <br />
-              <span className="font-semibold file-detail-label">Size:</span>{' '}
+              <span className="font-semibold file-detail-label">
+                Size:
+              </span>{' '}
               {formatSizeMb(file.sizeBytes)}
-              {file.width && file.height ? ` (${file.width}×${file.height})` : ''}
+              {file.width && file.height
+                ? ` (${file.width}×${file.height})`
+                : ''}
               <br />
-              <span className="font-semibold file-detail-label">Modified:</span>{' '}
+              <span className="font-semibold file-detail-label">
+                Modified:
+              </span>{' '}
               {formatDateTime(file.mtime)}
             </div>
           </div>

--- a/frontend/src/features/file-detail/useFileDetailController.ts
+++ b/frontend/src/features/file-detail/useFileDetailController.ts
@@ -1,34 +1,40 @@
+import { useQueryClient } from '@tanstack/react-query';
 import {
+  createElement,
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
-  type TouchEvent,
+  type ReactNode,
+  type TouchEvent
 } from 'react';
-import React from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 
-import { api, API_BASE, type FileItem, type FileTag, type ProviderRun, type SauceSettings } from '@/api';
-import {
-  useDeleteFile,
-  useUpdateFileFavorite,
-} from '@/hooks/files';
-import {
-  useAddManualTag,
-  useRefreshFileTags,
-  useRemoveManualTag,
-  useRemoveTopMatch,
-} from '@/hooks/tags';
-import { basenameFromPath, fileTypeFromPath } from '@/lib/format';
-import { queryKeys } from '@/lib/query-keys';
 import type {
   FetchState,
   Props as FileDetailPanelProps,
   ProviderHighlight,
   ProviderMeta,
-  TagGroup,
+  TagGroup
 } from './FileDetailPanel';
+
+import {
+  api,
+  API_BASE,
+  type FileItem,
+  type FileTag,
+  type ProviderRun,
+  type SauceSettings
+} from '@/api';
+import { useDeleteFile, useUpdateFileFavorite } from '@/hooks/files';
+import {
+  useAddManualTag,
+  useRefreshFileTags,
+  useRemoveManualTag,
+  useRemoveTopMatch
+} from '@/hooks/tags';
+import { basenameFromPath, fileTypeFromPath } from '@/lib/format';
+import { queryKeys } from '@/lib/query-keys';
 
 // ---------------------------------------------------------------------------
 // Local constants (mirrored from App.tsx — keep in sync)
@@ -38,14 +44,14 @@ type ProviderKind = 'SAUCENAO' | 'FLUFFLE';
 const providerKinds: readonly ProviderKind[] = ['SAUCENAO', 'FLUFFLE'];
 const providerScoreThresholds: Record<ProviderKind, number> = {
   SAUCENAO: 90,
-  FLUFFLE: 95,
+  FLUFFLE: 95
 };
 
 type DetailSwipeAxis = 'idle' | 'x' | 'y';
 
 const resolveProviderScore = (
   provider: ProviderKind,
-  result: { score?: number | null; distance?: number | null },
+  result: { score?: number | null; distance?: number | null }
 ): number | null => {
   if (provider !== 'FLUFFLE') {
     return typeof result.score === 'number' ? result.score : null;
@@ -63,7 +69,7 @@ const canonicalSauces: Record<string, string> = {
   'static3.e621.net': 'e621',
   'static4.e621.net': 'e621',
   'danbooru.donmai.us': 'danbooru',
-  'www.danbooru.donmai.us': 'danbooru',
+  'www.danbooru.donmai.us': 'danbooru'
 };
 
 const normalizeSauceKey = (value: string) => value.trim().toLowerCase();
@@ -95,7 +101,7 @@ const looksLikeFilename = (value: string): boolean => {
 
 const sauceKeyFromResult = (
   sourceUrl: string | null | undefined,
-  sourceName: string | null | undefined,
+  sourceName: string | null | undefined
 ): string | null => {
   if (sourceName) {
     const cleaned = normalizeSourceName(sourceName);
@@ -105,7 +111,9 @@ const sauceKeyFromResult = (
   }
   if (sourceUrl) {
     try {
-      return canonicalizeSauceKey(new URL(sourceUrl).hostname.replace(/^www\./, ''));
+      return canonicalizeSauceKey(
+        new URL(sourceUrl).hostname.replace(/^www\./, '')
+      );
     } catch {
       return canonicalizeSauceKey(sourceUrl);
     }
@@ -113,7 +121,10 @@ const sauceKeyFromResult = (
   return null;
 };
 
-const guessMimeType = (filename: string, mediaType: FileItem['mediaType']): string => {
+const guessMimeType = (
+  filename: string,
+  mediaType: FileItem['mediaType']
+): string => {
   const ext = filename.split('.').pop()?.toLowerCase();
   if (!ext) return mediaType === 'VIDEO' ? 'video/*' : 'image/*';
   const map: Record<string, string> = {
@@ -126,7 +137,7 @@ const guessMimeType = (filename: string, mediaType: FileItem['mediaType']): stri
     webm: 'video/webm',
     mp4: 'video/mp4',
     mov: 'video/quicktime',
-    mkv: 'video/x-matroska',
+    mkv: 'video/x-matroska'
   };
   return map[ext] ?? 'application/octet-stream';
 };
@@ -185,9 +196,14 @@ export type FileDetailControllerOutput = {
 // ---------------------------------------------------------------------------
 
 export function useFileDetailController(
-  input: FileDetailControllerInput,
+  input: FileDetailControllerInput
 ): FileDetailControllerOutput {
-  const { gallery, sauceSettings, historyMode = 'browser', onExternalClose } = input;
+  const {
+    gallery,
+    sauceSettings,
+    historyMode = 'browser',
+    onExternalClose
+  } = input;
   const queryClient = useQueryClient();
 
   // --- mutations -----------------------------------------------------------
@@ -203,12 +219,30 @@ export function useFileDetailController(
   const [selectedFile, setSelectedFile] = useState<FileItem | null>(null);
 
   // --- action states -------------------------------------------------------
-  const [shareState, setShareState] = useState<FetchState>({ loading: false, error: null });
-  const [favoriteState, setFavoriteState] = useState<FetchState>({ loading: false, error: null });
-  const [deleteState, setDeleteState] = useState<FetchState>({ loading: false, error: null });
-  const [tagState, setTagState] = useState<FetchState>({ loading: false, error: null });
-  const [providerState, setProviderState] = useState<FetchState>({ loading: false, error: null });
-  const [matchRemoveState, setMatchRemoveState] = useState<FetchState>({ loading: false, error: null });
+  const [shareState, setShareState] = useState<FetchState>({
+    loading: false,
+    error: null
+  });
+  const [favoriteState, setFavoriteState] = useState<FetchState>({
+    loading: false,
+    error: null
+  });
+  const [deleteState, setDeleteState] = useState<FetchState>({
+    loading: false,
+    error: null
+  });
+  const [tagState, setTagState] = useState<FetchState>({
+    loading: false,
+    error: null
+  });
+  const [providerState, setProviderState] = useState<FetchState>({
+    loading: false,
+    error: null
+  });
+  const [matchRemoveState, setMatchRemoveState] = useState<FetchState>({
+    loading: false,
+    error: null
+  });
 
   // --- provider & tags data ------------------------------------------------
   const [providerInfo, setProviderInfo] = useState<ProviderRun[]>([]);
@@ -240,7 +274,7 @@ export function useFileDetailController(
     startY: 0,
     lastX: 0,
     startedAt: 0,
-    axis: 'idle',
+    axis: 'idle'
   });
 
   // --- nav peek ------------------------------------------------------------
@@ -262,7 +296,8 @@ export function useFileDetailController(
   // Note: galleryHasMore not available here — conservative false; App must wire
   // goRelative that handles load-more internally.
   const hasNext = activeIndex >= 0 && activeIndex < gallery.files.length - 1;
-  const prevLoadedFile = activeIndex > 0 ? (gallery.files[activeIndex - 1] ?? null) : null;
+  const prevLoadedFile =
+    activeIndex > 0 ? (gallery.files[activeIndex - 1] ?? null) : null;
   const nextLoadedFile =
     activeIndex >= 0 && activeIndex < gallery.files.length - 1
       ? (gallery.files[activeIndex + 1] ?? null)
@@ -272,7 +307,9 @@ export function useFileDetailController(
   // Derived file values
   // ---------------------------------------------------------------------------
 
-  const selectedFileName = selectedFile ? basenameFromPath(selectedFile.path) || selectedFile.path : '';
+  const selectedFileName = selectedFile
+    ? basenameFromPath(selectedFile.path) || selectedFile.path
+    : '';
   const selectedFileType = selectedFile
     ? fileTypeFromPath(selectedFile.path, selectedFile.mediaType)
     : '';
@@ -283,17 +320,17 @@ export function useFileDetailController(
   // ---------------------------------------------------------------------------
 
   const displayFilterActive =
-    (sauceSettings.displayInitialized ?? false) || sauceSettings.display.length > 0;
+    (sauceSettings.displayInitialized ?? false) ||
+    sauceSettings.display.length > 0;
 
   const displaySet = useMemo(() => {
-    if (!displayFilterActive)
-      return new Set<string>();
+    if (!displayFilterActive) return new Set<string>();
     return new Set(sauceSettings.display.map(canonicalizeSauceKey));
   }, [displayFilterActive, sauceSettings.display]);
 
   const targetSet = useMemo(
     () => new Set(sauceSettings.targets.map(canonicalizeSauceKey)),
-    [sauceSettings.targets],
+    [sauceSettings.targets]
   );
 
   // ---------------------------------------------------------------------------
@@ -303,7 +340,13 @@ export function useFileDetailController(
   const tagGroups = useMemo<readonly TagGroup[]>(() => {
     const map = new Map<
       string,
-      { tag: string; category: string; sources: Set<string>; score: number | null; hasManual: boolean }
+      {
+        tag: string;
+        category: string;
+        sources: Set<string>;
+        score: number | null;
+        hasManual: boolean;
+      }
     >();
     for (const tag of fileTags) {
       const key = `${tag.category}:${tag.tag}`;
@@ -311,7 +354,10 @@ export function useFileDetailController(
       const score = typeof tag.score === 'number' ? tag.score : null;
       if (existing) {
         existing.sources.add(tag.source);
-        if (score !== null && (existing.score === null || score > existing.score)) {
+        if (
+          score !== null &&
+          (existing.score === null || score > existing.score)
+        ) {
           existing.score = score;
         }
         if (tag.source === 'MANUAL') existing.hasManual = true;
@@ -321,12 +367,24 @@ export function useFileDetailController(
           category: tag.category,
           sources: new Set([tag.source]),
           score,
-          hasManual: tag.source === 'MANUAL',
+          hasManual: tag.source === 'MANUAL'
         });
       }
     }
-    const grouped = Array.from(map.values()).sort((a, b) => a.tag.localeCompare(b.tag));
-    const order = ['artist', 'character', 'copyright', 'species', 'general', 'meta', 'lore', 'invalid', 'other'];
+    const grouped = Array.from(map.values()).sort((a, b) =>
+      a.tag.localeCompare(b.tag)
+    );
+    const order = [
+      'artist',
+      'character',
+      'copyright',
+      'species',
+      'general',
+      'meta',
+      'lore',
+      'invalid',
+      'other'
+    ];
     const categories = new Map<string, typeof grouped>();
     for (const entry of grouped) {
       const key = entry.category || 'other';
@@ -380,13 +438,16 @@ export function useFileDetailController(
                 sourceUrl: run.sourceUrl ?? null,
                 score: run.score ?? null,
                 sourceName: null,
-                distance: null,
-              },
+                distance: null
+              }
             ];
       for (const result of results) {
         if (!result?.sourceUrl) continue;
         if (displayFilterActive) {
-          const key = sauceKeyFromResult(result.sourceUrl, result.sourceName ?? null);
+          const key = sauceKeyFromResult(
+            result.sourceUrl,
+            result.sourceName ?? null
+          );
           if (!key || !displaySet.has(key)) continue;
         }
         const score = resolveProviderScore(provider as ProviderKind, result);
@@ -401,7 +462,7 @@ export function useFileDetailController(
           sourceUrl: result.sourceUrl,
           sourceName: result.sourceName ?? provider,
           score,
-          distance,
+          distance
         });
       }
     }
@@ -441,7 +502,8 @@ export function useFileDetailController(
     if (targetSet.size > 0) {
       for (const run of providerInfo) {
         if (run.status === 'PENDING' || run.status === 'RUNNING') continue;
-        const threshold = providerScoreThresholds[run.provider as ProviderKind] ?? 0;
+        const threshold =
+          providerScoreThresholds[run.provider as ProviderKind] ?? 0;
         const results: Array<{
           sourceUrl?: string | null;
           sourceName?: string | null;
@@ -449,11 +511,23 @@ export function useFileDetailController(
         }> =
           Array.isArray(run.results) && run.results.length > 0
             ? run.results
-            : [{ sourceUrl: run.sourceUrl ?? null, sourceName: null, score: run.score ?? null }];
+            : [
+                {
+                  sourceUrl: run.sourceUrl ?? null,
+                  sourceName: null,
+                  score: run.score ?? null
+                }
+              ];
         for (const result of results) {
-          const score = resolveProviderScore(run.provider as ProviderKind, result);
+          const score = resolveProviderScore(
+            run.provider as ProviderKind,
+            result
+          );
           if (score === null || score < threshold) continue;
-          const key = sauceKeyFromResult(result.sourceUrl, result.sourceName ?? null);
+          const key = sauceKeyFromResult(
+            result.sourceUrl,
+            result.sourceName ?? null
+          );
           if (key && targetSet.has(key)) {
             targetHit = true;
             break;
@@ -473,7 +547,8 @@ export function useFileDetailController(
       const runMs = new Date(run.completedAt ?? run.createdAt).getTime();
       if (Number.isNaN(runMs)) continue;
       const nextAt = runMs + dayMs;
-      if (nextAutoScanAt === null || nextAt < nextAutoScanAt) nextAutoScanAt = nextAt;
+      if (nextAutoScanAt === null || nextAt < nextAutoScanAt)
+        nextAutoScanAt = nextAt;
     }
 
     return {
@@ -483,7 +558,9 @@ export function useFileDetailController(
       nextAutoScanAt,
       activeRun,
       targetHit,
-      expired: Number.isFinite(firstRunMs) ? Date.now() - firstRunMs > 7 * dayMs : false,
+      expired: Number.isFinite(firstRunMs)
+        ? Date.now() - firstRunMs > 7 * dayMs
+        : false
     };
   }, [providerInfo, selectedFile, targetSet]);
 
@@ -493,7 +570,8 @@ export function useFileDetailController(
     if (providerMeta.targetHit) return 'stopped (target found)';
     if (providerMeta.missingProviders.length > 0)
       return 'pending (missing providers rotate every 10 min)';
-    if (!providerMeta.hasRuns) return 'pending (missing providers rotate every 10 min)';
+    if (!providerMeta.hasRuns)
+      return 'pending (missing providers rotate every 10 min)';
     if (providerMeta.expired) return 'stopped (7-day window elapsed)';
     if (providerMeta.nextAutoScanAt === null) return 'due now';
     return formatRemaining(providerMeta.nextAutoScanAt - Date.now());
@@ -508,14 +586,14 @@ export function useFileDetailController(
       try {
         const resp = await queryClient.fetchQuery({
           queryKey: queryKeys.files.providers(fileId),
-          queryFn: () => api.getProviders(fileId),
+          queryFn: () => api.getProviders(fileId)
         });
         setProviderInfo(resp.providers);
       } catch {
         setProviderInfo([]);
       }
     },
-    [queryClient],
+    [queryClient]
   );
 
   const loadTags = useCallback(
@@ -524,7 +602,7 @@ export function useFileDetailController(
       try {
         const resp = await queryClient.fetchQuery({
           queryKey: queryKeys.files.tags(fileId),
-          queryFn: () => api.getFileTags(fileId),
+          queryFn: () => api.getFileTags(fileId)
         });
         if (resp.tags.length === 0 && !tagRefreshRef.current.has(fileId)) {
           tagRefreshRef.current.add(fileId);
@@ -539,7 +617,7 @@ export function useFileDetailController(
         setTagState({ loading: false, error: (err as Error).message });
       }
     },
-    [queryClient, refreshFileTags],
+    [queryClient, refreshFileTags]
   );
 
   // ---------------------------------------------------------------------------
@@ -547,9 +625,10 @@ export function useFileDetailController(
   // ---------------------------------------------------------------------------
 
   useEffect(() => {
-    if (selectedFile) {
-      void loadProviders(selectedFile.id);
-      void loadTags(selectedFile.id);
+    const fileId = selectedFile?.id;
+    if (fileId) {
+      void loadProviders(fileId);
+      void loadTags(fileId);
       setMatchRemoveState({ loading: false, error: null });
     } else {
       setProviderInfo((prev) => (prev.length ? [] : prev));
@@ -565,7 +644,10 @@ export function useFileDetailController(
     if (selectedFile) {
       window.scrollTo({ top: 0, behavior: 'instant' as ScrollBehavior });
     } else {
-      window.scrollTo({ top: savedGalleryScrollRef.current, behavior: 'instant' as ScrollBehavior });
+      window.scrollTo({
+        top: savedGalleryScrollRef.current,
+        behavior: 'instant' as ScrollBehavior
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedFile?.id]);
@@ -589,7 +671,7 @@ export function useFileDetailController(
       startY: 0,
       lastX: 0,
       startedAt: 0,
-      axis: 'idle',
+      axis: 'idle'
     };
     setDetailSwipeLocked(false);
     setDetailSwipeTransition(false);
@@ -619,8 +701,14 @@ export function useFileDetailController(
     if (!mediaFullscreen && !detailSwipeLocked) return;
     const bodyStyle = document.body.style;
     const htmlStyle = document.documentElement.style;
-    const prevBody = { overflow: bodyStyle.overflow, overscrollBehavior: bodyStyle.overscrollBehavior };
-    const prevHtml = { overflow: htmlStyle.overflow, overscrollBehavior: htmlStyle.overscrollBehavior };
+    const prevBody = {
+      overflow: bodyStyle.overflow,
+      overscrollBehavior: bodyStyle.overscrollBehavior
+    };
+    const prevHtml = {
+      overflow: htmlStyle.overflow,
+      overscrollBehavior: htmlStyle.overscrollBehavior
+    };
     bodyStyle.overflow = 'hidden';
     bodyStyle.overscrollBehavior = 'none';
     htmlStyle.overflow = 'hidden';
@@ -637,23 +725,29 @@ export function useFileDetailController(
   // Effects: keyboard navigation
   // ---------------------------------------------------------------------------
 
-  const closeFile = useCallback((options?: { syncUrl?: boolean }) => {
-    if (historyMode === 'browser' && historyActiveRef.current) {
-      historyActiveRef.current = false;
-      window.history.back();
-    }
-    setSelectedFile(null);
-    if (historyMode === 'external' && options?.syncUrl !== false) {
-      onExternalClose?.();
-    }
-  }, [historyMode, onExternalClose]);
+  const closeFile = useCallback(
+    (options?: { syncUrl?: boolean }) => {
+      if (historyMode === 'browser' && historyActiveRef.current) {
+        historyActiveRef.current = false;
+        window.history.back();
+      }
+      setSelectedFile(null);
+      if (historyMode === 'external' && options?.syncUrl !== false) {
+        onExternalClose?.();
+      }
+    },
+    [historyMode, onExternalClose]
+  );
 
   const onDeleteFile = useCallback(
     async (fileId: string) => {
-      if (!window.confirm('Delete this file from disk? This cannot be undone.')) return;
+      if (!window.confirm('Delete this file from disk? This cannot be undone.'))
+        return;
       const nextFile =
         selectedFile?.id === fileId
-          ? (gallery.files[gallery.currentIndex + 1] ?? gallery.files[gallery.currentIndex - 1] ?? null)
+          ? (gallery.files[gallery.currentIndex + 1] ??
+            gallery.files[gallery.currentIndex - 1] ??
+            null)
           : null;
       setDeleteState({ loading: true, error: null });
       try {
@@ -673,7 +767,7 @@ export function useFileDetailController(
         setDeleteState({ loading: false, error: (err as Error).message });
       }
     },
-    [selectedFile, gallery, deleteFileMutation, closeFile],
+    [selectedFile, gallery, deleteFileMutation, closeFile]
   );
 
   useEffect(() => {
@@ -744,7 +838,8 @@ export function useFileDetailController(
         }, 220);
         return;
       }
-      const width = detailSwipeFrameRef.current?.clientWidth || window.innerWidth || 1;
+      const width =
+        detailSwipeFrameRef.current?.clientWidth || window.innerWidth || 1;
       setDetailSwipeOffset(delta < 0 ? width : -width);
       clearDetailSwipeTimer();
       detailSwipeTimerRef.current = window.setTimeout(() => {
@@ -754,7 +849,7 @@ export function useFileDetailController(
         setDetailSwipeOffset(0);
       }, 220);
     },
-    [clearDetailSwipeTimer, nextLoadedFile, prevLoadedFile],
+    [clearDetailSwipeTimer, nextLoadedFile, prevLoadedFile]
   );
 
   // ---------------------------------------------------------------------------
@@ -763,9 +858,15 @@ export function useFileDetailController(
 
   const onDetailTouchStart = useCallback(
     (event: TouchEvent<HTMLDivElement>) => {
-      if (mediaFullscreen || detailSwipeTransition || event.touches.length !== 1) return;
+      if (
+        mediaFullscreen ||
+        detailSwipeTransition ||
+        event.touches.length !== 1
+      )
+        return;
       const target = event.target as HTMLElement | null;
-      if (target?.closest('button, a, input, textarea, select, label, video')) return;
+      if (target?.closest('button, a, input, textarea, select, label, video'))
+        return;
       const touch = event.touches[0];
       clearDetailSwipeTimer();
       detailGestureRef.current = {
@@ -774,17 +875,18 @@ export function useFileDetailController(
         startY: touch.clientY,
         lastX: touch.clientX,
         startedAt: performance.now(),
-        axis: 'idle',
+        axis: 'idle'
       };
       setDetailSwipeTransition(false);
     },
-    [clearDetailSwipeTimer, detailSwipeTransition, mediaFullscreen],
+    [clearDetailSwipeTimer, detailSwipeTransition, mediaFullscreen]
   );
 
   const onDetailTouchMove = useCallback(
     (event: TouchEvent<HTMLDivElement>) => {
       const gesture = detailGestureRef.current;
-      if (!gesture.active || event.touches.length !== 1 || mediaFullscreen) return;
+      if (!gesture.active || event.touches.length !== 1 || mediaFullscreen)
+        return;
       const touch = event.touches[0];
       const dx = touch.clientX - gesture.startX;
       const dy = touch.clientY - gesture.startY;
@@ -803,7 +905,7 @@ export function useFileDetailController(
       setDetailSwipeTransition(false);
       setDetailSwipeOffset(nextOffset);
     },
-    [mediaFullscreen, nextLoadedFile, prevLoadedFile],
+    [mediaFullscreen, nextLoadedFile, prevLoadedFile]
   );
 
   const onDetailTouchEnd = useCallback(() => {
@@ -818,7 +920,8 @@ export function useFileDetailController(
     const dx = gesture.lastX - gesture.startX;
     const elapsed = Math.max(1, performance.now() - gesture.startedAt);
     const velocity = dx / elapsed;
-    const width = detailSwipeFrameRef.current?.clientWidth || window.innerWidth || 1;
+    const width =
+      detailSwipeFrameRef.current?.clientWidth || window.innerWidth || 1;
     const threshold = Math.min(140, width * 0.22);
     if ((dx > threshold || (dx > 28 && velocity > 0.45)) && prevLoadedFile) {
       commitDetailSwipe(-1);
@@ -835,20 +938,28 @@ export function useFileDetailController(
       detailSwipeTimerRef.current = null;
       setDetailSwipeTransition(false);
     }, 220);
-  }, [clearDetailSwipeTimer, commitDetailSwipe, nextLoadedFile, prevLoadedFile]);
+  }, [
+    clearDetailSwipeTimer,
+    commitDetailSwipe,
+    nextLoadedFile,
+    prevLoadedFile
+  ]);
 
   // ---------------------------------------------------------------------------
   // openFile
   // ---------------------------------------------------------------------------
 
-  const openFile = useCallback((file: FileItem) => {
-    savedGalleryScrollRef.current = window.scrollY;
-    if (historyMode === 'browser' && !historyActiveRef.current) {
-      window.history.pushState({ detail: true }, '', window.location.href);
-      historyActiveRef.current = true;
-    }
-    setSelectedFile(file);
-  }, [historyMode]);
+  const openFile = useCallback(
+    (file: FileItem) => {
+      savedGalleryScrollRef.current = window.scrollY;
+      if (historyMode === 'browser' && !historyActiveRef.current) {
+        window.history.pushState({ detail: true }, '', window.location.href);
+        historyActiveRef.current = true;
+      }
+      setSelectedFile(file);
+    },
+    [historyMode]
+  );
 
   // ---------------------------------------------------------------------------
   // Handlers
@@ -861,10 +972,12 @@ export function useFileDetailController(
     try {
       const resp = await updateFileFavoriteMutation.mutateAsync({
         fileId: selectedFile.id,
-        favorite: nextFavorite,
+        favorite: nextFavorite
       });
       setSelectedFile((prev) =>
-        prev && prev.id === selectedFile.id ? { ...prev, isFavorite: resp.isFavorite } : prev,
+        prev && prev.id === selectedFile.id
+          ? { ...prev, isFavorite: resp.isFavorite }
+          : prev
       );
       setFavoriteState({ loading: false, error: null });
     } catch (err) {
@@ -878,9 +991,11 @@ export function useFileDetailController(
     const url = api.getFileContentUrl(selectedFile.id, { download: true });
     setShareState({ loading: true, error: null });
     try {
-      const blob = await api.getFileContentBlob(selectedFile.id, { download: true });
+      const blob = await api.getFileContentBlob(selectedFile.id, {
+        download: true
+      });
       const file = new File([blob], fileName, {
-        type: blob.type || guessMimeType(fileName, selectedFile.mediaType),
+        type: blob.type || guessMimeType(fileName, selectedFile.mediaType)
       });
       if (navigator.share) {
         try {
@@ -888,7 +1003,10 @@ export function useFileDetailController(
           setShareState({ loading: false, error: null });
           return;
         } catch (shareErr) {
-          if (shareErr instanceof DOMException && shareErr.name === 'AbortError') {
+          if (
+            shareErr instanceof DOMException &&
+            shareErr.name === 'AbortError'
+          ) {
             setShareState({ loading: false, error: null });
             return;
           }
@@ -912,12 +1030,12 @@ export function useFileDetailController(
     try {
       const results = await Promise.allSettled([
         api.runProvider(fileId, 'saucenao'),
-        api.runProvider(fileId, 'fluffle'),
+        api.runProvider(fileId, 'fluffle')
       ]);
       await loadProviders(fileId);
       await loadTags(fileId);
       const failure = results.find(
-        (r): r is PromiseRejectedResult => r.status === 'rejected',
+        (r): r is PromiseRejectedResult => r.status === 'rejected'
       );
       const error = failure
         ? failure.reason instanceof Error
@@ -952,7 +1070,7 @@ export function useFileDetailController(
       await addManualTagMutation.mutateAsync({
         fileId: selectedFile.id,
         tag: value,
-        category: manualTagCategory,
+        category: manualTagCategory
       });
       setManualTagInput('');
       await loadTags(selectedFile.id);
@@ -960,7 +1078,13 @@ export function useFileDetailController(
     } catch (err) {
       setTagState({ loading: false, error: (err as Error).message });
     }
-  }, [selectedFile, manualTagInput, manualTagCategory, addManualTagMutation, loadTags]);
+  }, [
+    selectedFile,
+    manualTagInput,
+    manualTagCategory,
+    addManualTagMutation,
+    loadTags
+  ]);
 
   const removeManualTag = useCallback(
     async (tag: string, category: string) => {
@@ -970,7 +1094,7 @@ export function useFileDetailController(
         await removeManualTagMutation.mutateAsync({
           fileId: selectedFile.id,
           tag,
-          category,
+          category
         });
         await loadTags(selectedFile.id);
         setTagState({ loading: false, error: null });
@@ -978,7 +1102,7 @@ export function useFileDetailController(
         setTagState({ loading: false, error: (err as Error).message });
       }
     },
-    [selectedFile, removeManualTagMutation, loadTags],
+    [selectedFile, removeManualTagMutation, loadTags]
   );
 
   const removeTopMatch = useCallback(
@@ -988,7 +1112,7 @@ export function useFileDetailController(
       try {
         const resp = await removeTopMatchMutation.mutateAsync({
           fileId: selectedFile.id,
-          sourceUrl,
+          sourceUrl
         });
         setProviderInfo(resp.providers);
         setFileTags(resp.tags);
@@ -998,33 +1122,30 @@ export function useFileDetailController(
         setMatchRemoveState({ loading: false, error: (err as Error).message });
       }
     },
-    [selectedFile, removeTopMatchMutation],
+    [selectedFile, removeTopMatchMutation]
   );
 
   // ---------------------------------------------------------------------------
   // renderFileMedia helper
   // ---------------------------------------------------------------------------
 
-  const renderFileMedia = useCallback(
-    (file: FileItem): React.ReactNode => {
-      if (file.mediaType === 'VIDEO') {
-        return React.createElement('video', {
-          src: `${API_BASE}/files/${file.id}/content`,
-          controls: true,
-          loop: true,
-          playsInline: true,
-          preload: 'metadata',
-          className: 'file-detail-media',
-        });
-      }
-      return React.createElement('img', {
+  const renderFileMedia = useCallback((file: FileItem): ReactNode => {
+    if (file.mediaType === 'VIDEO') {
+      return createElement('video', {
         src: `${API_BASE}/files/${file.id}/content`,
-        alt: file.path,
-        className: 'file-detail-media',
+        controls: true,
+        loop: true,
+        playsInline: true,
+        preload: 'metadata',
+        className: 'file-detail-media'
       });
-    },
-    [],
-  );
+    }
+    return createElement('img', {
+      src: `${API_BASE}/files/${file.id}/content`,
+      alt: file.path,
+      className: 'file-detail-media'
+    });
+  }, []);
 
   // ---------------------------------------------------------------------------
   // Assemble panelProps — must match FileDetailPanel.Props exactly
@@ -1035,7 +1156,7 @@ export function useFileDetailController(
     // (App.tsx only mounts it when selectedFile truthy), but the type
     // requires FileItem (not null). Use a fallback object to satisfy TS
     // without casting; App.tsx must guard before spreading.
-    const file = selectedFile!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    const file = selectedFile!;
 
     return {
       selectedFile: file,
@@ -1073,7 +1194,8 @@ export function useFileDetailController(
       onManualTagInputChange: (value: string) => setManualTagInput(value),
       onManualTagCategoryChange: (value: string) => setManualTagCategory(value),
       onAddManualTag: () => void addManualTag(),
-      onRemoveManualTag: (tag: string, category: string) => void removeManualTag(tag, category),
+      onRemoveManualTag: (tag: string, category: string) =>
+        void removeManualTag(tag, category),
       onRefreshTags: () => void refreshTags(),
 
       providerHighlights,
@@ -1089,7 +1211,7 @@ export function useFileDetailController(
       onClose: closeFile,
       onGoRelative: (delta: number) => gallery.goRelative(delta),
 
-      renderFileMedia,
+      renderFileMedia
     };
   }, [
     selectedFile,
@@ -1131,13 +1253,13 @@ export function useFileDetailController(
     onDeleteFile,
     closeFile,
     gallery,
-    renderFileMedia,
+    renderFileMedia
   ]);
 
   return {
     selectedFile,
     openFile,
     closeFile,
-    panelProps,
+    panelProps
   };
 }

--- a/frontend/src/features/folders/useFoldersController.ts
+++ b/frontend/src/features/folders/useFoldersController.ts
@@ -15,18 +15,20 @@
  *   `folders` array returned here.
  */
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import type {
+  FolderDescriptor,
+  FoldersListPanelProps
+} from './FoldersListPanel';
 
 import type { AuthUser, Folder } from '@/api';
-import { useDeleteFolder, useFolders, useUploadFolderFiles } from '@/hooks/folders';
+import {
+  useDeleteFolder,
+  useFolders,
+  useUploadFolderFiles
+} from '@/hooks/folders';
 import { basenameFromPath } from '@/lib/format';
-import type { FolderDescriptor, FoldersListPanelProps } from './FoldersListPanel';
 
 // ---------------------------------------------------------------------------
 // Local types re-exported so callers don't need to dig into the panel file
@@ -34,7 +36,12 @@ import type { FolderDescriptor, FoldersListPanelProps } from './FoldersListPanel
 
 type FetchState = { loading: boolean; error: string | null };
 
-type FolderUploadPhase = 'uploading' | 'processing' | 'success' | 'warning' | 'error';
+type FolderUploadPhase =
+  | 'uploading'
+  | 'processing'
+  | 'success'
+  | 'warning'
+  | 'error';
 
 type FolderUploadState = {
   phase: FolderUploadPhase;
@@ -59,7 +66,10 @@ const normalizeComparablePath = (value: string): string => {
   return normalized;
 };
 
-const getRelativeFolderPath = (folderPath: string, libraryRoot: string): string | null => {
+const getRelativeFolderPath = (
+  folderPath: string,
+  libraryRoot: string
+): string | null => {
   const normalizedFolder = normalizeComparablePath(folderPath);
   const normalizedRoot = normalizeComparablePath(libraryRoot);
   if (normalizedFolder === normalizedRoot) return '';
@@ -67,7 +77,10 @@ const getRelativeFolderPath = (folderPath: string, libraryRoot: string): string 
   return normalizedFolder.slice(normalizedRoot.length + 1);
 };
 
-export const describeFolder = (folder: Folder, libraryRoot: string): FolderDescriptor => {
+export const describeFolder = (
+  folder: Folder,
+  libraryRoot: string
+): FolderDescriptor => {
   const relativePath = getRelativeFolderPath(folder.path, libraryRoot);
   const isDirectChild = Boolean(relativePath && !relativePath.includes('/'));
   if (relativePath === '') {
@@ -77,7 +90,7 @@ export const describeFolder = (folder: Folder, libraryRoot: string): FolderDescr
       title: 'Main library',
       subtitle: 'Default gooncave-library folder',
       pathLabel: folder.path,
-      filterLabel: 'Main library',
+      filterLabel: 'Main library'
     };
   }
   const title = basenameFromPath(relativePath || folder.path) || folder.path;
@@ -91,7 +104,7 @@ export const describeFolder = (folder: Folder, libraryRoot: string): FolderDescr
         : `Mounted folder: ${relativePath}`
       : 'Mounted folder',
     pathLabel: folder.path,
-    filterLabel: relativePath || title,
+    filterLabel: relativePath || title
   };
 };
 
@@ -133,7 +146,9 @@ export type FoldersControllerOutput = {
 // Hook
 // ---------------------------------------------------------------------------
 
-export function useFoldersController(input: FoldersControllerInput): FoldersControllerOutput {
+export function useFoldersController(
+  input: FoldersControllerInput
+): FoldersControllerOutput {
   const {
     authUser,
     libraryRoot,
@@ -142,7 +157,7 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
     onUpdateFavoritesRoot,
     uploadInputAccept,
     onUploadComplete,
-    onScanFinished,
+    onScanFinished
   } = input;
 
   // ----- TanStack queries / mutations -----
@@ -150,14 +165,16 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
   const deleteFolderMutation = useDeleteFolder();
   const uploadFolderFilesMutation = useUploadFolderFiles();
 
-  const folders = foldersQuery.data ?? [];
+  const folders = useMemo(() => foldersQuery.data ?? [], [foldersQuery.data]);
 
   // ----- State -----
   const [folderActionState, setFolderActionState] = useState<FetchState>({
     loading: false,
-    error: null,
+    error: null
   });
-  const [folderUploads, setFolderUploads] = useState<Record<string, FolderUploadState>>({});
+  const [folderUploads, setFolderUploads] = useState<
+    Record<string, FolderUploadState>
+  >({});
 
   // ----- Refs -----
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
@@ -173,7 +190,7 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
   // ----- Derived -----
   const folderMap = useMemo(
     () => new Map(folders.map((folder) => [folder.id, folder])),
-    [folders],
+    [folders]
   );
 
   const folderDetailsById = useMemo<Map<string, FolderDescriptor>>(() => {
@@ -222,7 +239,7 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
         delete folderUploadHideTimersRef.current[folderId];
       }, FOLDER_UPLOAD_RESULT_VISIBILITY_MS);
     },
-    [clearFolderUploadHideTimer],
+    [clearFolderUploadHideTimer]
   );
 
   // ----- refreshFolders -----
@@ -239,7 +256,7 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
         }
       }
     },
-    [foldersQuery],
+    [foldersQuery]
   );
 
   // ----- Handlers -----
@@ -248,12 +265,19 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
     async (folder: Folder, files: File[]) => {
       if (!files.length) return;
       const uploadMessage =
-        files.length === 1 ? `Uploading ${files[0].name}` : `Uploading ${files.length} files`;
+        files.length === 1
+          ? `Uploading ${files[0].name}`
+          : `Uploading ${files.length} files`;
 
       clearFolderUploadHideTimer(folder.id);
       setFolderUploads((prev) => ({
         ...prev,
-        [folder.id]: { phase: 'uploading', progress: 0, message: uploadMessage, detail: null },
+        [folder.id]: {
+          phase: 'uploading',
+          progress: 0,
+          message: uploadMessage,
+          detail: null
+        }
       }));
 
       try {
@@ -267,10 +291,10 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
                 phase: 'uploading',
                 progress: percent,
                 message: uploadMessage,
-                detail: null,
-              },
+                detail: null
+              }
             }));
-          },
+          }
         });
 
         setFolderUploads((prev) => ({
@@ -279,8 +303,8 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
             phase: 'processing',
             progress: 100,
             message: 'Processing uploaded files…',
-            detail: null,
-          },
+            detail: null
+          }
         }));
 
         // Notify caller (App.tsx) to clear gallery cache and reload if needed.
@@ -291,7 +315,9 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
         const uploadedCount = result.uploaded.length;
         const rejectedCount = result.rejected.length;
         const rejectedDetail = rejectedCount
-          ? result.rejected.map((entry) => `${entry.name}: ${entry.reason ?? 'Skipped'}`).join(' | ')
+          ? result.rejected
+              .map((entry) => `${entry.name}: ${entry.reason ?? 'Skipped'}`)
+              .join(' | ')
           : null;
 
         let phase: FolderUploadPhase = 'success';
@@ -306,7 +332,7 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
 
         setFolderUploads((prev) => ({
           ...prev,
-          [folder.id]: { phase, progress: 100, message, detail: rejectedDetail },
+          [folder.id]: { phase, progress: 100, message, detail: rejectedDetail }
         }));
         scheduleFolderUploadHide(folder.id);
       } catch (err) {
@@ -316,8 +342,8 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
             phase: 'error',
             progress: 0,
             message: 'Upload failed.',
-            detail: (err as Error).message,
-          },
+            detail: (err as Error).message
+          }
         }));
         scheduleFolderUploadHide(folder.id);
       }
@@ -327,8 +353,8 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
       onUploadComplete,
       refreshFolders,
       scheduleFolderUploadHide,
-      uploadFolderFilesMutation,
-    ],
+      uploadFolderFilesMutation
+    ]
   );
 
   const onFolderUploadInputChange = useCallback(
@@ -342,7 +368,7 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
       if (!folder) return;
       await uploadFilesToFolder(folder, files);
     },
-    [folderMap, uploadFilesToFolder],
+    [folderMap, uploadFilesToFolder]
   );
 
   const openFolderUploadPicker = useCallback(
@@ -360,12 +386,13 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
       input.value = '';
       input.click();
     },
-    [folderActionState.loading, folderUploads],
+    [folderActionState.loading, folderUploads]
   );
 
   const onDeleteFolder = useCallback(
     async (folder: Folder) => {
-      if (!window.confirm(`Remove "${folder.path}" from the watch list?`)) return;
+      if (!window.confirm(`Remove "${folder.path}" from the watch list?`))
+        return;
       setFolderActionState({ loading: true, error: null });
       try {
         await deleteFolderMutation.mutateAsync(folder.id);
@@ -374,7 +401,7 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
         setFolderActionState({ loading: false, error: (err as Error).message });
       }
     },
-    [deleteFolderMutation],
+    [deleteFolderMutation]
   );
 
   // ----- Effects -----
@@ -383,7 +410,7 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
   useEffect(() => {
     return () => {
       Object.values(folderUploadHideTimersRef.current).forEach((timer) =>
-        window.clearTimeout(timer),
+        window.clearTimeout(timer)
       );
       folderUploadHideTimersRef.current = {};
     };
@@ -440,7 +467,7 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
     onOpenFolderUploadPicker: openFolderUploadPicker,
     onUpdateFavoritesRoot,
     onDeleteFolder,
-    describeFolder,
+    describeFolder
   };
 
   return {
@@ -448,6 +475,6 @@ export function useFoldersController(input: FoldersControllerInput): FoldersCont
     orderedFolders,
     folderDetailsById,
     panelProps,
-    refreshFolders,
+    refreshFolders
   };
 }

--- a/frontend/src/features/library/useGalleryController.ts
+++ b/frontend/src/features/library/useGalleryController.ts
@@ -1,15 +1,15 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import type {
+  FetchState,
+  FolderDetail,
+  GallerySort,
+  GalleryViewProps
+} from './GalleryView';
 
 import { api, type AuthUser, type FileItem, type Folder } from '@/api';
 import { useUpdateManualOrder } from '@/hooks/files';
 import { makeRandomSeed, useGalleryUiStore } from '@/stores/galleryUiStore';
-import type { FetchState, FolderDetail, GallerySort, GalleryViewProps } from './GalleryView';
 
 // ---------------------------------------------------------------------------
 // Constants & helpers (verbatim from App.tsx)
@@ -29,7 +29,7 @@ const buildGalleryCacheKey = ({
   sort,
   tagQuery,
   randomSeed,
-  filterKey,
+  filterKey
 }: GalleryCacheKeyOptions): string => {
   const folderKey = folderId || 'all';
   return sort === 'random'
@@ -131,7 +131,7 @@ export function useGalleryController(
     orderedFolders,
     folderDetailsById,
     isActive,
-    onRefreshAfterOrderFailure,
+    onRefreshAfterOrderFailure
   } = input;
 
   const updateManualOrderMutation = useUpdateManualOrder();
@@ -146,28 +146,44 @@ export function useGalleryController(
   const [galleryHasMore, setGalleryHasMore] = useState(false);
   const [galleryPageState, setGalleryPageState] = useState<FetchState>({
     loading: false,
-    error: null,
+    error: null
   });
   const [manualOrderState, setManualOrderState] = useState<FetchState>({
     loading: false,
-    error: null,
+    error: null
   });
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dragOverId, setDragOverId] = useState<string | null>(null);
   const galleryFolderId = useGalleryUiStore((state) => state.galleryFolderId);
   const gallerySort = useGalleryUiStore((state) => state.gallerySort);
   const galleryFilters = useGalleryUiStore((state) => state.galleryFilters);
-  const isGalleryFilterOpen = useGalleryUiStore((state) => state.isGalleryFilterOpen);
-  const galleryRandomSeed = useGalleryUiStore((state) => state.galleryRandomSeed);
+  const isGalleryFilterOpen = useGalleryUiStore(
+    (state) => state.isGalleryFilterOpen
+  );
+  const galleryRandomSeed = useGalleryUiStore(
+    (state) => state.galleryRandomSeed
+  );
   const galleryTagInput = useGalleryUiStore((state) => state.galleryTagInput);
   const galleryTagQuery = useGalleryUiStore((state) => state.galleryTagQuery);
-  const setGalleryFolderId = useGalleryUiStore((state) => state.setGalleryFolderId);
+  const setGalleryFolderId = useGalleryUiStore(
+    (state) => state.setGalleryFolderId
+  );
   const setGallerySort = useGalleryUiStore((state) => state.setGallerySort);
-  const setGalleryFilters = useGalleryUiStore((state) => state.setGalleryFilters);
-  const setIsGalleryFilterOpen = useGalleryUiStore((state) => state.setIsGalleryFilterOpen);
-  const setGalleryRandomSeed = useGalleryUiStore((state) => state.setGalleryRandomSeed);
-  const setGalleryTagInput = useGalleryUiStore((state) => state.setGalleryTagInput);
-  const setGalleryTagQuery = useGalleryUiStore((state) => state.setGalleryTagQuery);
+  const setGalleryFilters = useGalleryUiStore(
+    (state) => state.setGalleryFilters
+  );
+  const setIsGalleryFilterOpen = useGalleryUiStore(
+    (state) => state.setIsGalleryFilterOpen
+  );
+  const setGalleryRandomSeed = useGalleryUiStore(
+    (state) => state.setGalleryRandomSeed
+  );
+  const setGalleryTagInput = useGalleryUiStore(
+    (state) => state.setGalleryTagInput
+  );
+  const setGalleryTagQuery = useGalleryUiStore(
+    (state) => state.setGalleryTagQuery
+  );
 
   // -------------------------------------------------------------------------
   // Refs
@@ -175,7 +191,10 @@ export function useGalleryController(
 
   /** Hand-rolled LRU-style page cache keyed by buildGalleryCacheKey */
   const galleryCacheRef = useRef<
-    Map<string, { files: FileItem[]; total: number; offset: number; hasMore: boolean }>
+    Map<
+      string,
+      { files: FileItem[]; total: number; offset: number; hasMore: boolean }
+    >
   >(new Map());
 
   /** Stable closure refs for loadGalleryPage (avoids stale closures) */
@@ -273,7 +292,7 @@ export function useGalleryController(
         sort: gallerySort,
         tagQuery: galleryTagQuery,
         randomSeed: galleryRandomSeed,
-        filterKey,
+        filterKey
       });
       const cached = allowCache ? galleryCacheRef.current.get(cacheKey) : null;
       if (options.reset && cached) {
@@ -298,9 +317,10 @@ export function useGalleryController(
             limit,
             offset,
             seed: isRandom ? galleryRandomSeed : undefined,
-            mediaType: galleryMediaFilter === 'ALL' ? undefined : galleryMediaFilter,
+            mediaType:
+              galleryMediaFilter === 'ALL' ? undefined : galleryMediaFilter,
             favoritesOnly: galleryFavoritesOnly ? true : undefined,
-            signal: controller.signal,
+            signal: controller.signal
           }
         );
         if (requestId !== galleryRequestRef.current.id) return;
@@ -326,7 +346,7 @@ export function useGalleryController(
             files: updatedFiles,
             total,
             offset: nextOffset,
-            hasMore: shouldPaginate ? nextOffset < total : false,
+            hasMore: shouldPaginate ? nextOffset < total : false
           });
         }
         setGalleryPageState({ loading: false, error: null });
@@ -338,7 +358,7 @@ export function useGalleryController(
         }
         setGalleryPageState({
           loading: false,
-          error: (err as Error).message,
+          error: (err as Error).message
         });
       } finally {
         if (requestId === galleryRequestRef.current.id) {
@@ -346,8 +366,15 @@ export function useGalleryController(
         }
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- GALLERY_PAGE_SIZE is a module constant
-    [galleryFavoritesOnly, galleryFolderId, galleryMediaFilter, galleryRandomSeed, gallerySort, galleryTagQuery]
+
+    [
+      galleryFavoritesOnly,
+      galleryFolderId,
+      galleryMediaFilter,
+      galleryRandomSeed,
+      gallerySort,
+      galleryTagQuery
+    ]
   );
 
   // -------------------------------------------------------------------------
@@ -361,7 +388,7 @@ export function useGalleryController(
       setGalleryTagQuery(galleryTagInput.trim());
     }, 300);
     return () => window.clearTimeout(handle);
-  }, [galleryTagInput]);
+  }, [galleryTagInput, setGalleryTagQuery]);
 
   // Click-outside / Escape to close filter popover
   useEffect(() => {
@@ -382,14 +409,14 @@ export function useGalleryController(
       document.removeEventListener('pointerdown', handlePointerDown, true);
       window.removeEventListener('keydown', handleKey);
     };
-  }, [isGalleryFilterOpen]);
+  }, [isGalleryFilterOpen, setIsGalleryFilterOpen]);
 
   // Clear folder selection when the folder is removed (verbatim)
   useEffect(() => {
     if (galleryFolderId && !folderMap.has(galleryFolderId)) {
       setGalleryFolderId('');
     }
-  }, [folderMap, galleryFolderId]);
+  }, [folderMap, galleryFolderId, setGalleryFolderId]);
 
   // Refetch on gallery params change — only when gallery is active (verbatim logic)
   useEffect(() => {
@@ -402,7 +429,7 @@ export function useGalleryController(
       sort: gallerySort,
       tagQuery: galleryTagQuery,
       randomSeed: galleryRandomSeed,
-      filterKey,
+      filterKey
     });
     const cached = isRandom ? null : galleryCacheRef.current.get(cacheKey);
     if (cached) {
@@ -426,7 +453,7 @@ export function useGalleryController(
     galleryRandomSeed,
     gallerySort,
     galleryTagQuery,
-    loadGalleryPage,
+    loadGalleryPage
   ]);
 
   // Persist sort to localStorage (verbatim via applyGallerySort below)
@@ -455,23 +482,28 @@ export function useGalleryController(
   // -------------------------------------------------------------------------
 
   /** Apply a new sort, generate a fresh random seed if needed, persist to localStorage */
-  const applyGallerySort = useCallback((sort: GallerySort) => {
-    if (sort === 'random') {
-      setGalleryRandomSeed(makeRandomSeed());
-    }
-    setGallerySort(sort);
-  }, [setGalleryRandomSeed, setGallerySort]);
+  const applyGallerySort = useCallback(
+    (sort: GallerySort) => {
+      if (sort === 'random') {
+        setGalleryRandomSeed(makeRandomSeed());
+      }
+      setGallerySort(sort);
+    },
+    [setGalleryRandomSeed, setGallerySort]
+  );
 
   const saveManualOrder = useCallback(
     async (next: FileItem[]) => {
       setManualOrderState({ loading: true, error: null });
       try {
-        await updateManualOrderMutation.mutateAsync(next.map((file) => file.id));
+        await updateManualOrderMutation.mutateAsync(
+          next.map((file) => file.id)
+        );
         setManualOrderState({ loading: false, error: null });
       } catch (err) {
         setManualOrderState({
           loading: false,
-          error: (err as Error).message,
+          error: (err as Error).message
         });
         onRefreshAfterOrderFailure?.();
       }
@@ -523,7 +555,7 @@ export function useGalleryController(
         sort: gallerySort,
         tagQuery: galleryTagQuery,
         randomSeed: galleryRandomSeed,
-        filterKey,
+        filterKey
       });
       const removeFromFavoritesView =
         galleryFavoritesOnly &&
@@ -543,9 +575,7 @@ export function useGalleryController(
         setGalleryOffset((prev) => Math.max(0, prev - 1));
       }
       const cached =
-        gallerySort !== 'random'
-          ? galleryCacheRef.current.get(cacheKey)
-          : null;
+        gallerySort !== 'random' ? galleryCacheRef.current.get(cacheKey) : null;
       if (cached) {
         const existedInCache = cached.files.some((file) => file.id === fileId);
         let nextFiles = cached.files.map((file) =>
@@ -567,11 +597,18 @@ export function useGalleryController(
           files: nextFiles,
           total: nextTotal,
           offset: nextOffset,
-          hasMore: nextHasMore,
+          hasMore: nextHasMore
         });
       }
     },
-    [galleryFavoritesOnly, galleryFolderId, galleryMediaFilter, galleryRandomSeed, gallerySort, galleryTagQuery]
+    [
+      galleryFavoritesOnly,
+      galleryFolderId,
+      galleryMediaFilter,
+      galleryRandomSeed,
+      gallerySort,
+      galleryTagQuery
+    ]
   );
 
   /** Remove a file from the gallery list and update the cache after delete */
@@ -586,12 +623,10 @@ export function useGalleryController(
         sort: gallerySort,
         tagQuery: galleryTagQuery,
         randomSeed: galleryRandomSeed,
-        filterKey,
+        filterKey
       });
       const cached =
-        gallerySort !== 'random'
-          ? galleryCacheRef.current.get(cacheKey)
-          : null;
+        gallerySort !== 'random' ? galleryCacheRef.current.get(cacheKey) : null;
       if (cached) {
         const nextFiles = cached.files.filter((file) => file.id !== fileId);
         const nextTotal = cached.total > 0 ? cached.total - 1 : 0;
@@ -601,11 +636,18 @@ export function useGalleryController(
           files: nextFiles,
           total: nextTotal,
           offset: nextOffset,
-          hasMore: nextHasMore,
+          hasMore: nextHasMore
         });
       }
     },
-    [galleryFavoritesOnly, galleryFolderId, galleryMediaFilter, galleryRandomSeed, gallerySort, galleryTagQuery]
+    [
+      galleryFavoritesOnly,
+      galleryFolderId,
+      galleryMediaFilter,
+      galleryRandomSeed,
+      gallerySort,
+      galleryTagQuery
+    ]
   );
 
   const openFile = useCallback(() => {
@@ -625,8 +667,7 @@ export function useGalleryController(
   }, [loadGalleryPage]);
 
   const selectedFileIndex = useCallback(
-    (id: string) =>
-      galleryFilesRef.current.findIndex((file) => file.id === id),
+    (id: string) => galleryFilesRef.current.findIndex((file) => file.id === id),
     []
   );
 
@@ -668,7 +709,7 @@ export function useGalleryController(
     onLoadMore: () => void loadGalleryPage(),
     onMoveManualItem: moveManualItem,
     onDraggingChange: setDraggingId,
-    onDragOverChange: setDragOverId,
+    onDragOverChange: setDragOverId
   };
 
   return {
@@ -683,6 +724,6 @@ export function useGalleryController(
     updateFavoriteFlag,
     removeFileFromGallery,
     manualOrderState,
-    savedGalleryScrollRef,
+    savedGalleryScrollRef
   };
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,9 @@
 import './index.css';
 import './app.css';
-import React from 'react';
-import { createRoot } from 'react-dom/client';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
 
 import App from './App';
 import { createQueryClient } from './lib/query-client';
@@ -21,7 +21,9 @@ root.render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <App />
-      {import.meta.env.DEV ? <ReactQueryDevtools buttonPosition="bottom-left" /> : null}
+      {import.meta.env.DEV ? (
+        <ReactQueryDevtools buttonPosition="bottom-left" />
+      ) : null}
     </QueryClientProvider>
   </React.StrictMode>
 );

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,8 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
-import tailwindcss from '@tailwindcss/vite';
 import path from 'node:path';
+
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],


### PR DESCRIPTION
## Summary

Follow-up to the #103 modernization chain, which intentionally kept lint churn out of its PRs. Clears the frontend ESLint debt and normalizes the lint scripts.

- **Lint scripts** (`frontend/package.json`, `backend/package.json`): drop the legacy `--ext` flag. The flat config (`eslint.config.cjs`) already scopes target files, so `--ext` was redundant. Kept explicit paths (`eslint src vite.config.ts` / `eslint src test`) to preserve the exact source-only scope — `eslint .` would broaden linting to tooling files (config/scripts), out of scope here.
- **Auto-fixable (46)**: `import-x/order` reordering + group spacing via `eslint --fix`. Pure import reshuffles, no behavior change.
- **Manual (14)**, reviewed for behavior:
  - `useFoldersController`: `folders` wrapped in `useMemo` so the `?? []` fallback stops minting a fresh array each render (was destabilizing 5 hook dep arrays).
  - Stable zustand setters added to dep arrays in duplicates/gallery controllers (no-op at runtime — store actions have stable identity).
  - `useFileDetailController`: effect captures `const fileId = selectedFile?.id` so it keeps depending on the id, not the object reference (adding the full object would have changed behavior). `React.createElement` → named `createElement` import.
  - Removed unused `DuplicateScanOptions` type import.

A pre-commit prettier hook also reformatted touched files (trailing-comma style).

## Why

Old majors of the lint scripts used eslintrc-era `--ext` flags that no longer fit flat-config ESLint; the 60 warnings were deferred debt from #103. This makes `bun run lint` clean locally and in CI.

## Out of scope

- No behavior refactor beyond what each hook warning needs.
- Pre-existing `tsc` `baseUrl` deprecation in `frontend/tsconfig.json` left untouched.

## Test plan

- [x] `frontend: bun run lint` → 0 warnings, 0 errors
- [x] `backend: bun run lint` → 0 warnings, 0 errors
- [x] `frontend: bun run build` → green
- [x] `frontend: bun run test` → 27/27 passed

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)