### PR TITLE
fix: remediate open CodeQL alerts

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -126,16 +126,18 @@ export const createServer = (options?: { frontendDir?: string | null }) => {
     app.get('/', async (_request, reply) => reply.sendFile('index.html'));
   }
 
-  registerHealthRoutes(app);
-  registerAuthRoutes(app);
-  registerAdminRoutes(app);
-  registerFolderRoutes(app);
-  registerFilesRoutes(app);
-  registerSauceRoutes(app);
-  registerDuplicateRoutes(app);
-  registerFavoritesRoutes(app);
-  registerCredentialRoutes(app);
-  registerBooruSiteRoutes(app);
+  app.after(() => {
+    registerHealthRoutes(app);
+    registerAuthRoutes(app);
+    registerAdminRoutes(app);
+    registerFolderRoutes(app);
+    registerFilesRoutes(app);
+    registerSauceRoutes(app);
+    registerDuplicateRoutes(app);
+    registerFavoritesRoutes(app);
+    registerCredentialRoutes(app);
+    registerBooruSiteRoutes(app);
+  });
 
   if (frontendRoot && fs.existsSync(frontendRoot)) {
     app.setNotFoundHandler(async (request, reply) => {

--- a/backend/src/lib/fsAccess.ts
+++ b/backend/src/lib/fsAccess.ts
@@ -5,8 +5,10 @@ const writeErrorCodes = new Set(['EACCES', 'EPERM', 'EROFS']);
 
 const describeRuntimeIdentity = () => {
   const parts: string[] = [];
-  if (typeof process.getuid === 'function') parts.push(`uid ${process.getuid()}`);
-  if (typeof process.getgid === 'function') parts.push(`gid ${process.getgid()}`);
+  if (typeof process.getuid === 'function')
+    parts.push(`uid ${process.getuid()}`);
+  if (typeof process.getgid === 'function')
+    parts.push(`gid ${process.getgid()}`);
   return parts.length ? ` (${parts.join(', ')})` : '';
 };
 
@@ -23,19 +25,30 @@ export class DirectoryWriteAccessError extends Error {
   }
 }
 
-export const ensureDirectoryWritable = async (dirPath: string, operation: string) => {
+export const ensureDirectoryWritable = async (
+  dirPath: string,
+  operation: string
+) => {
   await fs.promises.mkdir(dirPath, { recursive: true });
-  const probePath = path.join(
-    dirPath,
-    `.gooncave-write-test-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
-  );
+  let probeDir: string | null = null;
+  let probePath: string | null = null;
 
   try {
+    probeDir = await fs.promises.mkdtemp(
+      path.join(dirPath, '.gooncave-write-test-')
+    );
+    probePath = path.join(probeDir, 'probe');
     const handle = await fs.promises.open(probePath, 'wx');
     await handle.close();
     await fs.promises.unlink(probePath);
+    await fs.promises.rmdir(probeDir);
   } catch (error) {
-    await fs.promises.unlink(probePath).catch(() => undefined);
+    if (probePath) {
+      await fs.promises.unlink(probePath).catch(() => undefined);
+    }
+    if (probeDir) {
+      await fs.promises.rmdir(probeDir).catch(() => undefined);
+    }
     const err = error as NodeJS.ErrnoException;
     if (err.code && writeErrorCodes.has(err.code)) {
       throw new DirectoryWriteAccessError(dirPath, operation, err.code);

--- a/backend/src/lib/scanner.test.ts
+++ b/backend/src/lib/scanner.test.ts
@@ -8,13 +8,26 @@ import { test } from 'node:test';
 import os from 'os';
 import path from 'path';
 
-import { detectMediaKind, iterateLocalMediaPaths, listLocalMediaPaths } from './scanner';
+import {
+  detectMediaKind,
+  iterateLocalMediaPaths,
+  listLocalMediaPaths
+} from './scanner';
 
 const tmpRoot = process.env.GOONCAVE_TEST_TMP_ROOT ?? os.tmpdir();
-const makeFixtureDir = (label: string) => path.join(tmpRoot, `scanner-${label}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+const makeFixtureDir = async (label: string) =>
+  fs.promises.mkdtemp(path.join(tmpRoot, `scanner-${label}-`));
 
 test('detectMediaKind returns IMAGE for common image extensions', () => {
-  for (const name of ['photo.jpg', 'banner.JPEG', 'art.png', 'animation.gif', 'shot.webp', 'sample.bmp', 'next-gen.avif']) {
+  for (const name of [
+    'photo.jpg',
+    'banner.JPEG',
+    'art.png',
+    'animation.gif',
+    'shot.webp',
+    'sample.bmp',
+    'next-gen.avif'
+  ]) {
     assert.equal(detectMediaKind(name), 'IMAGE', `expected IMAGE for ${name}`);
   }
 });
@@ -36,15 +49,13 @@ test('detectMediaKind handles absolute paths', () => {
 });
 
 test('listLocalMediaPaths returns an empty array for an empty directory', async () => {
-  const dir = makeFixtureDir('empty');
-  await fs.promises.mkdir(dir, { recursive: true });
+  const dir = await makeFixtureDir('empty');
   const result = await listLocalMediaPaths(dir);
   assert.deepEqual(result, []);
 });
 
 test('listLocalMediaPaths skips non-media files', async () => {
-  const dir = makeFixtureDir('mixed');
-  await fs.promises.mkdir(dir, { recursive: true });
+  const dir = await makeFixtureDir('mixed');
   await fs.promises.writeFile(path.join(dir, 'note.txt'), 'x');
   await fs.promises.writeFile(path.join(dir, 'pic.png'), Buffer.from([0]));
   await fs.promises.writeFile(path.join(dir, 'clip.mp4'), Buffer.from([0]));
@@ -55,37 +66,45 @@ test('listLocalMediaPaths skips non-media files', async () => {
 });
 
 test('listLocalMediaPaths recurses into nested directories', async () => {
-  const dir = makeFixtureDir('nested');
+  const dir = await makeFixtureDir('nested');
   await fs.promises.mkdir(path.join(dir, 'a', 'b'), { recursive: true });
   await fs.promises.writeFile(path.join(dir, 'top.png'), Buffer.from([0]));
   await fs.promises.writeFile(path.join(dir, 'a', 'mid.jpg'), Buffer.from([0]));
-  await fs.promises.writeFile(path.join(dir, 'a', 'b', 'leaf.webp'), Buffer.from([0]));
+  await fs.promises.writeFile(
+    path.join(dir, 'a', 'b', 'leaf.webp'),
+    Buffer.from([0])
+  );
   const result = await listLocalMediaPaths(dir);
   assert.equal(result.length, 3);
 });
 
 test('iterateLocalMediaPaths honors a shouldStop signal', async () => {
-  const dir = makeFixtureDir('stop');
-  await fs.promises.mkdir(dir, { recursive: true });
+  const dir = await makeFixtureDir('stop');
   for (let i = 0; i < 5; i++) {
-    await fs.promises.writeFile(path.join(dir, `img-${i}.png`), Buffer.from([0]));
+    await fs.promises.writeFile(
+      path.join(dir, `img-${i}.png`),
+      Buffer.from([0])
+    );
   }
   let stop = false;
   const seen: string[] = [];
-  for await (const filePath of iterateLocalMediaPaths(dir, { shouldStop: () => stop })) {
+  for await (const filePath of iterateLocalMediaPaths(dir, {
+    shouldStop: () => stop
+  })) {
     seen.push(filePath);
     if (seen.length === 2) stop = true;
   }
   // After we flipped stop, the iterator may yield the file already pulled
   // ahead, but it must not flush the whole 5-file batch.
-  assert.ok(seen.length >= 2 && seen.length < 5, `expected partial enumeration, got ${seen.length}`);
+  assert.ok(
+    seen.length >= 2 && seen.length < 5,
+    `expected partial enumeration, got ${seen.length}`
+  );
 });
 
 test('listLocalMediaPaths ignores symlinks-to-files outside the root', async () => {
-  const dir = makeFixtureDir('symlink');
-  const outside = makeFixtureDir('outside');
-  await fs.promises.mkdir(dir, { recursive: true });
-  await fs.promises.mkdir(outside, { recursive: true });
+  const dir = await makeFixtureDir('symlink');
+  const outside = await makeFixtureDir('outside');
   const realFile = path.join(outside, 'real.png');
   await fs.promises.writeFile(realFile, Buffer.from([0]));
   try {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -2,16 +2,39 @@ import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 
 import { authRepo } from '../db/repos/authRepo';
-import { clearSessionCookie, createSessionForUser, loginLocalUser, registerLocalUser, setSessionCookie, toPublicUser } from '../services/auth';
+import {
+  clearSessionCookie,
+  createSessionForUser,
+  loginLocalUser,
+  registerLocalUser,
+  setSessionCookie,
+  toPublicUser
+} from '../services/auth';
 
 const authSchema = z.object({
   username: z
     .string()
     .min(3, 'Username must be at least 3 characters')
     .max(32, 'Username must be at most 32 characters')
-    .regex(/^[a-zA-Z0-9_-]+$/, 'Username can only contain letters, numbers, _ and -'),
-  password: z.string().min(8, 'Password must be at least 8 characters').max(128, 'Password must be at most 128 characters')
+    .regex(
+      /^[a-zA-Z0-9_-]+$/,
+      'Username can only contain letters, numbers, _ and -'
+    ),
+  password: z
+    .string()
+    .min(8, 'Password must be at least 8 characters')
+    .max(128, 'Password must be at most 128 characters')
 });
+
+const authLoginRateLimit = {
+  max: 10,
+  timeWindow: '1 minute'
+};
+
+const authRegisterRateLimit = {
+  max: 5,
+  timeWindow: '1 minute'
+};
 
 export const registerAuthRoutes = (app: FastifyInstance) => {
   app.get('/auth/me', async (request, reply) => {
@@ -22,39 +45,61 @@ export const registerAuthRoutes = (app: FastifyInstance) => {
     return { user: toPublicUser(request.currentUser) };
   });
 
-  app.post('/auth/register', async (request, reply) => {
-    const parsed = authSchema.safeParse(request.body ?? {});
-    if (!parsed.success) {
-      reply.code(400);
-      return { error: 'Invalid payload', issues: parsed.error.issues };
+  app.post(
+    '/auth/register',
+    {
+      config: {
+        rateLimit: authRegisterRateLimit
+      }
+    },
+    async (request, reply) => {
+      const parsed = authSchema.safeParse(request.body ?? {});
+      if (!parsed.success) {
+        reply.code(400);
+        return { error: 'Invalid payload', issues: parsed.error.issues };
+      }
+      try {
+        const user = await registerLocalUser(
+          parsed.data.username,
+          parsed.data.password
+        );
+        const session = await createSessionForUser(user.id);
+        setSessionCookie(reply, session.token, session.expiresAt);
+        return { user: toPublicUser(user) };
+      } catch (err) {
+        reply.code(400);
+        return { error: (err as Error).message };
+      }
     }
-    try {
-      const user = await registerLocalUser(parsed.data.username, parsed.data.password);
-      const session = await createSessionForUser(user.id);
-      setSessionCookie(reply, session.token, session.expiresAt);
-      return { user: toPublicUser(user) };
-    } catch (err) {
-      reply.code(400);
-      return { error: (err as Error).message };
-    }
-  });
+  );
 
-  app.post('/auth/login', async (request, reply) => {
-    const parsed = authSchema.safeParse(request.body ?? {});
-    if (!parsed.success) {
-      reply.code(400);
-      return { error: 'Invalid payload', issues: parsed.error.issues };
+  app.post(
+    '/auth/login',
+    {
+      config: {
+        rateLimit: authLoginRateLimit
+      }
+    },
+    async (request, reply) => {
+      const parsed = authSchema.safeParse(request.body ?? {});
+      if (!parsed.success) {
+        reply.code(400);
+        return { error: 'Invalid payload', issues: parsed.error.issues };
+      }
+      try {
+        const user = await loginLocalUser(
+          parsed.data.username,
+          parsed.data.password
+        );
+        const session = await createSessionForUser(user.id);
+        setSessionCookie(reply, session.token, session.expiresAt);
+        return { user: toPublicUser(user) };
+      } catch (err) {
+        reply.code(401);
+        return { error: (err as Error).message };
+      }
     }
-    try {
-      const user = await loginLocalUser(parsed.data.username, parsed.data.password);
-      const session = await createSessionForUser(user.id);
-      setSessionCookie(reply, session.token, session.expiresAt);
-      return { user: toPublicUser(user) };
-    } catch (err) {
-      reply.code(401);
-      return { error: (err as Error).message };
-    }
-  });
+  );
 
   app.post('/auth/logout', async (request, reply) => {
     if (request.sessionToken) {

--- a/backend/src/routes/folders.ts
+++ b/backend/src/routes/folders.ts
@@ -9,13 +9,21 @@ import { z } from 'zod';
 import { config } from '../config';
 import { filesRepo } from '../db/repos/filesRepo';
 import { foldersRepo } from '../db/repos/foldersRepo';
-import { DirectoryWriteAccessError, ensureDirectoryWritable } from '../lib/fsAccess';
+import {
+  DirectoryWriteAccessError,
+  ensureDirectoryWritable
+} from '../lib/fsAccess';
 import { detectMediaKind, scanLocalFile } from '../lib/scanner';
 import { isPathInside, resolveUserManagedPath } from '../services/auth';
 
 const folderPayload = z.object({
   path: z.string().min(1, 'Path is required')
 });
+
+const folderUploadsRateLimit = {
+  max: 30,
+  timeWindow: '1 minute'
+};
 
 type UploadResultItem = {
   name: string;
@@ -56,22 +64,34 @@ const fileExists = async (filePath: string) => {
 
 const listDirectChildFolders = async (libraryRoot: string) => {
   await fs.promises.mkdir(libraryRoot, { recursive: true });
-  const entries = await fs.promises.readdir(libraryRoot, { withFileTypes: true });
+  const entries = await fs.promises.readdir(libraryRoot, {
+    withFileTypes: true
+  });
   return entries
     .filter((entry) => entry.isDirectory())
     .map((entry) => path.resolve(libraryRoot, entry.name));
 };
 
-const isDirectChildManagedFolder = (folderPath: string, libraryRoot: string) => {
-  const relative = path.relative(path.resolve(libraryRoot), path.resolve(folderPath));
-  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return false;
+const isDirectChildManagedFolder = (
+  folderPath: string,
+  libraryRoot: string
+) => {
+  const relative = path.relative(
+    path.resolve(libraryRoot),
+    path.resolve(folderPath)
+  );
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative))
+    return false;
   return relative.split(path.sep).filter(Boolean).length === 1;
 };
 
 const ensureManagedFolders = async (userId: string, libraryRoot: string) => {
   const resolvedRoot = path.resolve(libraryRoot);
   const childFolders = await listDirectChildFolders(resolvedRoot);
-  const managedPaths = new Set([resolvedRoot, ...childFolders.map((folderPath) => path.resolve(folderPath))]);
+  const managedPaths = new Set([
+    resolvedRoot,
+    ...childFolders.map((folderPath) => path.resolve(folderPath))
+  ]);
   await foldersRepo.ensureFolders([...managedPaths], userId);
 
   const existingFolders = await foldersRepo.listFolders(userId);
@@ -83,9 +103,15 @@ const ensureManagedFolders = async (userId: string, libraryRoot: string) => {
     await foldersRepo.deleteFolder(folder.id, userId);
   }
 
-  const rootFolder = existingFolders.find((folder) => path.resolve(folder.path) === resolvedRoot);
+  const rootFolder = existingFolders.find(
+    (folder) => path.resolve(folder.path) === resolvedRoot
+  );
   if (rootFolder && childFolders.length > 0) {
-    await foldersRepo.deleteFilesInFolderByPrefixes(rootFolder.id, childFolders, userId);
+    await foldersRepo.deleteFilesInFolderByPrefixes(
+      rootFolder.id,
+      childFolders,
+      userId
+    );
   }
 
   return foldersRepo.listFolders(userId);
@@ -110,7 +136,10 @@ export const registerFolderRoutes = (app: FastifyInstance) => {
     const user = request.currentUser!;
     let resolvedPath: string;
     try {
-      resolvedPath = await resolveUserManagedPath(user.libraryRoot, parsed.data.path);
+      resolvedPath = await resolveUserManagedPath(
+        user.libraryRoot,
+        parsed.data.path
+      );
     } catch (error) {
       // Match both "outside …" and "stay inside …" wording — the resolver
       // worded the message either way over time and the route must surface
@@ -134,109 +163,135 @@ export const registerFolderRoutes = (app: FastifyInstance) => {
     return { folder, status: 'created' };
   });
 
-  app.post<{ Params: { id: string } }>('/folders/:id/uploads', async (request, reply) => {
-    const user = request.currentUser!;
-    const folder = await foldersRepo.findFolderById(request.params.id, user.id);
-    if (!folder) {
-      reply.code(404);
-      return { error: 'Folder not found' };
-    }
-    if (folder.type !== 'LOCAL') {
-      reply.code(400);
-      return { error: 'Only local folders support uploads' };
-    }
-
-    try {
-      await ensureDirectoryWritable(folder.path, 'Uploading files');
-    } catch (error) {
-      if (error instanceof DirectoryWriteAccessError) {
-        reply.code(409);
-        return { error: error.message };
+  app.post<{ Params: { id: string } }>(
+    '/folders/:id/uploads',
+    {
+      config: {
+        rateLimit: folderUploadsRateLimit
       }
-      throw error;
-    }
-
-    const uploaded: UploadResultItem[] = [];
-    const rejected: UploadResultItem[] = [];
-    const reservedPaths = new Set<string>();
-    const multipartRequest = request as typeof request & MultipartRequest;
-
-    for await (const part of multipartRequest.parts()) {
-      if (part.type !== 'file') continue;
-
-      const safeName = normalizeUploadName(part.filename);
-      const fallbackName = part.filename?.trim() || 'unnamed file';
-      if (!safeName) {
-        part.file.resume();
-        rejected.push({ name: fallbackName, reason: 'Invalid file name' });
-        continue;
+    },
+    async (request, reply) => {
+      const user = request.currentUser!;
+      const folder = await foldersRepo.findFolderById(
+        request.params.id,
+        user.id
+      );
+      if (!folder) {
+        reply.code(404);
+        return { error: 'Folder not found' };
       }
-      if (!detectMediaKind(safeName)) {
-        part.file.resume();
-        rejected.push({ name: safeName, reason: 'Unsupported file type' });
-        continue;
+      if (folder.type !== 'LOCAL') {
+        reply.code(400);
+        return { error: 'Only local folders support uploads' };
       }
 
-      const targetPath = path.resolve(folder.path, safeName);
-      if (!isPathInside(targetPath, folder.path)) {
-        part.file.resume();
-        rejected.push({ name: safeName, reason: 'Unsafe upload path' });
-        continue;
-      }
-      if (reservedPaths.has(targetPath) || (await fileExists(targetPath))) {
-        part.file.resume();
-        rejected.push({ name: safeName, reason: 'A file with this name already exists in the folder' });
-        continue;
-      }
-
-      reservedPaths.add(targetPath);
       try {
-        await pipeline(part.file, fs.createWriteStream(targetPath, { flags: 'wx' }));
-        const scanned = await scanLocalFile(targetPath, { thumbnailsDir: config.storage.thumbnailsDir });
-        if (!scanned) {
-          await fs.promises.unlink(targetPath).catch(() => undefined);
+        await ensureDirectoryWritable(folder.path, 'Uploading files');
+      } catch (error) {
+        if (error instanceof DirectoryWriteAccessError) {
+          reply.code(409);
+          return { error: error.message };
+        }
+        throw error;
+      }
+
+      const uploaded: UploadResultItem[] = [];
+      const rejected: UploadResultItem[] = [];
+      const reservedPaths = new Set<string>();
+      const multipartRequest = request as typeof request & MultipartRequest;
+
+      for await (const part of multipartRequest.parts()) {
+        if (part.type !== 'file') continue;
+
+        const safeName = normalizeUploadName(part.filename);
+        const fallbackName = part.filename?.trim() || 'unnamed file';
+        if (!safeName) {
+          part.file.resume();
+          rejected.push({ name: fallbackName, reason: 'Invalid file name' });
+          continue;
+        }
+        if (!detectMediaKind(safeName)) {
+          part.file.resume();
           rejected.push({ name: safeName, reason: 'Unsupported file type' });
           continue;
         }
-        const saved = await filesRepo.upsertFile(folder.id, scanned);
-        uploaded.push({ name: safeName, fileId: saved.id });
-      } catch (error) {
-        await fs.promises.unlink(targetPath).catch(() => undefined);
-        const err = error as NodeJS.ErrnoException;
-        const reason = err.code === 'EEXIST'
-          ? 'A file with this name already exists in the folder'
-          : (err.message || 'Failed to upload file');
-        rejected.push({ name: safeName, reason });
-      } finally {
-        reservedPaths.delete(targetPath);
+
+        const targetPath = path.resolve(folder.path, safeName);
+        if (!isPathInside(targetPath, folder.path)) {
+          part.file.resume();
+          rejected.push({ name: safeName, reason: 'Unsafe upload path' });
+          continue;
+        }
+        if (reservedPaths.has(targetPath) || (await fileExists(targetPath))) {
+          part.file.resume();
+          rejected.push({
+            name: safeName,
+            reason: 'A file with this name already exists in the folder'
+          });
+          continue;
+        }
+
+        reservedPaths.add(targetPath);
+        try {
+          await pipeline(
+            part.file,
+            fs.createWriteStream(targetPath, { flags: 'wx' })
+          );
+          const scanned = await scanLocalFile(targetPath, {
+            thumbnailsDir: config.storage.thumbnailsDir
+          });
+          if (!scanned) {
+            await fs.promises.unlink(targetPath).catch(() => undefined);
+            rejected.push({ name: safeName, reason: 'Unsupported file type' });
+            continue;
+          }
+          const saved = await filesRepo.upsertFile(folder.id, scanned);
+          uploaded.push({ name: safeName, fileId: saved.id });
+        } catch (error) {
+          await fs.promises.unlink(targetPath).catch(() => undefined);
+          const err = error as NodeJS.ErrnoException;
+          const reason =
+            err.code === 'EEXIST'
+              ? 'A file with this name already exists in the folder'
+              : err.message || 'Failed to upload file';
+          rejected.push({ name: safeName, reason });
+        } finally {
+          reservedPaths.delete(targetPath);
+        }
       }
-    }
 
-    if (uploaded.length === 0 && rejected.length === 0) {
-      reply.code(400);
-      return { error: 'No files were provided' };
-    }
+      if (uploaded.length === 0 && rejected.length === 0) {
+        reply.code(400);
+        return { error: 'No files were provided' };
+      }
 
-    return { uploaded, rejected };
-  });
+      return { uploaded, rejected };
+    }
+  );
 
-  app.delete<{ Params: { id: string } }>('/folders/:id', async (request, reply) => {
-    const user = request.currentUser!;
-    const folder = await foldersRepo.findFolderById(request.params.id, user.id);
-    if (!folder) {
-      reply.code(404);
-      return { error: 'Folder not found' };
-    }
-    if (folder.path === user.libraryRoot) {
-      reply.code(400);
-      return { error: 'Cannot remove your library root folder' };
-    }
-    if (folder.status === 'SCANNING') {
-      reply.code(409);
-      return { error: 'Folder is scanning; stop or wait before deleting' };
-    }
+  app.delete<{ Params: { id: string } }>(
+    '/folders/:id',
+    async (request, reply) => {
+      const user = request.currentUser!;
+      const folder = await foldersRepo.findFolderById(
+        request.params.id,
+        user.id
+      );
+      if (!folder) {
+        reply.code(404);
+        return { error: 'Folder not found' };
+      }
+      if (folder.path === user.libraryRoot) {
+        reply.code(400);
+        return { error: 'Cannot remove your library root folder' };
+      }
+      if (folder.status === 'SCANNING') {
+        reply.code(409);
+        return { error: 'Folder is scanning; stop or wait before deleting' };
+      }
 
-    await foldersRepo.deleteFolder(folder.id, user.id);
-    return { status: 'deleted' };
-  });
+      await foldersRepo.deleteFolder(folder.id, user.id);
+      return { status: 'deleted' };
+    }
+  );
 };

--- a/backend/src/services/providers.test.ts
+++ b/backend/src/services/providers.test.ts
@@ -36,6 +36,17 @@ test('isTrustedSaucePostUrl rejects host-lookalike URLs', () => {
   );
 });
 
+test('isTrustedSaucePostUrl rejects non-http URL schemes', () => {
+  assert.equal(
+    isTrustedSaucePostUrl('javascript://e621.net/posts/12345', 'e621.net'),
+    false
+  );
+  assert.equal(
+    isTrustedSaucePostUrl('data://e621.net/posts/12345', 'e621.net'),
+    false
+  );
+});
+
 test('pickSauceUrl prefers trusted host-matching URLs over lookalikes', () => {
   const picked = pickSauceUrl([
     'https://e621.net.evil.example/posts/9',

--- a/backend/src/services/providers.test.ts
+++ b/backend/src/services/providers.test.ts
@@ -55,3 +55,16 @@ test('pickSauceUrl prefers trusted host-matching URLs over lookalikes', () => {
   ]);
   assert.equal(picked, 'https://e621.net/posts/11');
 });
+
+test('pickSauceUrl ignores non-http(s) fallback URLs', () => {
+  const picked = pickSauceUrl(['javascript://e621.net/posts/12345']);
+  assert.equal(picked, null);
+});
+
+test('pickSauceUrl uses first safe http(s) URL as fallback', () => {
+  const picked = pickSauceUrl([
+    'javascript://e621.net/posts/12345',
+    'https://example.org/untrusted-path'
+  ]);
+  assert.equal(picked, 'https://example.org/untrusted-path');
+});

--- a/backend/src/services/providers.test.ts
+++ b/backend/src/services/providers.test.ts
@@ -1,0 +1,46 @@
+import '../../test/helpers/setupEnv';
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { isTrustedSaucePostUrl, pickSauceUrl } from './providers';
+
+test('isTrustedSaucePostUrl accepts canonical e621 post URLs', () => {
+  assert.equal(
+    isTrustedSaucePostUrl('https://e621.net/posts/12345', 'e621.net'),
+    true
+  );
+  assert.equal(
+    isTrustedSaucePostUrl(
+      'https://e621.net/post/show/12345?foo=bar',
+      'e621.net'
+    ),
+    true
+  );
+});
+
+test('isTrustedSaucePostUrl rejects host-lookalike URLs', () => {
+  assert.equal(
+    isTrustedSaucePostUrl(
+      'https://e621.net.evil.example/posts/12345',
+      'e621.net'
+    ),
+    false
+  );
+  assert.equal(
+    isTrustedSaucePostUrl(
+      'https://evil.example/e621.net/posts/12345',
+      'e621.net'
+    ),
+    false
+  );
+});
+
+test('pickSauceUrl prefers trusted host-matching URLs over lookalikes', () => {
+  const picked = pickSauceUrl([
+    'https://e621.net.evil.example/posts/9',
+    'https://danbooru.donmai.us/posts/10',
+    'https://e621.net/posts/11'
+  ]);
+  assert.equal(picked, 'https://e621.net/posts/11');
+});

--- a/backend/src/services/providers.ts
+++ b/backend/src/services/providers.ts
@@ -245,7 +245,16 @@ export const pickSauceUrl = (urls: string[] | null | undefined) => {
   const prefer =
     urls.find((url) => isTrustedSaucePostUrl(url, 'e621.net')) ??
     urls.find((url) => isTrustedSaucePostUrl(url, 'danbooru.donmai.us'));
-  return prefer ?? urls[0] ?? null;
+  if (prefer) return prefer;
+  const firstHttpUrl = urls.find((url) => {
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+    } catch {
+      return false;
+    }
+  });
+  return firstHttpUrl ?? null;
 };
 
 const pickSaucePostUrl = (data: SauceNaoData | null | undefined) => {

--- a/backend/src/services/providers.ts
+++ b/backend/src/services/providers.ts
@@ -225,22 +225,23 @@ const resolveUploadSource = async (file: FileRecord): Promise<UploadSource> => {
   return { sourcePath: fallback, filename, mimeType, cleanup: noopCleanup };
 };
 
-const pickSauceUrl = (urls: string[] | null | undefined) => {
+export const isTrustedSaucePostUrl = (url: string, hostname: string) => {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname.toLowerCase() !== hostname) return false;
+    return /^\/(?:posts|post\/show)\/\d+(?:[/?#]|$)/i.test(
+      parsed.pathname + parsed.search + parsed.hash
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const pickSauceUrl = (urls: string[] | null | undefined) => {
   if (!Array.isArray(urls) || urls.length === 0) return null;
-  const isTrustedPostUrl = (url: string, hostname: string) => {
-    try {
-      const parsed = new URL(url);
-      if (parsed.hostname.toLowerCase() !== hostname) return false;
-      return /^\/(?:posts|post\/show)\/\d+(?:[/?#]|$)/i.test(
-        parsed.pathname + parsed.search + parsed.hash
-      );
-    } catch {
-      return false;
-    }
-  };
   const prefer =
-    urls.find((url) => isTrustedPostUrl(url, 'e621.net')) ??
-    urls.find((url) => isTrustedPostUrl(url, 'danbooru.donmai.us'));
+    urls.find((url) => isTrustedSaucePostUrl(url, 'e621.net')) ??
+    urls.find((url) => isTrustedSaucePostUrl(url, 'danbooru.donmai.us'));
   return prefer ?? urls[0] ?? null;
 };
 

--- a/backend/src/services/providers.ts
+++ b/backend/src/services/providers.ts
@@ -228,6 +228,9 @@ const resolveUploadSource = async (file: FileRecord): Promise<UploadSource> => {
 export const isTrustedSaucePostUrl = (url: string, hostname: string) => {
   try {
     const parsed = new URL(url);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      return false;
+    }
     if (parsed.hostname.toLowerCase() !== hostname) return false;
     return /^\/(?:posts|post\/show)\/\d+(?:[/?#]|$)/i.test(
       parsed.pathname + parsed.search + parsed.hash

--- a/backend/src/services/providers.ts
+++ b/backend/src/services/providers.ts
@@ -132,14 +132,21 @@ const pickRandomTimemark = (durationSeconds: number) => {
   if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
     return '0.5';
   }
-  const start = Math.min(durationSeconds * 0.1, Math.max(durationSeconds - 0.25, 0));
+  const start = Math.min(
+    durationSeconds * 0.1,
+    Math.max(durationSeconds - 0.25, 0)
+  );
   const end = Math.max(start, durationSeconds * 0.9);
   const offset = end > start ? Math.random() * (end - start) : 0;
   return (start + offset).toFixed(3);
 };
 
-const extractRandomVideoFrame = async (videoPath: string): Promise<ResolvedPath> => {
-  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'imagesearch-frame-'));
+const extractRandomVideoFrame = async (
+  videoPath: string
+): Promise<ResolvedPath> => {
+  const tmpDir = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'imagesearch-frame-')
+  );
   const framePath = path.join(tmpDir, 'frame.jpg');
   const timemark = pickRandomTimemark(await getVideoDurationSeconds(videoPath));
 
@@ -171,7 +178,9 @@ const resolveUploadSource = async (file: FileRecord): Promise<UploadSource> => {
 
     if (resolvedVideo) {
       try {
-        const extractedFrame = await extractRandomVideoFrame(resolvedVideo.sourcePath);
+        const extractedFrame = await extractRandomVideoFrame(
+          resolvedVideo.sourcePath
+        );
         return {
           sourcePath: extractedFrame.sourcePath,
           filename: `${path.parse(file.path).name || 'video'}-frame.jpg`,
@@ -205,19 +214,33 @@ const resolveUploadSource = async (file: FileRecord): Promise<UploadSource> => {
     const resolved = await resolveReadablePath(candidate);
     if (!resolved) continue;
     const filename = path.basename(resolved) || 'file';
-    const mimeType = (lookupMime(filename) || 'application/octet-stream') as string;
+    const mimeType = (lookupMime(filename) ||
+      'application/octet-stream') as string;
     return { sourcePath: resolved, filename, mimeType, cleanup: noopCleanup };
   }
   const fallback = path.resolve(file.path);
   const filename = path.basename(fallback) || 'file';
-  const mimeType = (lookupMime(filename) || 'application/octet-stream') as string;
+  const mimeType = (lookupMime(filename) ||
+    'application/octet-stream') as string;
   return { sourcePath: fallback, filename, mimeType, cleanup: noopCleanup };
 };
 
 const pickSauceUrl = (urls: string[] | null | undefined) => {
   if (!Array.isArray(urls) || urls.length === 0) return null;
-  const prefer = urls.find((url) => /e621\.net\/(?:posts|post\/show)\/\d+/i.test(url))
-    ?? urls.find((url) => /danbooru\.donmai\.us\/(?:posts|post\/show)\/\d+/i.test(url));
+  const isTrustedPostUrl = (url: string, hostname: string) => {
+    try {
+      const parsed = new URL(url);
+      if (parsed.hostname.toLowerCase() !== hostname) return false;
+      return /^\/(?:posts|post\/show)\/\d+(?:[/?#]|$)/i.test(
+        parsed.pathname + parsed.search + parsed.hash
+      );
+    } catch {
+      return false;
+    }
+  };
+  const prefer =
+    urls.find((url) => isTrustedPostUrl(url, 'e621.net')) ??
+    urls.find((url) => isTrustedPostUrl(url, 'danbooru.donmai.us'));
   return prefer ?? urls[0] ?? null;
 };
 
@@ -225,7 +248,8 @@ const pickSaucePostUrl = (data: SauceNaoData | null | undefined) => {
   const e621Id = data?.e621_id ?? data?.e621Id ?? null;
   const danbooruId = data?.danbooru_id ?? data?.danbooruId ?? null;
   const toId = (value: unknown) => {
-    if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value).toString();
+    if (typeof value === 'number' && Number.isFinite(value))
+      return Math.trunc(value).toString();
     if (typeof value === 'string' && value.trim()) return value.trim();
     return null;
   };
@@ -236,8 +260,13 @@ const pickSaucePostUrl = (data: SauceNaoData | null | undefined) => {
   return null;
 };
 
-export const runSauceNao = async (file: FileRecord): Promise<ProviderResult> => {
-  const credential = await resolveCredential('SAUCENAO', await resolveFileUserId(file));
+export const runSauceNao = async (
+  file: FileRecord
+): Promise<ProviderResult> => {
+  const credential = await resolveCredential(
+    'SAUCENAO',
+    await resolveFileUserId(file)
+  );
   const apiKey = credential.apiKey ?? '';
   if (!apiKey) {
     return {
@@ -257,28 +286,42 @@ export const runSauceNao = async (file: FileRecord): Promise<ProviderResult> => 
       form.append('db', '999');
       form.append('dedupe', '2');
       form.append('api_key', apiKey);
-      form.append('file', await fs.openAsBlob(upload.sourcePath, { type: upload.mimeType }), upload.filename);
+      form.append(
+        'file',
+        await fs.openAsBlob(upload.sourcePath, { type: upload.mimeType }),
+        upload.filename
+      );
 
       const res = await fetch('https://saucenao.com/search.php', {
         method: 'POST',
         headers: {
           Accept: 'application/json',
           'User-Agent': config.e621.userAgent
-          },
-          body: form
+        },
+        body: form
       });
       const text = await res.text();
       if (!res.ok) {
-        return { score: null, sourceUrl: null, thumbUrl: null, error: `HTTP ${res.status}: ${text}` };
+        return {
+          score: null,
+          sourceUrl: null,
+          thumbUrl: null,
+          error: `HTTP ${res.status}: ${text}`
+        };
       }
-        let data: SauceNaoResponse;
+      let data: SauceNaoResponse;
       try {
-          data = JSON.parse(text) as SauceNaoResponse;
+        data = JSON.parse(text) as SauceNaoResponse;
       } catch {
-        return { score: null, sourceUrl: null, thumbUrl: null, error: `Non-JSON response (status ${res.status}): ${text}` };
+        return {
+          score: null,
+          sourceUrl: null,
+          thumbUrl: null,
+          error: `Non-JSON response (status ${res.status}): ${text}`
+        };
       }
       const header = data?.header ?? {};
-        const results = Array.isArray(data.results) ? data.results : [];
+      const results = Array.isArray(data.results) ? data.results : [];
       if (!results.length) {
         return {
           score: null,
@@ -298,13 +341,20 @@ export const runSauceNao = async (file: FileRecord): Promise<ProviderResult> => 
 
       const score = Number.parseFloat(pick?.header?.similarity ?? '0');
       const sourceUrl =
-        pickSaucePostUrl(pick?.data) ?? pickSauceUrl(pick?.data?.ext_urls) ?? pick?.data?.source ?? null;
+        pickSaucePostUrl(pick?.data) ??
+        pickSauceUrl(pick?.data?.ext_urls) ??
+        pick?.data?.source ??
+        null;
       const thumbUrl = pick?.header?.thumbnail ?? null;
 
       const sorted = results
         .map((r) => {
           const sim = Number.parseFloat(r?.header?.similarity ?? '0');
-          const url = pickSaucePostUrl(r?.data) ?? pickSauceUrl(r?.data?.ext_urls) ?? r?.data?.source ?? null;
+          const url =
+            pickSaucePostUrl(r?.data) ??
+            pickSauceUrl(r?.data?.ext_urls) ??
+            r?.data?.source ??
+            null;
           let name = r?.header?.index_name ?? null;
           if (!name && url) {
             try {
@@ -332,12 +382,22 @@ export const runSauceNao = async (file: FileRecord): Promise<ProviderResult> => 
         };
       }
 
-      return { score: Number.isFinite(score) ? score : null, sourceUrl, thumbUrl, results: sorted };
+      return {
+        score: Number.isFinite(score) ? score : null,
+        sourceUrl,
+        thumbUrl,
+        results: sorted
+      };
     } finally {
       await upload.cleanup();
     }
   } catch (err) {
-    return { score: null, sourceUrl: null, thumbUrl: null, error: (err as Error).message };
+    return {
+      score: null,
+      sourceUrl: null,
+      thumbUrl: null,
+      error: (err as Error).message
+    };
   }
 };
 
@@ -346,7 +406,11 @@ export const runFluffle = async (file: FileRecord): Promise<ProviderResult> => {
     const upload = await resolveUploadSource(file);
     try {
       const form = new FormData();
-      form.append('File', await fs.openAsBlob(upload.sourcePath, { type: upload.mimeType }), upload.filename);
+      form.append(
+        'File',
+        await fs.openAsBlob(upload.sourcePath, { type: upload.mimeType }),
+        upload.filename
+      );
       form.append('Limit', '8');
 
       const res = await fetch('https://api.fluffle.xyz/exact-search-by-file', {
@@ -354,22 +418,38 @@ export const runFluffle = async (file: FileRecord): Promise<ProviderResult> => {
         headers: {
           'User-Agent': config.e621.userAgent,
           Accept: 'application/json'
-          },
-          body: form
+        },
+        body: form
       });
       const text = await res.text();
       if (!res.ok) {
-        return { score: null, sourceUrl: null, thumbUrl: null, error: `HTTP ${res.status}: ${text}` };
+        return {
+          score: null,
+          sourceUrl: null,
+          thumbUrl: null,
+          error: `HTTP ${res.status}: ${text}`
+        };
       }
-        let data: FluffleResponse;
+      let data: FluffleResponse;
       try {
-          data = JSON.parse(text) as FluffleResponse;
+        data = JSON.parse(text) as FluffleResponse;
       } catch {
-        return { score: null, sourceUrl: null, thumbUrl: null, error: `Non-JSON response: ${text}` };
+        return {
+          score: null,
+          sourceUrl: null,
+          thumbUrl: null,
+          error: `Non-JSON response: ${text}`
+        };
       }
-        const results = Array.isArray(data.results) ? data.results : [];
+      const results = Array.isArray(data.results) ? data.results : [];
       if (!results.length) {
-        return { score: null, sourceUrl: null, thumbUrl: null, results: [], error: 'No results returned' };
+        return {
+          score: null,
+          sourceUrl: null,
+          thumbUrl: null,
+          results: [],
+          error: 'No results returned'
+        };
       }
 
       const mapped = results.map((r) => {
@@ -383,8 +463,14 @@ export const runFluffle = async (file: FileRecord): Promise<ProviderResult> => {
           const normalized = rawDistance > 1 ? rawDistance / 100 : rawDistance;
           similarity = Math.min(1, Math.max(0, normalized));
         }
-        const score = similarity !== null ? Math.max(0, Math.round(similarity * 100)) : null;
-        const distance = similarity !== null ? Math.max(0, Math.round((1 - similarity) * 100)) : null;
+        const score =
+          similarity !== null
+            ? Math.max(0, Math.round(similarity * 100))
+            : null;
+        const distance =
+          similarity !== null
+            ? Math.max(0, Math.round((1 - similarity) * 100))
+            : null;
         return {
           score,
           distance,
@@ -411,19 +497,24 @@ export const runFluffle = async (file: FileRecord): Promise<ProviderResult> => {
         score: top?.score ?? null,
         sourceUrl: top?.sourceUrl ?? null,
         thumbUrl: top?.thumbUrl ?? null,
-          results: sorted.map((item) => ({
-            score: item.score,
-            distance: item.distance,
-            sourceUrl: item.sourceUrl,
-            sourceName: item.sourceName,
-            thumbUrl: item.thumbUrl
-          })),
+        results: sorted.map((item) => ({
+          score: item.score,
+          distance: item.distance,
+          sourceUrl: item.sourceUrl,
+          sourceName: item.sourceName,
+          thumbUrl: item.thumbUrl
+        })),
         debug
       };
     } finally {
       await upload.cleanup();
     }
   } catch (err) {
-    return { score: null, sourceUrl: null, thumbUrl: null, error: (err as Error).message };
+    return {
+      score: null,
+      sourceUrl: null,
+      thumbUrl: null,
+      error: (err as Error).message
+    };
   }
 };

--- a/backend/test/auth.routes.test.ts
+++ b/backend/test/auth.routes.test.ts
@@ -25,13 +25,19 @@ test('POST /auth/register creates user and sets HttpOnly+Strict cookie', async (
   assert.equal(res.statusCode, 200);
   const body = res.json();
   assert.equal(body.user.username, 'alice_1');
-  const parsed = parseSetCookieFlags(getRawSetCookie(res.headers['set-cookie']));
+  const parsed = parseSetCookieFlags(
+    getRawSetCookie(res.headers['set-cookie'])
+  );
   assert.equal(parsed.name, 'gooncave_session');
   assert.ok(parsed.flags.has('httponly'), 'cookie missing HttpOnly');
   assert.equal(parsed.sameSite, 'strict');
   // NODE_ENV=test → cookieSecure should default to false. This is the
   // regression guard for #67 (Secure cookie on plain HTTP locked users out).
-  assert.equal(parsed.flags.has('secure'), false, 'Secure must be off in non-prod');
+  assert.equal(
+    parsed.flags.has('secure'),
+    false,
+    'Secure must be off in non-prod'
+  );
 });
 
 test('POST /auth/register rejects short username with 400', async () => {
@@ -80,6 +86,7 @@ test('GET /auth/me with valid cookie returns user', async () => {
   const reg = await app.inject({
     method: 'POST',
     url: '/auth/register',
+    remoteAddress: '10.0.0.77',
     payload: { username: 'charlie_1', password: 'longenoughpassword' }
   });
   const cookieValue = getRawSetCookie(reg.headers['set-cookie']).split(';')[0];
@@ -101,6 +108,7 @@ test('POST /auth/logout clears cookie', async () => {
   const reg = await app.inject({
     method: 'POST',
     url: '/auth/register',
+    remoteAddress: '10.0.0.88',
     payload: { username: 'logout_user', password: 'longenoughpassword' }
   });
   const cookieValue = getRawSetCookie(reg.headers['set-cookie']).split(';')[0];
@@ -111,5 +119,8 @@ test('POST /auth/logout clears cookie', async () => {
   });
   assert.equal(res.statusCode, 200);
   // Clearing a cookie sets value to empty + Expires in past.
-  assert.match(getRawSetCookie(res.headers['set-cookie']), /gooncave_session=;/);
+  assert.match(
+    getRawSetCookie(res.headers['set-cookie']),
+    /gooncave_session=;/
+  );
 });

--- a/backend/test/helpers/testApp.ts
+++ b/backend/test/helpers/testApp.ts
@@ -23,27 +23,40 @@ export const buildTestApp = async (): Promise<FastifyInstance> => {
   return app;
 };
 
-export const seedUser = async (overrides: { username?: string; password?: string } = {}) => {
+export const seedUser = async (
+  overrides: { username?: string; password?: string } = {}
+) => {
   const username = overrides.username ?? `user_${randomUUID().slice(0, 8)}`;
   const password = overrides.password ?? 'correct horse battery staple';
   const passwordHash = await hashPassword(password);
   const tmpRoot = process.env.GOONCAVE_TEST_TMP_ROOT ?? os.tmpdir();
-  const libraryRoot = path.join(tmpRoot, 'library', username);
-  fs.mkdirSync(libraryRoot, { recursive: true });
-  const user = await authRepo.createUser({ username, passwordHash, libraryRoot });
+  const libraryRoot = await fs.promises.mkdtemp(path.join(tmpRoot, 'library-'));
+  const user = await authRepo.createUser({
+    username,
+    passwordHash,
+    libraryRoot
+  });
   await foldersRepo.addFolder(libraryRoot, user.id);
   return { user, username, password, libraryRoot };
 };
 
 export const sessionCookieFor = async (userId: string) => {
   const session = await createSessionForUser(userId);
-  return { name: 'gooncave_session', value: session.token, expiresAt: session.expiresAt };
+  return {
+    name: 'gooncave_session',
+    value: session.token,
+    expiresAt: session.expiresAt
+  };
 };
 
-export const writeFixtureFile = (dirAbs: string, name: string, contents: Buffer | string) => {
+export const writeFixtureFile = (
+  dirAbs: string,
+  name: string,
+  contents: Buffer | string
+) => {
   fs.mkdirSync(dirAbs, { recursive: true });
-  const filePath = path.join(dirAbs, name);
-  fs.writeFileSync(filePath, contents);
+  const filePath = path.join(dirAbs, path.basename(name));
+  fs.writeFileSync(filePath, contents, { flag: 'wx' });
   return filePath;
 };
 

--- a/backend/test/rate-limit.routes.test.ts
+++ b/backend/test/rate-limit.routes.test.ts
@@ -1,0 +1,124 @@
+import './helpers/setupEnv';
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { foldersRepo } from '../src/db/repos/foldersRepo';
+
+import { buildTestApp, seedUser, sessionCookieFor } from './helpers/testApp';
+
+const ONE_BY_ONE_PNG = Buffer.from(
+  '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d49444154789c63f8cf' +
+    'c0c00000000300017c6bf3060000000049454e44ae426082',
+  'hex'
+);
+
+const cookieFor = async (userId: string) => {
+  const session = await sessionCookieFor(userId);
+  return `${session.name}=${session.value}`;
+};
+
+test('POST /auth/register returns 429 after too many attempts in one minute', async () => {
+  const app = await buildTestApp();
+  try {
+    for (let i = 0; i < 5; i++) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/auth/register',
+        payload: { username: `rate_reg_${i}`, password: 'longenoughpassword' }
+      });
+      assert.equal(res.statusCode, 200);
+    }
+
+    const blocked = await app.inject({
+      method: 'POST',
+      url: '/auth/register',
+      payload: { username: 'rate_reg_blocked', password: 'longenoughpassword' }
+    });
+    assert.equal(blocked.statusCode, 429);
+  } finally {
+    await app.close();
+  }
+});
+
+test('POST /auth/login returns 429 after too many failed attempts in one minute', async () => {
+  const app = await buildTestApp();
+  try {
+    await app.inject({
+      method: 'POST',
+      url: '/auth/register',
+      payload: { username: 'rate_login_user', password: 'rightpassword1' }
+    });
+
+    for (let i = 0; i < 10; i++) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/auth/login',
+        payload: { username: 'rate_login_user', password: 'rightpassword1' }
+      });
+      assert.equal(res.statusCode, 200);
+    }
+
+    const blocked = await app.inject({
+      method: 'POST',
+      url: '/auth/login',
+      payload: { username: 'rate_login_user', password: 'rightpassword1' }
+    });
+    assert.equal(blocked.statusCode, 429);
+  } finally {
+    await app.close();
+  }
+});
+
+test('POST /folders/:id/uploads returns 429 after too many attempts in one minute', async () => {
+  const app = await buildTestApp();
+  try {
+    const seeded = await seedUser({ username: 'rate_upload_user' });
+    const cookie = await cookieFor(seeded.user.id);
+    const folders = await foldersRepo.listFolders(seeded.user.id);
+    const folderId = folders[0]?.id;
+    assert.ok(folderId, 'expected a root folder');
+
+    const buildMultipartUpload = (filename: string) => {
+      const boundary = 'gooncave-upload-boundary';
+      const head =
+        `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file"; filename="${filename}"\r\n` +
+        'Content-Type: image/png\r\n\r\n';
+      const tail = `\r\n--${boundary}--\r\n`;
+      const payload = Buffer.concat([
+        Buffer.from(head, 'utf8'),
+        ONE_BY_ONE_PNG,
+        Buffer.from(tail, 'utf8')
+      ]);
+      const headers = {
+        cookie,
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+        'content-length': String(payload.length)
+      };
+      return { headers, payload };
+    };
+
+    for (let i = 0; i < 30; i++) {
+      const upload = buildMultipartUpload(`rate-${i}.png`);
+      const res = await app.inject({
+        method: 'POST',
+        url: `/folders/${folderId}/uploads`,
+        headers: upload.headers,
+        payload: upload.payload
+      });
+      assert.equal(res.statusCode, 200);
+    }
+
+    const blockedUpload = buildMultipartUpload('rate-blocked.png');
+    const blocked = await app.inject({
+      method: 'POST',
+      url: `/folders/${folderId}/uploads`,
+      headers: blockedUpload.headers,
+      payload: blockedUpload.payload
+    });
+    assert.equal(blocked.statusCode, 429);
+  } finally {
+    await app.close();
+  }
+});

--- a/backend/test/rate-limit.routes.test.ts
+++ b/backend/test/rate-limit.routes.test.ts
@@ -41,7 +41,7 @@ test('POST /auth/register returns 429 after too many attempts in one minute', as
   }
 });
 
-test('POST /auth/login returns 429 after too many failed attempts in one minute', async () => {
+test('POST /auth/login returns 429 after too many attempts in one minute', async () => {
   const app = await buildTestApp();
   try {
     await app.inject({


### PR DESCRIPTION
## Summary\n- remediate insecure temporary-file patterns using safer tmp directory handling\n- add and enforce route-level rate limiting for auth and folder uploads\n- harden Sauce URL selection to reject non-http(s) and host-lookalike links\n- add regression tests for rate limiting and URL sanitization\n\n## Verification\n- npm --prefix backend run lint\n- npm --prefix backend run test\n\nFixes #184