### PR TITLE
refactor: derive booru site capabilities from the engine

### DIFF
--- a/backend/src/db/migrations/0002_drop_booru_site_caps.sql
+++ b/backend/src/db/migrations/0002_drop_booru_site_caps.sql
@@ -1,0 +1,12 @@
+-- Capabilities are now derived from the engine module at runtime, so the
+-- per-site cap_* columns (and their indexes) are redundant. Drop the indexes
+-- first: SQLite refuses DROP COLUMN while a column is referenced by an index.
+
+DROP INDEX IF EXISTS idx_user_booru_sites_user_fav;
+DROP INDEX IF EXISTS idx_user_booru_sites_user_tags;
+DROP INDEX IF EXISTS idx_user_booru_sites_user_match;
+
+ALTER TABLE user_booru_sites DROP COLUMN cap_favorites;
+ALTER TABLE user_booru_sites DROP COLUMN cap_tags;
+ALTER TABLE user_booru_sites DROP COLUMN cap_source_match;
+ALTER TABLE user_booru_sites DROP COLUMN cap_search;

--- a/backend/src/db/repos/booruSitesRepo.ts
+++ b/backend/src/db/repos/booruSitesRepo.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 
 import type { BooruSiteInput, BooruSiteRecord } from '../../db/types';
+import { engineSupports } from '../../lib/booruEngines';
 import { sqlite } from '../client';
 
 type BooruSiteRow = {
@@ -14,10 +15,6 @@ type BooruSiteRow = {
   is_preset: number;
   preset_key?: string | null;
   enabled: number;
-  cap_favorites: number;
-  cap_tags: number;
-  cap_source_match: number;
-  cap_search: number;
   site_auto_sync_midnight: number;
   site_reverse_sync_enabled: number;
   site_auto_fav_enabled: number;
@@ -37,10 +34,6 @@ const mapBooruSiteRow = (row: BooruSiteRow): BooruSiteRecord => ({
   isPreset: row.is_preset === 1,
   presetKey: row.preset_key ?? null,
   enabled: row.enabled === 1,
-  capFavorites: row.cap_favorites === 1,
-  capTags: row.cap_tags === 1,
-  capSourceMatch: row.cap_source_match === 1,
-  capSearch: row.cap_search === 1,
   siteAutoSyncMidnight: row.site_auto_sync_midnight === 1,
   siteReverseSyncEnabled: row.site_reverse_sync_enabled === 1,
   siteAutoFavEnabled: row.site_auto_fav_enabled === 1,
@@ -110,10 +103,9 @@ export const booruSitesRepo = {
           `INSERT INTO user_booru_sites
            (id, user_id, name, engine, base_url, username, api_key,
             is_preset, preset_key, enabled,
-            cap_favorites, cap_tags, cap_source_match, cap_search,
             site_auto_sync_midnight, site_reverse_sync_enabled, site_auto_fav_enabled,
             sort_order, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .run(
           id,
@@ -126,10 +118,6 @@ export const booruSitesRepo = {
           input.isPreset ? 1 : 0,
           input.presetKey ?? null,
           input.enabled === false ? 0 : 1,
-          input.capFavorites ? 1 : 0,
-          input.capTags ? 1 : 0,
-          input.capSourceMatch ? 1 : 0,
-          input.capSearch ? 1 : 0,
           input.siteAutoSyncMidnight ? 1 : 0,
           input.siteReverseSyncEnabled ? 1 : 0,
           input.siteAutoFavEnabled ? 1 : 0,
@@ -177,30 +165,6 @@ export const booruSitesRepo = {
             ? 1
             : 0
           : existing.enabled,
-      cap_favorites:
-        updates.capFavorites !== undefined
-          ? updates.capFavorites
-            ? 1
-            : 0
-          : existing.cap_favorites,
-      cap_tags:
-        updates.capTags !== undefined
-          ? updates.capTags
-            ? 1
-            : 0
-          : existing.cap_tags,
-      cap_source_match:
-        updates.capSourceMatch !== undefined
-          ? updates.capSourceMatch
-            ? 1
-            : 0
-          : existing.cap_source_match,
-      cap_search:
-        updates.capSearch !== undefined
-          ? updates.capSearch
-            ? 1
-            : 0
-          : existing.cap_search,
       site_auto_sync_midnight:
         updates.siteAutoSyncMidnight !== undefined
           ? updates.siteAutoSyncMidnight
@@ -226,7 +190,7 @@ export const booruSitesRepo = {
       .prepare(
         `UPDATE user_booru_sites
        SET name = ?, engine = ?, base_url = ?, username = ?, api_key = ?, is_preset = ?, preset_key = ?,
-           enabled = ?, cap_favorites = ?, cap_tags = ?, cap_source_match = ?, cap_search = ?,
+           enabled = ?,
            site_auto_sync_midnight = ?, site_reverse_sync_enabled = ?, site_auto_fav_enabled = ?,
            sort_order = ?, updated_at = ?
        WHERE id = ? AND user_id = ?`
@@ -240,10 +204,6 @@ export const booruSitesRepo = {
         merged.is_preset,
         merged.preset_key ?? null,
         merged.enabled,
-        merged.cap_favorites,
-        merged.cap_tags,
-        merged.cap_source_match,
-        merged.cap_search,
         merged.site_auto_sync_midnight,
         merged.site_reverse_sync_enabled,
         merged.site_auto_fav_enabled,
@@ -255,12 +215,14 @@ export const booruSitesRepo = {
     return mapBooruSiteRow(merged);
   },
   async listUsersWithAutoSyncFavorites(): Promise<string[]> {
+    // Favorites capability is engine-derived, so it can't be filtered in SQL.
+    // Pull candidate (user, engine) rows and keep only users with at least one
+    // favorites-capable engine, deduped in stable user_id order.
     const rows = sqlite
       .prepare(
-        `SELECT DISTINCT user_id
+        `SELECT user_id, engine
          FROM user_booru_sites
          WHERE enabled = 1
-           AND cap_favorites = 1
            AND username IS NOT NULL
            AND TRIM(username) <> ''
            AND api_key IS NOT NULL
@@ -268,8 +230,16 @@ export const booruSitesRepo = {
            AND site_auto_sync_midnight = 1
          ORDER BY user_id ASC`
       )
-      .all() as Array<{ user_id: string }>;
-    return rows.map((row) => row.user_id);
+      .all() as Array<{ user_id: string; engine: string }>;
+    const userIds: string[] = [];
+    const seen = new Set<string>();
+    for (const row of rows) {
+      if (!engineSupports(row.engine, 'favorites')) continue;
+      if (seen.has(row.user_id)) continue;
+      seen.add(row.user_id);
+      userIds.push(row.user_id);
+    }
+    return userIds;
   },
   async deleteBooruSite(id: string, userId: string): Promise<boolean> {
     const tx = sqlite.transaction(() => {

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -262,10 +262,6 @@ export const userBooruSites = sqliteTable(
     isPreset: integer('is_preset').notNull(),
     presetKey: text('preset_key'),
     enabled: integer('enabled').notNull(),
-    capFavorites: integer('cap_favorites').notNull(),
-    capTags: integer('cap_tags').notNull(),
-    capSourceMatch: integer('cap_source_match').notNull(),
-    capSearch: integer('cap_search').notNull(),
     siteAutoSyncMidnight: integer('site_auto_sync_midnight').notNull(),
     siteReverseSyncEnabled: integer('site_reverse_sync_enabled').notNull(),
     siteAutoFavEnabled: integer('site_auto_fav_enabled').notNull(),
@@ -277,21 +273,6 @@ export const userBooruSites = sqliteTable(
     userSortIdx: index('idx_user_booru_sites_user_sort').on(
       table.userId,
       table.sortOrder
-    ),
-    userFavIdx: index('idx_user_booru_sites_user_fav').on(
-      table.userId,
-      table.enabled,
-      table.capFavorites
-    ),
-    userTagsIdx: index('idx_user_booru_sites_user_tags').on(
-      table.userId,
-      table.enabled,
-      table.capTags
-    ),
-    userMatchIdx: index('idx_user_booru_sites_user_match').on(
-      table.userId,
-      table.enabled,
-      table.capSourceMatch
     ),
     userPresetUnique: uniqueIndex('user_booru_sites_user_preset_unique').on(
       table.userId,

--- a/backend/src/db/types.ts
+++ b/backend/src/db/types.ts
@@ -101,10 +101,6 @@ export type BooruSiteRecord = {
   isPreset: boolean;
   presetKey: string | null;
   enabled: boolean;
-  capFavorites: boolean;
-  capTags: boolean;
-  capSourceMatch: boolean;
-  capSearch: boolean;
   siteAutoSyncMidnight: boolean;
   siteReverseSyncEnabled: boolean;
   siteAutoFavEnabled: boolean;
@@ -122,10 +118,6 @@ export type BooruSiteInput = {
   isPreset?: boolean;
   presetKey?: string | null;
   enabled?: boolean;
-  capFavorites?: boolean;
-  capTags?: boolean;
-  capSourceMatch?: boolean;
-  capSearch?: boolean;
   siteAutoSyncMidnight?: boolean;
   siteReverseSyncEnabled?: boolean;
   siteAutoFavEnabled?: boolean;

--- a/backend/src/lib/booruEngines/engines.test.ts
+++ b/backend/src/lib/booruEngines/engines.test.ts
@@ -26,10 +26,6 @@ const baseSite = (overrides: Partial<BooruSiteRecord>): BooruSiteRecord => ({
   isPreset: false,
   presetKey: null,
   enabled: true,
-  capFavorites: false,
-  capTags: true,
-  capSourceMatch: true,
-  capSearch: true,
   sortOrder: 0,
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
@@ -83,54 +79,90 @@ test('sankaku probe matches typed tag entries', () => {
 
 test('e621 extractIdFromUrl matches canonical /posts/{id}', () => {
   const site = baseSite({ engine: 'e621', baseUrl: 'https://e621.net' });
-  assert.deepEqual(e621Engine.extractIdFromUrl('https://e621.net/posts/12345', site), { remoteId: '12345' });
+  assert.deepEqual(
+    e621Engine.extractIdFromUrl('https://e621.net/posts/12345', site),
+    { remoteId: '12345' }
+  );
 });
 
 test('e621 extractIdFromUrl rejects wrong host', () => {
   const site = baseSite({ engine: 'e621', baseUrl: 'https://e621.net' });
-  assert.equal(e621Engine.extractIdFromUrl('https://danbooru.donmai.us/posts/42', site), null);
+  assert.equal(
+    e621Engine.extractIdFromUrl('https://danbooru.donmai.us/posts/42', site),
+    null
+  );
 });
 
 test('danbooru extractIdFromUrl matches /posts/{id}', () => {
-  const site = baseSite({ engine: 'danbooru', baseUrl: 'https://danbooru.donmai.us' });
+  const site = baseSite({
+    engine: 'danbooru',
+    baseUrl: 'https://danbooru.donmai.us'
+  });
   assert.deepEqual(
-    danbooruEngine.extractIdFromUrl('https://danbooru.donmai.us/posts/777', site),
+    danbooruEngine.extractIdFromUrl(
+      'https://danbooru.donmai.us/posts/777',
+      site
+    ),
     { remoteId: '777' }
   );
 });
 
 test('moebooru extractIdFromUrl matches /post/show/{id}', () => {
   const site = baseSite({ engine: 'moebooru', baseUrl: 'https://yande.re' });
-  assert.deepEqual(moebooruEngine.extractIdFromUrl('https://yande.re/post/show/9001', site), { remoteId: '9001' });
+  assert.deepEqual(
+    moebooruEngine.extractIdFromUrl('https://yande.re/post/show/9001', site),
+    { remoteId: '9001' }
+  );
 });
 
 test('gelbooru extractIdFromUrl reads id query parameter', () => {
-  const site = baseSite({ engine: 'gelbooru', baseUrl: 'https://gelbooru.com' });
+  const site = baseSite({
+    engine: 'gelbooru',
+    baseUrl: 'https://gelbooru.com'
+  });
   assert.deepEqual(
-    gelbooruEngine.extractIdFromUrl('https://gelbooru.com/index.php?page=post&s=view&id=42', site),
+    gelbooruEngine.extractIdFromUrl(
+      'https://gelbooru.com/index.php?page=post&s=view&id=42',
+      site
+    ),
     { remoteId: '42' }
   );
 });
 
 test('philomena extractIdFromUrl matches /images/{id}', () => {
-  const site = baseSite({ engine: 'philomena', baseUrl: 'https://derpibooru.org' });
+  const site = baseSite({
+    engine: 'philomena',
+    baseUrl: 'https://derpibooru.org'
+  });
   assert.deepEqual(
-    philomenaEngine.extractIdFromUrl('https://derpibooru.org/images/12345', site),
+    philomenaEngine.extractIdFromUrl(
+      'https://derpibooru.org/images/12345',
+      site
+    ),
     { remoteId: '12345' }
   );
 });
 
 test('sankaku extractIdFromUrl matches /post/show/{id}', () => {
-  const site = baseSite({ engine: 'sankaku', baseUrl: 'https://chan.sankakucomplex.com' });
+  const site = baseSite({
+    engine: 'sankaku',
+    baseUrl: 'https://chan.sankakucomplex.com'
+  });
   assert.deepEqual(
-    sankakuEngine.extractIdFromUrl('https://chan.sankakucomplex.com/post/show/42', site),
+    sankakuEngine.extractIdFromUrl(
+      'https://chan.sankakucomplex.com/post/show/42',
+      site
+    ),
     { remoteId: '42' }
   );
 });
 
 test('engine buildPostUrl returns canonical URL', () => {
   const site = baseSite({ engine: 'e621', baseUrl: 'https://e621.net' });
-  assert.equal(e621Engine.buildPostUrl(site, '42'), 'https://e621.net/posts/42');
+  assert.equal(
+    e621Engine.buildPostUrl(site, '42'),
+    'https://e621.net/posts/42'
+  );
 });
 
 // --- szurubooru ---------------------------------------------------------
@@ -141,7 +173,13 @@ test('szurubooru probe matches the szurubooru search envelope', () => {
     offset: 0,
     limit: 1,
     total: 99,
-    results: [{ id: 7, tags: [{ names: ['cat'], category: 'general' }], thumbnailUrl: '/t/7.jpg' }]
+    results: [
+      {
+        id: 7,
+        tags: [{ names: ['cat'], category: 'general' }],
+        thumbnailUrl: '/t/7.jpg'
+      }
+    ]
   };
   assert.equal(szurubooruEngine.probeMatches(body), true);
 });
@@ -160,16 +198,32 @@ test('szurubooru probe rejects danbooru-style flat tag string', () => {
 
 test('szurubooru probeSample returns id, thumbnail, and /post/{id} path', () => {
   const body = {
-    results: [{ id: 42, thumbnailUrl: '/t/42.jpg', tags: [{ names: ['cat'], category: 'general' }] }]
+    results: [
+      {
+        id: 42,
+        thumbnailUrl: '/t/42.jpg',
+        tags: [{ names: ['cat'], category: 'general' }]
+      }
+    ]
   };
   const sample = szurubooruEngine.probeSample?.(body);
-  assert.deepEqual(sample, { postId: '42', thumbUrl: '/t/42.jpg', postPath: '/post/42' });
+  assert.deepEqual(sample, {
+    postId: '42',
+    thumbUrl: '/t/42.jpg',
+    postPath: '/post/42'
+  });
 });
 
 test('szurubooru extractIdFromUrl matches /post/{id}', () => {
-  const site = baseSite({ engine: 'szurubooru', baseUrl: 'https://booru.foalcon.com' });
+  const site = baseSite({
+    engine: 'szurubooru',
+    baseUrl: 'https://booru.foalcon.com'
+  });
   assert.deepEqual(
-    szurubooruEngine.extractIdFromUrl('https://booru.foalcon.com/post/12345', site),
+    szurubooruEngine.extractIdFromUrl(
+      'https://booru.foalcon.com/post/12345',
+      site
+    ),
     { remoteId: '12345' }
   );
 });
@@ -195,11 +249,17 @@ test('shimmie probe rejects non-string bodies (defends against JSON misdispatch)
   // The detect loop hands every engine the same parsed body. If JSON.parse
   // succeeded upstream, shimmie must NOT match the resulting object — it
   // only understands raw XML strings.
-  assert.equal(shimmieEngine.probeMatches({ posts: [{ id: 1 }] } as unknown), false);
+  assert.equal(
+    shimmieEngine.probeMatches({ posts: [{ id: 1 }] } as unknown),
+    false
+  );
 });
 
 test('shimmie probe rejects HTML / arbitrary text', () => {
-  assert.equal(shimmieEngine.probeMatches('<!DOCTYPE html><html><body>nope</body></html>'), false);
+  assert.equal(
+    shimmieEngine.probeMatches('<!DOCTYPE html><html><body>nope</body></html>'),
+    false
+  );
   assert.equal(shimmieEngine.probeMatches('plain text'), false);
 });
 
@@ -208,13 +268,23 @@ test('shimmie probeSample pulls id + preview_url out of the first <post> element
     <post id="5678" md5="deadbeef" preview_url="/t/5678.jpg" tags="foo bar"/>
   </posts>`;
   const sample = shimmieEngine.probeSample?.(xml);
-  assert.deepEqual(sample, { postId: '5678', thumbUrl: '/t/5678.jpg', postPath: '/post/view/5678' });
+  assert.deepEqual(sample, {
+    postId: '5678',
+    thumbUrl: '/t/5678.jpg',
+    postPath: '/post/view/5678'
+  });
 });
 
 test('shimmie extractIdFromUrl matches /post/view/{id}', () => {
-  const site = baseSite({ engine: 'shimmie', baseUrl: 'https://cascards.fluffyquack.com' });
+  const site = baseSite({
+    engine: 'shimmie',
+    baseUrl: 'https://cascards.fluffyquack.com'
+  });
   assert.deepEqual(
-    shimmieEngine.extractIdFromUrl('https://cascards.fluffyquack.com/post/view/42', site),
+    shimmieEngine.extractIdFromUrl(
+      'https://cascards.fluffyquack.com/post/view/42',
+      site
+    ),
     { remoteId: '42' }
   );
 });
@@ -222,7 +292,9 @@ test('shimmie extractIdFromUrl matches /post/view/{id}', () => {
 // --- probeSample on the original six engines ---------------------------
 
 test('e621 probeSample returns first post id + preview', () => {
-  const body = { posts: [{ id: 9, preview: { url: '/p/9.jpg' }, tags: { general: ['cat'] } }] };
+  const body = {
+    posts: [{ id: 9, preview: { url: '/p/9.jpg' }, tags: { general: ['cat'] } }]
+  };
   assert.deepEqual(e621Engine.probeSample?.(body), {
     postId: '9',
     thumbUrl: '/p/9.jpg',
@@ -231,7 +303,9 @@ test('e621 probeSample returns first post id + preview', () => {
 });
 
 test('danbooru probeSample returns first post id + preview_file_url', () => {
-  const body = [{ id: 1, preview_file_url: '/p/1.jpg', tag_string_general: 'cat' }];
+  const body = [
+    { id: 1, preview_file_url: '/p/1.jpg', tag_string_general: 'cat' }
+  ];
   assert.deepEqual(danbooruEngine.probeSample?.(body), {
     postId: '1',
     thumbUrl: '/p/1.jpg',
@@ -240,7 +314,9 @@ test('danbooru probeSample returns first post id + preview_file_url', () => {
 });
 
 test('philomena probeSample returns image id + thumb representation', () => {
-  const body = { images: [{ id: 42, representations: { thumb: '/t/42.jpg' }, tags: ['a'] }] };
+  const body = {
+    images: [{ id: 42, representations: { thumb: '/t/42.jpg' }, tags: ['a'] }]
+  };
   assert.deepEqual(philomenaEngine.probeSample?.(body), {
     postId: '42',
     thumbUrl: '/t/42.jpg',

--- a/backend/src/lib/booruEngines/gelbooru.test.ts
+++ b/backend/src/lib/booruEngines/gelbooru.test.ts
@@ -21,7 +21,9 @@ const setupMockAgent = (t: TestContext): MockAgent => {
   return agent;
 };
 
-const baseSite = (overrides: Partial<BooruSiteRecord> = {}): BooruSiteRecord => ({
+const baseSite = (
+  overrides: Partial<BooruSiteRecord> = {}
+): BooruSiteRecord => ({
   id: 'site-1',
   userId: 'user-1',
   name: 'TestBooru',
@@ -32,10 +34,6 @@ const baseSite = (overrides: Partial<BooruSiteRecord> = {}): BooruSiteRecord => 
   isPreset: false,
   presetKey: null,
   enabled: true,
-  capFavorites: true,
-  capTags: true,
-  capSourceMatch: true,
-  capSearch: true,
   sortOrder: 0,
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
@@ -54,7 +52,10 @@ const mockPool = (agent: MockAgent) => agent.get('https://gelbooru.com');
 
 test('fetchFavorites throws when credentials missing', async () => {
   const site = baseSite({ username: null, apiKey: null });
-  await assert.rejects(() => gelbooruEngine.fetchFavorites!(site), /credentials missing/);
+  await assert.rejects(
+    () => gelbooruEngine.fetchFavorites!(site),
+    /credentials missing/
+  );
 });
 
 test('fetchFavorites scrapes HTML and resolves each post via API', async (t) => {
@@ -69,10 +70,14 @@ test('fetchFavorites scrapes HTML and resolves each post via API', async (t) => 
     .reply(200, '');
   // API calls for each post id
   mockPool(agent)
-    .intercept({ path: (p: string) => p.includes('s=post') && p.includes('id=1') })
+    .intercept({
+      path: (p: string) => p.includes('s=post') && p.includes('id=1')
+    })
     .reply(200, postJson(1, 'https://img.gelbooru.com/1.jpg'));
   mockPool(agent)
-    .intercept({ path: (p: string) => p.includes('s=post') && p.includes('id=2') })
+    .intercept({
+      path: (p: string) => p.includes('s=post') && p.includes('id=2')
+    })
     .reply(200, postJson(2, 'https://img.gelbooru.com/2.jpg'));
 
   const result = await gelbooruEngine.fetchFavorites!(baseSite());
@@ -99,7 +104,10 @@ test('fetchFavorites throws when HTML page returns non-200', async (t) => {
     .intercept({ path: (p: string) => p.includes('page=favorites') })
     .reply(500, 'server error');
 
-  await assert.rejects(() => gelbooruEngine.fetchFavorites!(baseSite()), /favorites page failed.*500/);
+  await assert.rejects(
+    () => gelbooruEngine.fetchFavorites!(baseSite()),
+    /favorites page failed.*500/
+  );
 });
 
 test('fetchFavorites throws on JSON-string auth error from post API', async (t) => {
@@ -123,10 +131,14 @@ test('fetchFavorites skips a post when its API call fails (non-200)', async (t) 
     .intercept({ path: (p: string) => p.includes('page=favorites') })
     .reply(200, favHtmlPage([1, 2]));
   mockPool(agent)
-    .intercept({ path: (p: string) => p.includes('s=post') && p.includes('id=1') })
+    .intercept({
+      path: (p: string) => p.includes('s=post') && p.includes('id=1')
+    })
     .reply(404, 'not found');
   mockPool(agent)
-    .intercept({ path: (p: string) => p.includes('s=post') && p.includes('id=2') })
+    .intercept({
+      path: (p: string) => p.includes('s=post') && p.includes('id=2')
+    })
     .reply(200, postJson(2, 'https://img.gelbooru.com/2.jpg'));
 
   const result = await gelbooruEngine.fetchFavorites!(baseSite());
@@ -138,10 +150,15 @@ test('fetchFavorites scrapes HTML page with site.username (user_id) in URL', asy
   const agent = setupMockAgent(t);
   let capturedPath = '';
   mockPool(agent)
-    .intercept({ path: (p: string) => {
-      if (p.includes('page=favorites')) { capturedPath = p; return true; }
-      return false;
-    } })
+    .intercept({
+      path: (p: string) => {
+        if (p.includes('page=favorites')) {
+          capturedPath = p;
+          return true;
+        }
+        return false;
+      }
+    })
     .reply(200, '');
 
   await gelbooruEngine.fetchFavorites!(baseSite({ username: '4141023' }));
@@ -153,7 +170,8 @@ test('fetchFavorites aborts when signal fires before loop', async () => {
   const controller = new AbortController();
   controller.abort();
   await assert.rejects(
-    () => gelbooruEngine.fetchFavorites!(baseSite(), { signal: controller.signal }),
+    () =>
+      gelbooruEngine.fetchFavorites!(baseSite(), { signal: controller.signal }),
     /aborted/i
   );
 });
@@ -161,7 +179,12 @@ test('fetchFavorites aborts when signal fires before loop', async () => {
 test('unfavorite rejects a redirect to the favorites view', async (t) => {
   const agent = setupMockAgent(t);
   mockPool(agent)
-    .intercept({ path: (p: string) => p.includes('page=favorites') && p.includes('s=delete') && p.includes('id=123') })
+    .intercept({
+      path: (p: string) =>
+        p.includes('page=favorites') &&
+        p.includes('s=delete') &&
+        p.includes('id=123')
+    })
     .reply(302, '', {
       headers: {
         location: '/index.php?page=favorites&s=view&id='

--- a/backend/src/lib/booruEngines/index.ts
+++ b/backend/src/lib/booruEngines/index.ts
@@ -8,7 +8,11 @@ import { philomenaEngine } from './philomena';
 import { sankakuEngine } from './sankaku';
 import { shimmieEngine } from './shimmie';
 import { szurubooruEngine } from './szurubooru';
-import type { BooruEngineModule, EngineRegistry } from './types';
+import type {
+  BooruEngineModule,
+  EngineCapabilityDefaults,
+  EngineRegistry
+} from './types';
 
 export const ENGINE_REGISTRY: EngineRegistry = {
   danbooru: danbooruEngine,
@@ -21,14 +25,25 @@ export const ENGINE_REGISTRY: EngineRegistry = {
   szurubooru: szurubooruEngine
 };
 
-export const getEngine = (type: BooruEngineType | string): BooruEngineModule | null => {
+export const getEngine = (
+  type: BooruEngineType | string
+): BooruEngineModule | null => {
   if (Object.prototype.hasOwnProperty.call(ENGINE_REGISTRY, type)) {
     return ENGINE_REGISTRY[type as BooruEngineType];
   }
   return null;
 };
 
-export const listEngines = (): BooruEngineModule[] => Object.values(ENGINE_REGISTRY);
+export const listEngines = (): BooruEngineModule[] =>
+  Object.values(ENGINE_REGISTRY);
+
+// Capabilities are an inherent property of the engine, not a per-site setting.
+// Single source of truth for "can this site do X" — derived from the engine
+// module the site runs on. Unknown engine → no capabilities.
+export const engineSupports = (
+  engine: BooruEngineType | string,
+  capability: keyof EngineCapabilityDefaults
+): boolean => getEngine(engine)?.defaultCapabilities[capability] ?? false;
 
 export * from './types';
 export {

--- a/backend/src/lib/booruEngines/presets.ts
+++ b/backend/src/lib/booruEngines/presets.ts
@@ -5,84 +5,58 @@ export type BooruPreset = {
   name: string;
   engine: BooruEngineType;
   baseUrl: string;
-  defaultCapabilities: {
-    favorites: boolean;
-    tags: boolean;
-    sourceMatch: boolean;
-    search: boolean;
-  };
 };
 
 export const BOORU_PRESETS: BooruPreset[] = [
-  {
-    key: 'E621',
-    name: 'e621',
-    engine: 'e621',
-    baseUrl: 'https://e621.net',
-    defaultCapabilities: { favorites: true, tags: true, sourceMatch: true, search: true }
-  },
-  {
-    key: 'E926',
-    name: 'e926',
-    engine: 'e621',
-    baseUrl: 'https://e926.net',
-    defaultCapabilities: { favorites: true, tags: true, sourceMatch: true, search: true }
-  },
+  { key: 'E621', name: 'e621', engine: 'e621', baseUrl: 'https://e621.net' },
+  { key: 'E926', name: 'e926', engine: 'e621', baseUrl: 'https://e926.net' },
   {
     key: 'DANBOORU',
     name: 'Danbooru',
     engine: 'danbooru',
-    baseUrl: 'https://danbooru.donmai.us',
-    defaultCapabilities: { favorites: true, tags: true, sourceMatch: true, search: true }
+    baseUrl: 'https://danbooru.donmai.us'
   },
   {
     key: 'GELBOORU',
     name: 'Gelbooru',
     engine: 'gelbooru',
-    baseUrl: 'https://gelbooru.com',
-    defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true }
+    baseUrl: 'https://gelbooru.com'
   },
   {
     key: 'RULE34',
     name: 'Rule34',
     engine: 'gelbooru',
-    baseUrl: 'https://rule34.xxx',
-    defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true }
+    baseUrl: 'https://rule34.xxx'
   },
   {
     key: 'YANDERE',
     name: 'yande.re',
     engine: 'moebooru',
-    baseUrl: 'https://yande.re',
-    defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true }
+    baseUrl: 'https://yande.re'
   },
   {
     key: 'KONACHAN',
     name: 'Konachan',
     engine: 'moebooru',
-    baseUrl: 'https://konachan.com',
-    defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true }
+    baseUrl: 'https://konachan.com'
   },
   {
     key: 'SANKAKU',
     name: 'Sankaku Channel',
     engine: 'sankaku',
-    baseUrl: 'https://chan.sankakucomplex.com',
-    defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true }
+    baseUrl: 'https://chan.sankakucomplex.com'
   },
   {
     key: 'IDOL_COMPLEX',
     name: 'Idol Complex',
     engine: 'sankaku',
-    baseUrl: 'https://idol.sankakucomplex.com',
-    defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true }
+    baseUrl: 'https://idol.sankakucomplex.com'
   },
   {
     key: 'DERPIBOORU',
     name: 'Derpibooru',
     engine: 'philomena',
-    baseUrl: 'https://derpibooru.org',
-    defaultCapabilities: { favorites: false, tags: true, sourceMatch: true, search: true }
+    baseUrl: 'https://derpibooru.org'
   }
 ];
 

--- a/backend/src/lib/booruSitesSeed.test.ts
+++ b/backend/src/lib/booruSitesSeed.test.ts
@@ -14,24 +14,36 @@ import { seedBooruSitesFromLegacyCredentials } from './booruSitesSeed';
 
 test('seedBooruSitesFromLegacyCredentials creates preset rows from existing E621/DANBOORU credentials', async () => {
   const seeded = await seedUser({ username: 'seed-from-creds' });
-  await authRepo.upsertCredential('E621', { username: 'e621-user', apiKey: 'e621-key' }, seeded.user.id);
-  await authRepo.upsertCredential('DANBOORU', { username: 'db-user', apiKey: 'db-key' }, seeded.user.id);
+  await authRepo.upsertCredential(
+    'E621',
+    { username: 'e621-user', apiKey: 'e621-key' },
+    seeded.user.id
+  );
+  await authRepo.upsertCredential(
+    'DANBOORU',
+    { username: 'db-user', apiKey: 'db-key' },
+    seeded.user.id
+  );
 
   const result = await seedBooruSitesFromLegacyCredentials();
   assert.ok(result.scannedUsers >= 1);
   assert.ok(result.insertedRows >= 2);
 
-  const e621 = await booruSitesRepo.findBooruSiteByPresetKey('E621', seeded.user.id);
+  const e621 = await booruSitesRepo.findBooruSiteByPresetKey(
+    'E621',
+    seeded.user.id
+  );
   assert.ok(e621);
   assert.equal(e621!.engine, 'e621');
   assert.equal(e621!.baseUrl, 'https://e621.net');
   assert.equal(e621!.username, 'e621-user');
   assert.equal(e621!.apiKey, 'e621-key');
   assert.equal(e621!.isPreset, true);
-  assert.equal(e621!.capFavorites, true);
-  assert.equal(e621!.capTags, true);
 
-  const danbooru = await booruSitesRepo.findBooruSiteByPresetKey('DANBOORU', seeded.user.id);
+  const danbooru = await booruSitesRepo.findBooruSiteByPresetKey(
+    'DANBOORU',
+    seeded.user.id
+  );
   assert.ok(danbooru);
   assert.equal(danbooru!.username, 'db-user');
   assert.equal(danbooru!.apiKey, 'db-key');
@@ -39,22 +51,37 @@ test('seedBooruSitesFromLegacyCredentials creates preset rows from existing E621
 
 test('seedBooruSitesFromLegacyCredentials is idempotent — second run inserts zero rows for already-seeded user', async () => {
   const seeded = await seedUser({ username: 'seed-idempotent' });
-  await authRepo.upsertCredential('E621', { username: 'u', apiKey: 'k' }, seeded.user.id);
+  await authRepo.upsertCredential(
+    'E621',
+    { username: 'u', apiKey: 'k' },
+    seeded.user.id
+  );
 
   const first = await seedBooruSitesFromLegacyCredentials();
   const firstInserted = first.insertedRows;
   const second = await seedBooruSitesFromLegacyCredentials();
   // The second call must not touch rows for users already seeded.
-  assert.ok(second.insertedRows < firstInserted, `expected second-pass inserts to drop, got ${second.insertedRows} vs ${firstInserted}`);
+  assert.ok(
+    second.insertedRows < firstInserted,
+    `expected second-pass inserts to drop, got ${second.insertedRows} vs ${firstInserted}`
+  );
 
   const sites = await booruSitesRepo.listBooruSites(seeded.user.id);
   const e621Sites = sites.filter((site) => site.presetKey === 'E621');
-  assert.equal(e621Sites.length, 1, 'should never produce duplicate preset rows for one user');
+  assert.equal(
+    e621Sites.length,
+    1,
+    'should never produce duplicate preset rows for one user'
+  );
 });
 
 test('seedBooruSitesFromLegacyCredentials skips SAUCENAO credentials (not a booru)', async () => {
   const seeded = await seedUser({ username: 'seed-saucenao-only' });
-  await authRepo.upsertCredential('SAUCENAO', { apiKey: 'sn-key' }, seeded.user.id);
+  await authRepo.upsertCredential(
+    'SAUCENAO',
+    { apiKey: 'sn-key' },
+    seeded.user.id
+  );
 
   await seedBooruSitesFromLegacyCredentials();
   const sites = await booruSitesRepo.listBooruSites(seeded.user.id);

--- a/backend/src/lib/booruSitesSeed.ts
+++ b/backend/src/lib/booruSitesSeed.ts
@@ -41,10 +41,6 @@ export const seedBooruSitesFromLegacyCredentials = async (): Promise<{
         isPreset: true,
         presetKey: preset.key,
         enabled: true,
-        capFavorites: preset.defaultCapabilities.favorites,
-        capTags: preset.defaultCapabilities.tags,
-        capSourceMatch: preset.defaultCapabilities.sourceMatch,
-        capSearch: preset.defaultCapabilities.search,
         siteAutoSyncMidnight: siteDefaults.siteAutoSyncMidnight,
         siteReverseSyncEnabled: siteDefaults.siteReverseSyncEnabled,
         siteAutoFavEnabled: siteDefaults.siteAutoFavEnabled

--- a/backend/src/lib/booruSitesStore.test.ts
+++ b/backend/src/lib/booruSitesStore.test.ts
@@ -21,11 +21,7 @@ test('deleteBooruSite purges favorite_items rows owned by the deleted custom sit
       baseUrl: 'https://my.example.com',
       isPreset: false,
       presetKey: null,
-      enabled: true,
-      capFavorites: true,
-      capTags: true,
-      capSourceMatch: true,
-      capSearch: false
+      enabled: true
     },
     seeded.user.id
   );
@@ -69,11 +65,7 @@ test('deleteBooruSite deletes preset row and purges preset-key favorites', async
       baseUrl: 'https://e621.net',
       isPreset: true,
       presetKey: 'E621',
-      enabled: true,
-      capFavorites: true,
-      capTags: true,
-      capSourceMatch: true,
-      capSearch: false
+      enabled: true
     },
     seeded.user.id
   );
@@ -111,11 +103,7 @@ test('updateBooruSite persists preset flags when explicitly changed', async () =
       baseUrl: 'https://custom.example.com',
       isPreset: false,
       presetKey: null,
-      enabled: true,
-      capFavorites: true,
-      capTags: true,
-      capSourceMatch: true,
-      capSearch: true
+      enabled: true
     },
     seeded.user.id
   );
@@ -140,11 +128,7 @@ test("deleteBooruSite does not touch another user's favorites that share a remot
       baseUrl: 'https://a.example.com',
       isPreset: false,
       presetKey: null,
-      enabled: true,
-      capFavorites: true,
-      capTags: true,
-      capSourceMatch: true,
-      capSearch: false
+      enabled: true
     },
     a.user.id
   );

--- a/backend/src/lib/favoriteSourceMatch.test.ts
+++ b/backend/src/lib/favoriteSourceMatch.test.ts
@@ -20,10 +20,6 @@ const siteFixture = (overrides: Partial<BooruSiteRecord>): BooruSiteRecord => ({
   isPreset: false,
   presetKey: null,
   enabled: true,
-  capFavorites: false,
-  capTags: false,
-  capSourceMatch: true,
-  capSearch: false,
   sortOrder: 0,
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
@@ -31,8 +27,16 @@ const siteFixture = (overrides: Partial<BooruSiteRecord>): BooruSiteRecord => ({
 });
 
 test('extractFavoriteRemoteFromSiteList resolves canonical e621 URL to its preset site', () => {
-  const e621 = siteFixture({ engine: 'e621', baseUrl: 'https://e621.net', isPreset: true, presetKey: 'E621' });
-  const result = extractFavoriteRemoteFromSiteList('https://e621.net/posts/42', [e621]);
+  const e621 = siteFixture({
+    engine: 'e621',
+    baseUrl: 'https://e621.net',
+    isPreset: true,
+    presetKey: 'E621'
+  });
+  const result = extractFavoriteRemoteFromSiteList(
+    'https://e621.net/posts/42',
+    [e621]
+  );
   assert.ok(result);
   assert.equal(result!.provider, e621.id);
   assert.equal(result!.remoteId, '42');
@@ -46,21 +50,26 @@ test('extractFavoriteRemoteFromSiteList resolves danbooru URL to danbooru site',
     isPreset: true,
     presetKey: 'DANBOORU'
   });
-  const result = extractFavoriteRemoteFromSiteList('https://danbooru.donmai.us/posts/777', [danbooru]);
+  const result = extractFavoriteRemoteFromSiteList(
+    'https://danbooru.donmai.us/posts/777',
+    [danbooru]
+  );
   assert.ok(result);
   assert.equal(result!.remoteId, '777');
   assert.equal(result!.site.engine, 'danbooru');
 });
 
-test('extractFavoriteRemoteFromSiteList skips sites with capSourceMatch=false', () => {
-  const e621 = siteFixture({
-    engine: 'e621',
-    baseUrl: 'https://e621.net',
-    capSourceMatch: false
+test('extractFavoriteRemoteFromSiteList skips sites whose engine is unrecognized', () => {
+  const site = siteFixture({
+    engine: 'made-up-engine' as BooruEngineType,
+    baseUrl: 'https://e621.net'
   });
-  // Even though the URL belongs to e621, the user has disabled URL matching
-  // for this site, so it must not produce a hit.
-  assert.equal(extractFavoriteRemoteFromSiteList('https://e621.net/posts/1', [e621]), null);
+  // Source matching is an engine capability; an unknown engine supports
+  // nothing, so even a URL that looks like e621 must not produce a hit.
+  assert.equal(
+    extractFavoriteRemoteFromSiteList('https://e621.net/posts/1', [site]),
+    null
+  );
 });
 
 test('extractFavoriteRemoteFromSiteList skips disabled sites', () => {
@@ -69,12 +78,18 @@ test('extractFavoriteRemoteFromSiteList skips disabled sites', () => {
     baseUrl: 'https://e621.net',
     enabled: false
   });
-  assert.equal(extractFavoriteRemoteFromSiteList('https://e621.net/posts/1', [e621]), null);
+  assert.equal(
+    extractFavoriteRemoteFromSiteList('https://e621.net/posts/1', [e621]),
+    null
+  );
 });
 
 test('extractFavoriteRemoteFromSiteList returns null for URLs no configured site claims', () => {
   const e621 = siteFixture({ engine: 'e621', baseUrl: 'https://e621.net' });
-  assert.equal(extractFavoriteRemoteFromSiteList('https://example.com/post/1', [e621]), null);
+  assert.equal(
+    extractFavoriteRemoteFromSiteList('https://example.com/post/1', [e621]),
+    null
+  );
 });
 
 test('extractFavoriteRemoteFromSiteList prefers earlier sortOrder when two sites could match', () => {
@@ -93,7 +108,10 @@ test('extractFavoriteRemoteFromSiteList prefers earlier sortOrder when two sites
     baseUrl: 'https://e926.net',
     sortOrder: 1
   });
-  const result = extractFavoriteRemoteFromSiteList('https://e621.net/posts/9', [second, first]);
+  const result = extractFavoriteRemoteFromSiteList('https://e621.net/posts/9', [
+    second,
+    first
+  ]);
   assert.ok(result);
   assert.equal(result!.site.id, 'first');
 });

--- a/backend/src/lib/favoriteSourceMatch.ts
+++ b/backend/src/lib/favoriteSourceMatch.ts
@@ -1,19 +1,25 @@
 import type { BooruSiteRecord, FavoriteProvider } from '../db/types';
 
-import { getEngine } from './booruEngines';
+import { engineSupports, getEngine } from './booruEngines';
 
 // Per-user URL matcher built from the caller's `user_booru_sites` rows. Only
-// considers sites with `capSourceMatch = true` and `enabled = true`, in
+// considers `enabled = true` sites whose engine supports source matching, in
 // ascending `sortOrder`. Returns the site id as the `provider` value so the
 // caller can persist a `favorite_items.provider = site.id` row that uniquely
 // identifies which configured site originated the match.
 export const extractFavoriteRemoteFromSiteList = (
   sourceUrl: string | null | undefined,
   sites: BooruSiteRecord[]
-): { provider: FavoriteProvider; remoteId: string; site: BooruSiteRecord } | null => {
+): {
+  provider: FavoriteProvider;
+  remoteId: string;
+  site: BooruSiteRecord;
+} | null => {
   if (!sourceUrl) return null;
   const ordered = [...sites]
-    .filter((site) => site.enabled && site.capSourceMatch)
+    .filter(
+      (site) => site.enabled && engineSupports(site.engine, 'sourceMatch')
+    )
     .sort((a, b) => a.sortOrder - b.sortOrder);
   for (const site of ordered) {
     const engine = getEngine(site.engine);

--- a/backend/src/routes/booruSites.ts
+++ b/backend/src/routes/booruSites.ts
@@ -26,10 +26,6 @@ const createSchema = z.object({
   baseUrl: z.string().url(),
   username: z.string().optional().nullable(),
   apiKey: z.string().optional().nullable(),
-  capFavorites: z.boolean().optional(),
-  capTags: z.boolean().optional(),
-  capSourceMatch: z.boolean().optional(),
-  capSearch: z.boolean().optional(),
   siteAutoSyncMidnight: z.boolean().optional(),
   siteReverseSyncEnabled: z.boolean().optional(),
   siteAutoFavEnabled: z.boolean().optional(),
@@ -41,10 +37,6 @@ const updateSchema = z.object({
   username: z.string().nullable().optional(),
   apiKey: z.string().nullable().optional(),
   enabled: z.boolean().optional(),
-  capFavorites: z.boolean().optional(),
-  capTags: z.boolean().optional(),
-  capSourceMatch: z.boolean().optional(),
-  capSearch: z.boolean().optional(),
   siteAutoSyncMidnight: z.boolean().optional(),
   siteReverseSyncEnabled: z.boolean().optional(),
   siteAutoFavEnabled: z.boolean().optional(),
@@ -77,10 +69,6 @@ const toPublic = (site: BooruSiteRecord) => ({
   isPreset: site.isPreset,
   presetKey: site.presetKey,
   enabled: site.enabled,
-  capFavorites: site.capFavorites,
-  capTags: site.capTags,
-  capSourceMatch: site.capSourceMatch,
-  capSearch: site.capSearch,
   siteAutoSyncMidnight: site.siteAutoSyncMidnight,
   siteReverseSyncEnabled: site.siteReverseSyncEnabled,
   siteAutoFavEnabled: site.siteAutoFavEnabled,
@@ -162,8 +150,7 @@ export const registerBooruSiteRoutes = (app: FastifyInstance) => {
       key: preset.key,
       name: preset.name,
       engine: preset.engine,
-      baseUrl: preset.baseUrl,
-      defaultCapabilities: preset.defaultCapabilities
+      baseUrl: preset.baseUrl
     }))
   }));
 
@@ -227,7 +214,6 @@ export const registerBooruSiteRoutes = (app: FastifyInstance) => {
         error: 'A site with this base URL already exists for this account'
       };
     }
-    const capDefaults = engine.defaultCapabilities;
     const site = await booruSitesRepo.insertBooruSite(
       {
         name: parsed.data.name,
@@ -238,10 +224,6 @@ export const registerBooruSiteRoutes = (app: FastifyInstance) => {
         isPreset: false,
         presetKey: null,
         enabled: parsed.data.enabled ?? true,
-        capFavorites: parsed.data.capFavorites ?? capDefaults.favorites,
-        capTags: parsed.data.capTags ?? capDefaults.tags,
-        capSourceMatch: parsed.data.capSourceMatch ?? capDefaults.sourceMatch,
-        capSearch: parsed.data.capSearch ?? capDefaults.search,
         siteAutoSyncMidnight: parsed.data.siteAutoSyncMidnight ?? false,
         siteReverseSyncEnabled: parsed.data.siteReverseSyncEnabled ?? false,
         siteAutoFavEnabled: parsed.data.siteAutoFavEnabled ?? false

--- a/backend/src/services/credentials.test.ts
+++ b/backend/src/services/credentials.test.ts
@@ -28,7 +28,11 @@ test('resolveCredential returns "none" when the user has no stored credential', 
 
 test('resolveCredential returns "db" source when a credential exists', async () => {
   const seeded = await seedUser({ username: 'cred_set' });
-  await authRepo.upsertCredential('E621', { username: 'alice', apiKey: 'secret' }, seeded.user.id);
+  await authRepo.upsertCredential(
+    'E621',
+    { username: 'alice', apiKey: 'secret' },
+    seeded.user.id
+  );
   const result = await resolveCredential('E621', seeded.user.id);
   assert.equal(result.source, 'db');
   assert.equal(result.username, 'alice');
@@ -40,13 +44,20 @@ test('resolveCredentials preserves provider order', async () => {
   const seeded = await seedUser({ username: 'cred_order' });
   const providers = ['SAUCENAO', 'E621', 'DANBOORU'] as const;
   const result = await resolveCredentials([...providers], seeded.user.id);
-  assert.deepEqual(result.map((r) => r.provider), [...providers]);
+  assert.deepEqual(
+    result.map((r) => r.provider),
+    [...providers]
+  );
 });
 
 test('resolveCredentials isolates one user from another', async () => {
   const alice = await seedUser({ username: 'cred_alice' });
   const bob = await seedUser({ username: 'cred_bob' });
-  await authRepo.upsertCredential('SAUCENAO', { username: 'alice@s', apiKey: 'A' }, alice.user.id);
+  await authRepo.upsertCredential(
+    'SAUCENAO',
+    { username: 'alice@s', apiKey: 'A' },
+    alice.user.id
+  );
   const bobResult = await resolveCredential('SAUCENAO', bob.user.id);
   // Bob never saved a credential; Alice's must NOT leak.
   assert.equal(bobResult.source, 'none');
@@ -55,7 +66,11 @@ test('resolveCredentials isolates one user from another', async () => {
 
 test('resolveCredential falls back to legacy provider_credentials when preset row has empty credentials', async () => {
   const seeded = await seedUser({ username: 'cred_legacy_fallback' });
-  await authRepo.upsertCredential('E621', { username: 'legacy-user', apiKey: 'legacy-key' }, seeded.user.id);
+  await authRepo.upsertCredential(
+    'E621',
+    { username: 'legacy-user', apiKey: 'legacy-key' },
+    seeded.user.id
+  );
 
   const { booruSitesRepo } = await import('../db/repos/booruSitesRepo');
   await booruSitesRepo.insertBooruSite(
@@ -67,11 +82,7 @@ test('resolveCredential falls back to legacy provider_credentials when preset ro
       apiKey: null,
       isPreset: true,
       presetKey: 'E621',
-      enabled: true,
-      capFavorites: true,
-      capTags: true,
-      capSourceMatch: true,
-      capSearch: false
+      enabled: true
     },
     seeded.user.id
   );

--- a/backend/src/services/credentials.ts
+++ b/backend/src/services/credentials.ts
@@ -127,10 +127,6 @@ export const upsertCredentialCompat = async (
         isPreset: true,
         presetKey: preset.key,
         enabled: true,
-        capFavorites: preset.defaultCapabilities.favorites,
-        capTags: preset.defaultCapabilities.tags,
-        capSourceMatch: preset.defaultCapabilities.sourceMatch,
-        capSearch: preset.defaultCapabilities.search,
         siteAutoSyncMidnight: siteDefaults.siteAutoSyncMidnight,
         siteReverseSyncEnabled: siteDefaults.siteReverseSyncEnabled,
         siteAutoFavEnabled: siteDefaults.siteAutoFavEnabled

--- a/backend/src/services/favorites.test.ts
+++ b/backend/src/services/favorites.test.ts
@@ -77,10 +77,6 @@ test('autoFavoriteFromSauce skips when matched site has auto-fav disabled', asyn
         isPreset: true,
         presetKey: 'E621',
         enabled: true,
-        capFavorites: true,
-        capTags: true,
-        capSourceMatch: true,
-        capSearch: false,
         siteAutoFavEnabled: false
       },
       seeded.user.id
@@ -152,10 +148,6 @@ test('autoFavoriteFromSauce skips and does NOT touch network when already marked
         isPreset: true,
         presetKey: 'E621',
         enabled: true,
-        capFavorites: true,
-        capTags: true,
-        capSourceMatch: true,
-        capSearch: false,
         siteAutoFavEnabled: false
       },
       seeded.user.id

--- a/backend/src/services/favorites.ts
+++ b/backend/src/services/favorites.ts
@@ -17,7 +17,7 @@ import type {
   FavoriteItemRecord,
   FileRecord
 } from '../db/types';
-import { getEngine } from '../lib/booruEngines';
+import { engineSupports, getEngine } from '../lib/booruEngines';
 import { extractFavoriteRemoteFromSiteList } from '../lib/favoriteSourceMatch';
 import { ensureDirectoryWritable } from '../lib/fsAccess';
 import { scanLocalFile } from '../lib/scanner';
@@ -46,7 +46,11 @@ const loadFavoriteSyncableSites = async (
 ): Promise<BooruSiteRecord[]> => {
   const sites = await booruSitesRepo.listBooruSites(userId);
   return sites.filter(
-    (site) => site.enabled && site.capFavorites && site.username && site.apiKey
+    (site) =>
+      site.enabled &&
+      engineSupports(site.engine, 'favorites') &&
+      site.username &&
+      site.apiKey
   );
 };
 
@@ -486,13 +490,15 @@ export const autoFavoriteFromSauce = async (
   const userId = await resolveFileUserIdSafe(file);
   if (!userId) return { status: 'skipped', reason: 'no-owner' };
 
-  // Match URL against every site that opted into source-match (cap_source_match).
+  // Match URL against every site whose engine supports source matching.
   // Don't pre-filter by favorites capability or credentials here: the
   // already-marked short-circuit below must fire even when the site is
   // disabled / missing creds, otherwise reverse-sync / repeated scans would
   // get the wrong outcome.
   const allSites = await booruSitesRepo.listBooruSites(userId);
-  const matchSites = allSites.filter((site) => site.capSourceMatch);
+  const matchSites = allSites.filter((site) =>
+    engineSupports(site.engine, 'sourceMatch')
+  );
   const remote = await findBestFavoritableMatch(file.id, matchSites);
   if (!remote) return { status: 'skipped', reason: 'no-supported-match' };
 
@@ -515,7 +521,7 @@ export const autoFavoriteFromSauce = async (
   if (!targetSite.siteAutoFavEnabled) {
     return { status: 'skipped', reason: 'disabled' };
   }
-  if (!targetSite.capFavorites) {
+  if (!engineSupports(targetSite.engine, 'favorites')) {
     return { status: 'skipped', reason: 'favorites-capability-disabled' };
   }
   if (!targetSite.username || !targetSite.apiKey) {

--- a/backend/src/services/tagging.ts
+++ b/backend/src/services/tagging.ts
@@ -11,13 +11,9 @@ import { config } from '../config';
 import { authRepo } from '../db/repos/authRepo';
 import { booruSitesRepo } from '../db/repos/booruSitesRepo';
 import { filesRepo } from '../db/repos/filesRepo';
-import {
-  BooruSiteRecord,
-  SPECIAL_TAG_SOURCES,
-  TagSource
-} from '../db/types';
+import { BooruSiteRecord, SPECIAL_TAG_SOURCES, TagSource } from '../db/types';
 import type { FileRecord, ProviderRunRecord } from '../db/types';
-import { getEngine } from '../lib/booruEngines';
+import { engineSupports, getEngine } from '../lib/booruEngines';
 
 type TagCandidate = {
   site: BooruSiteRecord;
@@ -27,7 +23,8 @@ type TagCandidate = {
   score: number;
 };
 
-const tagSourceForSite = (site: BooruSiteRecord): TagSource => site.presetKey ?? site.id;
+const tagSourceForSite = (site: BooruSiteRecord): TagSource =>
+  site.presetKey ?? site.id;
 
 type TagResult = {
   tag: string;
@@ -94,8 +91,9 @@ const resolveSiteFromName = (
 };
 
 // Per-user, engine-driven URL → site resolver. Replaces the static
-// e621Regex/danbooruRegex/... cascade. Iterates user's `cap_tags=true` sites
-// in sort order and asks each engine if the URL belongs to it.
+// e621Regex/danbooruRegex/... cascade. Iterates the user's enabled sites
+// whose engine supports tag fetch, in sort order, and asks each engine if
+// the URL belongs to it.
 const resolveTagCandidate = (
   url: string | null | undefined,
   score: number,
@@ -103,7 +101,7 @@ const resolveTagCandidate = (
   sites: BooruSiteRecord[]
 ): TagCandidate | null => {
   const eligible = sites
-    .filter((site) => site.enabled && site.capTags)
+    .filter((site) => site.enabled && engineSupports(site.engine, 'tags'))
     .sort((a, b) => a.sortOrder - b.sortOrder);
 
   if (url) {
@@ -119,7 +117,9 @@ const resolveTagCandidate = (
     // "Index #29: e621") then look up the post by md5 on that site.
     const md5 = resolveMd5(url) ?? resolveMd5(sourceName ?? null);
     if (md5) {
-      const site = sourceName ? resolveSiteFromName(sourceName, eligible) : null;
+      const site = sourceName
+        ? resolveSiteFromName(sourceName, eligible)
+        : null;
       if (site) {
         return { site, id: md5, idKind: 'MD5', url, score };
       }
@@ -137,7 +137,10 @@ const resolveTagCandidate = (
 
 // Tag parsing moved into engine modules (lib/booruEngines).
 
-const extractCandidates = (run: ProviderRunRecord, sites: BooruSiteRecord[]): TagCandidate[] => {
+const extractCandidates = (
+  run: ProviderRunRecord,
+  sites: BooruSiteRecord[]
+): TagCandidate[] => {
   const minScore = providerScoreThresholds[run.provider] ?? 0;
   const results =
     run.results && run.results.length
@@ -151,7 +154,8 @@ const extractCandidates = (run: ProviderRunRecord, sites: BooruSiteRecord[]): Ta
     const score = resolveCandidateScore(run, result);
     if (score < minScore) continue;
     const url = result.sourceUrl ?? null;
-    const sourceName = (result as { sourceName?: string | null }).sourceName ?? null;
+    const sourceName =
+      (result as { sourceName?: string | null }).sourceName ?? null;
     const candidate = resolveTagCandidate(url, score, sourceName, sites);
     if (!candidate) continue;
     const key = tagSourceForSite(candidate.site);
@@ -164,7 +168,10 @@ const extractCandidates = (run: ProviderRunRecord, sites: BooruSiteRecord[]): Ta
   return Array.from(picks.values());
 };
 
-const collectCandidatesFromRuns = (runs: ProviderRunRecord[], sites: BooruSiteRecord[]) => {
+const collectCandidatesFromRuns = (
+  runs: ProviderRunRecord[],
+  sites: BooruSiteRecord[]
+) => {
   const picks = new Map<string, TagCandidate>();
   for (const run of runs) {
     if (run.status !== 'COMPLETED') continue;
@@ -197,7 +204,10 @@ const fetchTagsBySite = async (
     return result ?? { tags: [], sourceUrl: null };
   }
   const tags = await engine.fetchPostTags(site, candidate.id);
-  return { tags, sourceUrl: candidate.url || engine.buildPostUrl(site, candidate.id) };
+  return {
+    tags,
+    sourceUrl: candidate.url || engine.buildPostUrl(site, candidate.id)
+  };
 };
 
 const resolveLocalPath = async (file: FileRecord) => {
@@ -208,7 +218,11 @@ const runWd14Tagger = async (imagePath: string) => {
   const normalized = await sharp(imagePath).rotate().png().toBuffer();
   const imageBytes = Uint8Array.from(normalized);
   const form = new FormData();
-  form.set('file', new Blob([imageBytes], { type: 'image/png' }), `${path.parse(imagePath).name}.png`);
+  form.set(
+    'file',
+    new Blob([imageBytes], { type: 'image/png' }),
+    `${path.parse(imagePath).name}.png`
+  );
   const res = await fetch(`${config.tagger.url}/tag`, {
     method: 'POST',
     body: form
@@ -221,7 +235,9 @@ const runWd14Tagger = async (imagePath: string) => {
 };
 
 const extractVideoFrames = async (filePath: string, count: number) => {
-  const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'imagesearch-frames-'));
+  const tmp = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'imagesearch-frames-')
+  );
   const durationSeconds = await new Promise<number>((resolve) => {
     ffprobe(filePath, (err, data) => {
       if (err) {
@@ -233,7 +249,9 @@ const extractVideoFrames = async (filePath: string, count: number) => {
   });
   const stamps =
     durationSeconds > 0
-      ? Array.from({ length: count }, (_, idx) => ((durationSeconds * (idx + 1)) / (count + 1)).toFixed(2))
+      ? Array.from({ length: count }, (_, idx) =>
+          ((durationSeconds * (idx + 1)) / (count + 1)).toFixed(2)
+        )
       : ['1'];
   await new Promise<void>((resolve, reject) => {
     ffmpeg(filePath)
@@ -270,8 +288,13 @@ const extractVideoFrames = async (filePath: string, count: number) => {
   };
 };
 
-const mergeTagScores = (sets: { tag: string; score: number; category: string }[][]) => {
-  const map = new Map<string, { tag: string; score: number; category: string }>();
+const mergeTagScores = (
+  sets: { tag: string; score: number; category: string }[][]
+) => {
+  const map = new Map<
+    string,
+    { tag: string; score: number; category: string }
+  >();
   for (const tags of sets) {
     for (const item of tags) {
       const key = `${item.category}:${item.tag}`;
@@ -293,7 +316,8 @@ const dedupeTags = (tags: TagResult[]) => {
       map.set(key, item);
       continue;
     }
-    const existingScore = typeof existing.score === 'number' ? existing.score : -Infinity;
+    const existingScore =
+      typeof existing.score === 'number' ? existing.score : -Infinity;
     const nextScore = typeof item.score === 'number' ? item.score : -Infinity;
     if (nextScore > existingScore) {
       map.set(key, { ...existing, ...item });
@@ -306,7 +330,12 @@ const dedupeTags = (tags: TagResult[]) => {
   return Array.from(map.values());
 };
 
-const replaceTags = async (fileId: string, source: TagSource, tags: TagResult[], sourceUrl?: string) => {
+const replaceTags = async (
+  fileId: string,
+  source: TagSource,
+  tags: TagResult[],
+  sourceUrl?: string
+) => {
   const uniqueTags = dedupeTags(tags);
   await filesRepo.replaceTagsForSource(
     fileId,
@@ -333,7 +362,8 @@ export const applyRemotePostTags = async (
   const userId = await resolveFileUserId(file.id);
   if (!userId) return { applied: false, count: 0 };
   const byId = await booruSitesRepo.getBooruSite(provider, userId);
-  const site = byId ?? (await booruSitesRepo.findBooruSiteByPresetKey(provider, userId));
+  const site =
+    byId ?? (await booruSitesRepo.findBooruSiteByPresetKey(provider, userId));
   if (!site) return { applied: false, count: 0 };
   const engine = getEngine(site.engine);
   if (!engine) return { applied: false, count: 0 };
@@ -347,24 +377,37 @@ export const applyRemotePostTags = async (
 const applyCandidateTags = async (fileId: string, candidate: TagCandidate) => {
   const { tags, sourceUrl } = await fetchTagsBySite(candidate.site, candidate);
   if (!tags.length) return false;
-  await replaceTags(fileId, tagSourceForSite(candidate.site), tags, sourceUrl ?? candidate.url);
+  await replaceTags(
+    fileId,
+    tagSourceForSite(candidate.site),
+    tags,
+    sourceUrl ?? candidate.url
+  );
   return true;
 };
 
-const applyCombinedTags = async (file: FileRecord, candidates: TagCandidate[]) => {
+const applyCombinedTags = async (
+  file: FileRecord,
+  candidates: TagCandidate[]
+) => {
   for (const candidate of candidates) {
     await applyCandidateTags(file.id, candidate);
   }
   await ensureWd14Tags(file, file.mediaType === 'VIDEO', { force: true });
 };
 
-const loadTagSitesForFile = async (file: FileRecord): Promise<BooruSiteRecord[]> => {
+const loadTagSitesForFile = async (
+  file: FileRecord
+): Promise<BooruSiteRecord[]> => {
   const userId = await resolveFileUserId(file.id);
   if (!userId) return [];
   return booruSitesRepo.listBooruSites(userId);
 };
 
-export const refreshTagsFromProviderRun = async (file: FileRecord, _run: ProviderRunRecord) => {
+export const refreshTagsFromProviderRun = async (
+  file: FileRecord,
+  _run: ProviderRunRecord
+) => {
   void _run;
   try {
     const sites = await loadTagSitesForFile(file);
@@ -372,7 +415,9 @@ export const refreshTagsFromProviderRun = async (file: FileRecord, _run: Provide
     const candidates = collectCandidatesFromRuns(runs, sites);
     await applyCombinedTags(file, candidates);
   } catch (err) {
-    console.warn(`[tags] refresh failed for ${file.id}: ${(err as Error).message}`);
+    console.warn(
+      `[tags] refresh failed for ${file.id}: ${(err as Error).message}`
+    );
   }
 };
 
@@ -388,7 +433,13 @@ export const ensureWd14Tags = async (
   const hasSourceTags = tags.some((tag) => !specialSources.has(tag.source));
   const hasWd14 = tags.some((tag) => tag.source === 'WD14');
   if (hasWd14 && !options?.force) return;
-  if (!forceForVideo && hasSourceTags && !options?.force && !options?.ignoreSourceTags) return;
+  if (
+    !forceForVideo &&
+    hasSourceTags &&
+    !options?.force &&
+    !options?.ignoreSourceTags
+  )
+    return;
 
   const resolved = await resolveLocalPath(file);
   if (!resolved) return;
@@ -396,7 +447,9 @@ export const ensureWd14Tags = async (
     if (file.mediaType === 'VIDEO') {
       const { frames, cleanup } = await extractVideoFrames(resolved.path, 3);
       try {
-        const results = await Promise.all(frames.map((frame) => runWd14Tagger(frame)));
+        const results = await Promise.all(
+          frames.map((frame) => runWd14Tagger(frame))
+        );
         const merged = mergeTagScores(results);
         await replaceTags(file.id, 'WD14', merged);
       } finally {
@@ -407,7 +460,9 @@ export const ensureWd14Tags = async (
       await replaceTags(file.id, 'WD14', tagsFromModel);
     }
   } catch (err) {
-    console.warn(`[tags] wd14 failed for ${file.id}: ${(err as Error).message}`);
+    console.warn(
+      `[tags] wd14 failed for ${file.id}: ${(err as Error).message}`
+    );
   } finally {
     await resolved.cleanup();
   }

--- a/backend/test/files.test.ts
+++ b/backend/test/files.test.ts
@@ -336,10 +336,6 @@ test('DELETE /files/:id reverse-syncs custom Gelbooru favorites', async (t) => {
       apiKey: 'testkey',
       isPreset: false,
       enabled: true,
-      capFavorites: true,
-      capTags: true,
-      capSourceMatch: true,
-      capSearch: true,
       siteReverseSyncEnabled: true
     },
     seeded.user.id
@@ -404,10 +400,6 @@ test('DELETE /files/:id reports Gelbooru unfavorite redirects', async (t) => {
       apiKey: 'testkey',
       isPreset: false,
       enabled: true,
-      capFavorites: true,
-      capTags: true,
-      capSourceMatch: true,
-      capSearch: true,
       siteReverseSyncEnabled: true
     },
     seeded.user.id

--- a/backend/test/migrate.test.ts
+++ b/backend/test/migrate.test.ts
@@ -245,5 +245,5 @@ test('migrate command upgrades legacy drizzle metadata to checksum + name withou
     site_reverse_sync_enabled: 1,
     site_auto_fav_enabled: 1
   });
-  assert.equal(count.count, 2);
+  assert.equal(count.count, 3);
 });

--- a/frontend/src/BooruSitesPanel.tsx
+++ b/frontend/src/BooruSitesPanel.tsx
@@ -1,19 +1,20 @@
 import { useCallback, useState } from 'react';
 
-import { type BooruCredentialSchema, type BooruSite } from './api';
+import {
+  type BooruCredentialSchema,
+  type BooruEngineType,
+  type BooruSite
+} from './api';
 
 import { BooruSiteCredentialForm } from '@/features/booru-sites/BooruSiteCredentialForm';
 import { AddBooruSiteForm } from '@/features/booru-sites/BooruSiteForms';
 import {
-  CAPABILITY_HELP_TEXT,
   SITE_SETTING_HELP_TEXT,
   SITE_SETTING_LABELS,
   SUGGESTION_PRESETS,
   type SiteSettingKey
 } from '@/features/booru-sites/BooruSitesPanelText';
 import {
-  CAPABILITY_LABELS,
-  type CapabilityKey,
   ENGINE_LABELS,
   credentialFieldsForSchema
 } from '@/features/booru-sites/shared';
@@ -77,20 +78,6 @@ export const BooruSitesPanel = ({
   const reload = async () => {
     setLocalError(null);
     await Promise.all([sitesQuery.refetch(), catalogQuery.refetch()]);
-  };
-
-  const toggleCapability = async (
-    site: BooruSite,
-    capability: CapabilityKey
-  ) => {
-    try {
-      await updateSiteMutation.mutateAsync({
-        id: site.id,
-        payload: { [capability]: !site[capability] }
-      });
-    } catch (err) {
-      setLocalError((err as Error).message);
-    }
   };
 
   const toggleEnabled = async (site: BooruSite) => {
@@ -348,26 +335,6 @@ export const BooruSitesPanel = ({
                     </div>
 
                     <div className="favorites-site-toggle-grid mt-2">
-                      {(Object.keys(CAPABILITY_LABELS) as CapabilityKey[]).map(
-                        (cap) => (
-                          <div key={cap} className="favorites-site-toggle-col">
-                            <div className="form-check form-switch favorites-site-switch">
-                              <input
-                                className="form-check-input"
-                                type="checkbox"
-                                id={`${site.id}-${cap}`}
-                                checked={site[cap]}
-                                onChange={() => toggleCapability(site, cap)}
-                              />
-                              {renderToggleLabel(
-                                `${site.id}-${cap}`,
-                                CAPABILITY_LABELS[cap],
-                                CAPABILITY_HELP_TEXT[cap]
-                              )}
-                            </div>
-                          </div>
-                        )
-                      )}
                       <div className="favorites-site-toggle-col">
                         <div className="form-check form-switch favorites-site-switch">
                           <input

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -193,10 +193,6 @@ export type BooruSite = {
   isPreset: boolean;
   presetKey: string | null;
   enabled: boolean;
-  capFavorites: boolean;
-  capTags: boolean;
-  capSourceMatch: boolean;
-  capSearch: boolean;
   siteAutoSyncMidnight: boolean;
   siteReverseSyncEnabled: boolean;
   siteAutoFavEnabled: boolean;
@@ -267,12 +263,6 @@ export type BooruEngineCatalog = {
     name: string;
     engine: BooruEngineType;
     baseUrl: string;
-    defaultCapabilities: {
-      favorites: boolean;
-      tags: boolean;
-      sourceMatch: boolean;
-      search: boolean;
-    };
   }>;
 };
 
@@ -774,10 +764,6 @@ export const api = {
     baseUrl: string;
     username?: string | null;
     apiKey?: string | null;
-    capFavorites?: boolean;
-    capTags?: boolean;
-    capSourceMatch?: boolean;
-    capSearch?: boolean;
     siteAutoSyncMidnight?: boolean;
     siteReverseSyncEnabled?: boolean;
     siteAutoFavEnabled?: boolean;
@@ -798,10 +784,6 @@ export const api = {
       username: string | null;
       apiKey: string | null;
       enabled: boolean;
-      capFavorites: boolean;
-      capTags: boolean;
-      capSourceMatch: boolean;
-      capSearch: boolean;
       siteAutoSyncMidnight: boolean;
       siteReverseSyncEnabled: boolean;
       siteAutoFavEnabled: boolean;

--- a/frontend/src/features/booru-sites/BooruSiteForms.tsx
+++ b/frontend/src/features/booru-sites/BooruSiteForms.tsx
@@ -50,12 +50,7 @@ export function AddBooruSiteForm({
       name: '',
       baseUrl: '',
       username: '',
-      apiKey: '',
-      capabilities: {
-        capFavorites: false,
-        capTags: true,
-        capSourceMatch: true
-      }
+      apiKey: ''
     }
   });
   const {
@@ -146,20 +141,6 @@ export function AddBooruSiteForm({
         if (requestSeq !== detectRequestSeq.current) return;
         setDetection(nextDetection);
         lastDetectedBaseUrl.current = normalized;
-        if ('engine' in nextDetection && nextDetection.defaultCapabilities) {
-          setValue(
-            'capabilities.capFavorites',
-            nextDetection.defaultCapabilities.favorites
-          );
-          setValue(
-            'capabilities.capTags',
-            nextDetection.defaultCapabilities.tags
-          );
-          setValue(
-            'capabilities.capSourceMatch',
-            nextDetection.defaultCapabilities.sourceMatch
-          );
-        }
       } catch (error) {
         if (requestSeq !== detectRequestSeq.current) return;
         setDetection(null);

--- a/frontend/src/features/booru-sites/BooruSitesPanelText.ts
+++ b/frontend/src/features/booru-sites/BooruSitesPanelText.ts
@@ -1,7 +1,4 @@
-import type { CapabilityKey } from './shared';
-
 import type { BooruEngineType } from '@/api';
-
 
 export type SiteSettingKey =
   | 'siteAutoSyncMidnight'
@@ -39,15 +36,6 @@ export const SUGGESTION_PRESETS: SuggestionPreset[] = [
     iconLabel: 'R34'
   }
 ];
-
-export const CAPABILITY_HELP_TEXT: Record<CapabilityKey, string> = {
-  capFavorites:
-    'Match your local files to your favorites here: new favorites are downloaded, and files you unfavorited are deleted locally. Works when pressing the Sync favorites button, or at midnight if "Daily midnight sync" is enabled.',
-  capTags:
-    'Copy the tags a post has on this site onto your matching local file, so you can search and filter by them.',
-  capSourceMatch:
-    'Use the source link saved on a local file to find the same post on this site and connect the two.'
-};
 
 export const SITE_SETTING_LABELS: Record<SiteSettingKey, string> = {
   siteAutoSyncMidnight: 'Daily midnight sync',

--- a/frontend/src/features/booru-sites/formSchemas.ts
+++ b/frontend/src/features/booru-sites/formSchemas.ts
@@ -4,12 +4,6 @@ import { ensureHttps } from '../../urlUtils';
 
 import type { BooruEngineType } from '@/api';
 
-const capabilitiesSchema = z.object({
-  capFavorites: z.boolean(),
-  capTags: z.boolean(),
-  capSourceMatch: z.boolean()
-});
-
 const normalizedUrlSchema = z
   .string()
   .trim()
@@ -27,8 +21,7 @@ export const booruSiteAddSchema = z.object({
     .max(100, 'Name must be at most 100 characters'),
   baseUrl: normalizedUrlSchema,
   username: trimStringSchema,
-  apiKey: trimStringSchema,
-  capabilities: capabilitiesSchema
+  apiKey: trimStringSchema
 });
 
 export type BooruSiteAddFormValues = z.infer<typeof booruSiteAddSchema>;
@@ -61,9 +54,6 @@ export const toBooruSiteCreatePayload = (
   baseUrl: ensureHttps(values.baseUrl),
   username: toNullableTrimmed(values.username),
   apiKey: toNullableTrimmed(values.apiKey),
-  capFavorites: values.capabilities.capFavorites,
-  capTags: values.capabilities.capTags,
-  capSourceMatch: values.capabilities.capSourceMatch,
   enabled: true
 });
 

--- a/frontend/src/features/booru-sites/shared.ts
+++ b/frontend/src/features/booru-sites/shared.ts
@@ -8,35 +8,46 @@ export const ENGINE_LABELS: Record<BooruEngineType, string> = {
   sankaku: 'Sankaku',
   philomena: 'Philomena (Derpibooru)',
   shimmie: 'Shimmie2',
-  szurubooru: 'Szurubooru',
-};
-
-export type CapabilityKey = 'capFavorites' | 'capTags' | 'capSourceMatch';
-
-export const CAPABILITY_LABELS: Record<CapabilityKey, string> = {
-  capFavorites: 'Sync favorites',
-  capTags: 'Tag fetch',
-  capSourceMatch: 'Source URL match',
-};
-
-export const defaultCapabilities: Record<CapabilityKey, boolean> = {
-  capFavorites: false,
-  capTags: true,
-  capSourceMatch: true,
+  szurubooru: 'Szurubooru'
 };
 
 export const credentialFieldsForSchema = (schema: BooruCredentialSchema) => {
   switch (schema) {
     case 'username+apikey':
-      return { username: true, usernameLabel: 'Username', apiKey: true, apiKeyLabel: 'API key' };
+      return {
+        username: true,
+        usernameLabel: 'Username',
+        apiKey: true,
+        apiKeyLabel: 'API key'
+      };
     case 'userid+apikey':
-      return { username: true, usernameLabel: 'User ID', apiKey: true, apiKeyLabel: 'API key' };
+      return {
+        username: true,
+        usernameLabel: 'User ID',
+        apiKey: true,
+        apiKeyLabel: 'API key'
+      };
     case 'apikey-only':
-      return { username: false, usernameLabel: '', apiKey: true, apiKeyLabel: 'API key' };
+      return {
+        username: false,
+        usernameLabel: '',
+        apiKey: true,
+        apiKeyLabel: 'API key'
+      };
     case 'token':
-      return { username: false, usernameLabel: '', apiKey: true, apiKeyLabel: 'Token' };
+      return {
+        username: false,
+        usernameLabel: '',
+        apiKey: true,
+        apiKeyLabel: 'Token'
+      };
     case 'none':
     default:
-      return { username: false, usernameLabel: '', apiKey: false, apiKeyLabel: '' };
+      return {
+        username: false,
+        usernameLabel: '',
+        apiKey: false,
+        apiKeyLabel: ''
+      };
   }
 };

--- a/frontend/test/formSchemas.test.ts
+++ b/frontend/test/formSchemas.test.ts
@@ -50,12 +50,7 @@ describe('booru form schemas', () => {
       name: '',
       baseUrl: 'not a url',
       username: '',
-      apiKey: '',
-      capabilities: {
-        capFavorites: false,
-        capTags: true,
-        capSourceMatch: true
-      }
+      apiKey: ''
     });
 
     expect(result.success).toBe(false);

--- a/frontend/test/formSchemas.test.ts
+++ b/frontend/test/formSchemas.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildAuthFormSchema, toAuthSubmitPayload } from '../src/features/auth/authSchemas';
+import {
+  buildAuthFormSchema,
+  toAuthSubmitPayload
+} from '../src/features/auth/authSchemas';
 import {
   booruSiteAddSchema,
   createBooruCredentialSchema,
   toBooruCredentialUpdatePayload,
-  toBooruSiteCreatePayload,
+  toBooruSiteCreatePayload
 } from '../src/features/booru-sites/formSchemas';
 
 describe('authSchemas', () => {
@@ -13,7 +16,7 @@ describe('authSchemas', () => {
     const result = buildAuthFormSchema('register').safeParse({
       username: 'a',
       password: 'short',
-      confirmPassword: 'different',
+      confirmPassword: 'different'
     });
 
     expect(result.success).toBe(false);
@@ -32,11 +35,11 @@ describe('authSchemas', () => {
       toAuthSubmitPayload({
         username: '  smoke-user  ',
         password: 'Password123',
-        confirmPassword: '',
-      }),
+        confirmPassword: ''
+      })
     ).toEqual({
       username: 'smoke-user',
-      password: 'Password123',
+      password: 'Password123'
     });
   });
 });
@@ -51,8 +54,8 @@ describe('booru form schemas', () => {
       capabilities: {
         capFavorites: false,
         capTags: true,
-        capSourceMatch: true,
-      },
+        capSourceMatch: true
+      }
     });
 
     expect(result.success).toBe(false);
@@ -72,32 +75,24 @@ describe('booru form schemas', () => {
           name: '  My booru  ',
           baseUrl: 'gelbooru.com/',
           username: '  user  ',
-          apiKey: '  secret  ',
-          capabilities: {
-            capFavorites: true,
-            capTags: false,
-            capSourceMatch: true,
-          },
+          apiKey: '  secret  '
         },
-        'gelbooru',
-      ),
+        'gelbooru'
+      )
     ).toEqual({
       name: 'My booru',
       engine: 'gelbooru',
       baseUrl: 'https://gelbooru.com/',
       username: 'user',
       apiKey: 'secret',
-      capFavorites: true,
-      capTags: false,
-      capSourceMatch: true,
-      enabled: true,
+      enabled: true
     });
   });
 
   it('keeps credential-row fields optional but trims saved values', () => {
     const result = createBooruCredentialSchema('username+apikey').safeParse({
       username: '  demo  ',
-      apiKey: '  token  ',
+      apiKey: '  token  '
     });
 
     expect(result.success).toBe(true);
@@ -107,7 +102,7 @@ describe('booru form schemas', () => {
 
     expect(toBooruCredentialUpdatePayload(result.data)).toEqual({
       username: 'demo',
-      apiKey: 'token',
+      apiKey: 'token'
     });
   });
 });


### PR DESCRIPTION
## Summary

Booru-site capabilities (favorites / tags / source-match) were stored per-site in `cap_*` DB columns **and** exposed as user toggles, with defaults duplicated between each engine module and its preset. The two sources had drifted apart — the Gelbooru engine declares `favorites: true` while the Gelbooru/Rule34 preset declared `favorites: false` — which silently switched off favorites sync for sites that actually support it.

This makes the **engine the single source of truth** for capabilities and removes the redundant per-site toggles.

## What changed

- New `engineSupports(engine, cap)` helper in `booruEngines/index.ts` — the one place capability is decided (`getEngine(engine)?.defaultCapabilities[cap] ?? false`).
- The 5 read-sites (`favorites.ts` ×3, `tagging.ts`, `favoriteSourceMatch.ts`) now derive capability from the engine instead of the DB column.
- Removed `defaultCapabilities` from presets (the diverging duplicate). The engine catalog (`/engines` engines[]) and `/detect` still expose engine capabilities — those stay as the source of truth.
- Removed the `Sync favorites` / `Tag fetch` / `Source URL match` toggles from `BooruSitesPanel` plus the related types, form fields and help text. `enabled` remains the only per-site switch; real preferences (daily sync, reverse sync, auto-fav) are untouched.
- Migration `0002_drop_booru_site_caps.sql` drops the 3 (unused) `cap_*` indexes then the 4 columns. Indexes first — SQLite refuses `DROP COLUMN` on an indexed column.
- `listUsersWithAutoSyncFavorites` can no longer filter favorites in SQL, so it selects `user_id, engine` and filters by engine capability in JS (stable, deduped, `user_id ASC`).

## Behavioral effect

Gelbooru/Rule34 now sync favorites automatically when the site is `enabled` (the engine genuinely supports it via HTML-favorites scraping), instead of being off by a stale preset default.

## Reviewer notes

- The migration is intentionally destructive (`DROP COLUMN`) on data no longer read by any code — explicitly authorized.
- Also includes a one-line fix for a pre-existing missing `BooruEngineType` import in `BooruSitesPanel.tsx` (invisible because Vite skips type-checking).

## Test plan

- [x] Backend: `npm test` (194/194), `npm run lint` clean
- [x] Frontend: `npm test` (27/27), `npm run build`, `npm run lint` clean
- [x] Migration bootstrap + legacy-upgrade covered by `migrate.test.ts`
- [ ] Manual: add Gelbooru/Rule34, confirm favorites sync runs and no capability toggles appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)