### PR TITLE
feat: reliable Rule34 reverse-delete via session cookie

### DIFF
--- a/backend/src/db/migrations/0003_booru_site_session_cookie.sql
+++ b/backend/src/db/migrations/0003_booru_site_session_cookie.sql
@@ -1,0 +1,6 @@
+-- Optional per-site session cookie for Gelbooru-compatible engines. The
+-- API-key delete endpoint redirects without proving removal (see issue #144),
+-- so an authenticated browser cookie is needed for reliable reverse-delete.
+-- Nullable: most engines don't use it and users may leave it unset.
+ALTER TABLE user_booru_sites
+  ADD COLUMN session_cookie TEXT;

--- a/backend/src/db/repos/booruSitesRepo.ts
+++ b/backend/src/db/repos/booruSitesRepo.ts
@@ -12,6 +12,7 @@ type BooruSiteRow = {
   base_url: string;
   username?: string | null;
   api_key?: string | null;
+  session_cookie?: string | null;
   is_preset: number;
   preset_key?: string | null;
   enabled: number;
@@ -31,6 +32,7 @@ const mapBooruSiteRow = (row: BooruSiteRow): BooruSiteRecord => ({
   baseUrl: row.base_url,
   username: row.username ?? null,
   apiKey: row.api_key ?? null,
+  sessionCookie: row.session_cookie ?? null,
   isPreset: row.is_preset === 1,
   presetKey: row.preset_key ?? null,
   enabled: row.enabled === 1,
@@ -101,11 +103,11 @@ export const booruSitesRepo = {
       sqlite
         .prepare(
           `INSERT INTO user_booru_sites
-           (id, user_id, name, engine, base_url, username, api_key,
+           (id, user_id, name, engine, base_url, username, api_key, session_cookie,
             is_preset, preset_key, enabled,
             site_auto_sync_midnight, site_reverse_sync_enabled, site_auto_fav_enabled,
             sort_order, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .run(
           id,
@@ -115,6 +117,7 @@ export const booruSitesRepo = {
           input.baseUrl,
           input.username ?? null,
           input.apiKey ?? null,
+          input.sessionCookie ?? null,
           input.isPreset ? 1 : 0,
           input.presetKey ?? null,
           input.enabled === false ? 0 : 1,
@@ -149,6 +152,10 @@ export const booruSitesRepo = {
       username:
         updates.username !== undefined ? updates.username : existing.username,
       api_key: updates.apiKey !== undefined ? updates.apiKey : existing.api_key,
+      session_cookie:
+        updates.sessionCookie !== undefined
+          ? updates.sessionCookie
+          : existing.session_cookie,
       is_preset:
         updates.isPreset !== undefined
           ? updates.isPreset
@@ -189,7 +196,7 @@ export const booruSitesRepo = {
     sqlite
       .prepare(
         `UPDATE user_booru_sites
-       SET name = ?, engine = ?, base_url = ?, username = ?, api_key = ?, is_preset = ?, preset_key = ?,
+       SET name = ?, engine = ?, base_url = ?, username = ?, api_key = ?, session_cookie = ?, is_preset = ?, preset_key = ?,
            enabled = ?,
            site_auto_sync_midnight = ?, site_reverse_sync_enabled = ?, site_auto_fav_enabled = ?,
            sort_order = ?, updated_at = ?
@@ -201,6 +208,7 @@ export const booruSitesRepo = {
         merged.base_url,
         merged.username ?? null,
         merged.api_key ?? null,
+        merged.session_cookie ?? null,
         merged.is_preset,
         merged.preset_key ?? null,
         merged.enabled,

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -259,6 +259,7 @@ export const userBooruSites = sqliteTable(
     baseUrl: text('base_url').notNull(),
     username: text('username'),
     apiKey: text('api_key'),
+    sessionCookie: text('session_cookie'),
     isPreset: integer('is_preset').notNull(),
     presetKey: text('preset_key'),
     enabled: integer('enabled').notNull(),

--- a/backend/src/db/types.ts
+++ b/backend/src/db/types.ts
@@ -98,6 +98,7 @@ export type BooruSiteRecord = {
   baseUrl: string;
   username: string | null;
   apiKey: string | null;
+  sessionCookie: string | null;
   isPreset: boolean;
   presetKey: string | null;
   enabled: boolean;
@@ -115,6 +116,7 @@ export type BooruSiteInput = {
   baseUrl: string;
   username?: string | null;
   apiKey?: string | null;
+  sessionCookie?: string | null;
   isPreset?: boolean;
   presetKey?: string | null;
   enabled?: boolean;

--- a/backend/src/lib/booruEngines/gelbooru.test.ts
+++ b/backend/src/lib/booruEngines/gelbooru.test.ts
@@ -349,3 +349,15 @@ test('checkSessionCookie sends the cookie but never returns its value', async (t
   assert.equal(result.ok, false);
   assert.ok(!(result.error ?? '').includes('supersecret-value')); // never leaked
 });
+
+test('checkSessionCookie returns a failure (not a throw) on a transport error', async (t) => {
+  // No account route armed → the mocked fetch rejects, simulating a network
+  // error. The /test route must stay a 200 status object, never a 500.
+  setupFetchMock(t);
+  const result = await gelbooruEngine.checkSessionCookie!(
+    baseSite({ sessionCookie: 'user_id=42; pass_hash=secret-value' })
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.error ?? '', /cookie check failed/);
+  assert.ok(!(result.error ?? '').includes('secret-value')); // never leaked
+});

--- a/backend/src/lib/booruEngines/gelbooru.test.ts
+++ b/backend/src/lib/booruEngines/gelbooru.test.ts
@@ -16,6 +16,7 @@ const baseSite = (
   baseUrl: 'https://gelbooru.com',
   username: '42',
   apiKey: 'testkey',
+  sessionCookie: null,
   isPreset: false,
   presetKey: null,
   enabled: true,
@@ -161,22 +162,190 @@ test('fetchFavorites aborts when signal fires before loop', async () => {
   );
 });
 
-test('unfavorite rejects a redirect to the favorites view', async (t) => {
+test('unfavorite returns once the favorite is gone after the delete', async (t) => {
   const fm = setupFetchMock(t);
-  fm.intercept(
-    (url) =>
-      url.includes('page=favorites') &&
-      url.includes('s=delete') &&
-      url.includes('id=123'),
-    {
-      status: 302,
-      body: '',
-      headers: { location: '/index.php?page=favorites&s=view&id=' }
-    }
-  );
+  // Delete endpoint redirects back to favorites — proves nothing on its own.
+  fm.intercept((url) => url.includes('s=delete') && url.includes('id=123'), {
+    status: 302,
+    body: '',
+    headers: { location: '/index.php?page=favorites&s=view&id=' }
+  });
+  // Verification re-fetch: favorites page no longer lists 123.
+  fm.intercept((url) => url.includes('s=view') && url.includes('pid='), {
+    status: 200,
+    body: favHtmlPage([999])
+  });
+
+  await gelbooruEngine.unfavorite!(baseSite(), '123');
+});
+
+test('unfavorite returns on 404 without re-fetching (already absent)', async (t) => {
+  const fm = setupFetchMock(t);
+  // Only the delete is armed; if verification ran it would hit no route and
+  // throw, so a clean resolve proves we short-circuit on 404.
+  fm.intercept((url) => url.includes('s=delete'), {
+    status: 404,
+    body: 'not found'
+  });
+
+  await gelbooruEngine.unfavorite!(baseSite(), '123');
+});
+
+test('unfavorite throws on a hard failure response', async (t) => {
+  const fm = setupFetchMock(t);
+  fm.intercept((url) => url.includes('s=delete'), {
+    status: 500,
+    body: 'boom'
+  });
 
   await assert.rejects(
     () => gelbooruEngine.unfavorite!(baseSite(), '123'),
-    /unfavorite redirected/
+    /unfavorite failed.*500/
   );
+});
+
+test('unfavorite flags an expired cookie when the post is still favorited', async (t) => {
+  const fm = setupFetchMock(t);
+  fm.intercept((url) => url.includes('s=delete'), {
+    status: 302,
+    body: '',
+    headers: { location: '/index.php?page=favorites' }
+  });
+  // Verification still finds 123 → delete did not take.
+  fm.intercept((url) => url.includes('s=view') && url.includes('pid='), {
+    status: 200,
+    body: favHtmlPage([123])
+  });
+
+  await assert.rejects(
+    () =>
+      gelbooruEngine.unfavorite!(
+        baseSite({ sessionCookie: 'sess=abc' }),
+        '123'
+      ),
+    /not confirmed.*expired or invalid/
+  );
+});
+
+test('unfavorite asks for a cookie when none is set and delete did not take', async (t) => {
+  const fm = setupFetchMock(t);
+  fm.intercept((url) => url.includes('s=delete'), {
+    status: 302,
+    body: '',
+    headers: { location: '/index.php?page=favorites' }
+  });
+  fm.intercept((url) => url.includes('s=view') && url.includes('pid='), {
+    status: 200,
+    body: favHtmlPage([123])
+  });
+
+  await assert.rejects(
+    () => gelbooruEngine.unfavorite!(baseSite({ sessionCookie: null }), '123'),
+    /add a session cookie/
+  );
+});
+
+test('unfavorite sends the session cookie and never leaks it in errors', async (t) => {
+  const fm = setupFetchMock(t);
+  const secret = 'user_id=42; pass_hash=supersecret-value';
+  let sentCookie: string | undefined;
+  fm.intercept(
+    (url, init) => {
+      if (!url.includes('s=delete')) return false;
+      sentCookie = (init?.headers as Record<string, string> | undefined)
+        ?.Cookie;
+      return true;
+    },
+    {
+      status: 302,
+      body: '',
+      headers: { location: '/index.php?page=favorites' }
+    }
+  );
+  // Still favorited so it throws — lets us assert the error omits the cookie.
+  fm.intercept((url) => url.includes('s=view') && url.includes('pid='), {
+    status: 200,
+    body: favHtmlPage([123])
+  });
+
+  let message = '';
+  try {
+    await gelbooruEngine.unfavorite!(
+      baseSite({ sessionCookie: secret }),
+      '123'
+    );
+  } catch (err) {
+    message = (err as Error).message;
+  }
+
+  assert.equal(sentCookie, secret); // cookie actually reached the delete request
+  assert.ok(message.length > 0); // it did throw (not a silent success)
+  assert.ok(!message.includes('supersecret-value')); // but never leaked the value
+});
+
+test('checkSessionCookie reports ok when the logout link is present', async (t) => {
+  const fm = setupFetchMock(t);
+  // Rule34's logout link — the code=01 is the logged-in marker. Entity-encoded
+  // ampersand, as it appears in real HTML.
+  fm.intercept((url) => url.includes('page=account'), {
+    status: 200,
+    body: '<a href="index.php?page=account&amp;s=login&amp;code=01">Logout</a>'
+  });
+
+  const result = await gelbooruEngine.checkSessionCookie!(
+    baseSite({ sessionCookie: 'user_id=42; pass_hash=abc' })
+  );
+  assert.equal(result.ok, true);
+});
+
+test('checkSessionCookie flags a cookie that redirects away from the account page', async (t) => {
+  const fm = setupFetchMock(t);
+  fm.intercept((url) => url.includes('page=account'), {
+    status: 302,
+    body: '',
+    headers: { location: '/index.php?page=account&s=login' }
+  });
+
+  const result = await gelbooruEngine.checkSessionCookie!(
+    baseSite({ sessionCookie: 'user_id=42; pass_hash=stale' })
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.error ?? '', /not authenticated/);
+});
+
+test('checkSessionCookie flags a page without the logout link', async (t) => {
+  const fm = setupFetchMock(t);
+  // The plain login form (s=login, no code=01) — i.e. not logged in.
+  fm.intercept((url) => url.includes('page=account'), {
+    status: 200,
+    body: '<form action="index.php?page=account&s=login"><input name="pass" type="password"></form>'
+  });
+
+  const result = await gelbooruEngine.checkSessionCookie!(
+    baseSite({ sessionCookie: 'user_id=42; pass_hash=wrong' })
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.error ?? '', /not authenticated/);
+});
+
+test('checkSessionCookie sends the cookie but never returns its value', async (t) => {
+  const fm = setupFetchMock(t);
+  const secret = 'user_id=42; pass_hash=supersecret-value';
+  let sentCookie: string | undefined;
+  fm.intercept(
+    (url, init) => {
+      if (!url.includes('page=account')) return false;
+      sentCookie = (init?.headers as Record<string, string> | undefined)
+        ?.Cookie;
+      return true;
+    },
+    { status: 200, body: '<form><input name="pass" type="password"></form>' }
+  );
+
+  const result = await gelbooruEngine.checkSessionCookie!(
+    baseSite({ sessionCookie: secret })
+  );
+  assert.equal(sentCookie, secret); // cookie reached the request
+  assert.equal(result.ok, false);
+  assert.ok(!(result.error ?? '').includes('supersecret-value')); // never leaked
 });

--- a/backend/src/lib/booruEngines/gelbooru.ts
+++ b/backend/src/lib/booruEngines/gelbooru.ts
@@ -354,7 +354,10 @@ export const gelbooruEngine: BooruEngineModule = {
     // `code=01` is what distinguishes logout from the plain login form. It's in
     // the nav on every page once authenticated, so its presence proves the
     // cookie works. (Confirmed against rule34.xxx — issue #144.) Tolerate HTML
-    // entity-encoded ampersands (`&amp;`).
+    // entity-encoded ampersands (`&amp;`). Other Gelbooru forks may render the
+    // logout link differently — there this advisory may false-negative, but the
+    // authoritative removal proof is the favorites re-fetch in unfavorite(),
+    // which is fork-agnostic, so a wrong answer here never blocks a real delete.
     if (/s=login&(?:amp;)?code=01/i.test(html)) return { ok: true };
     return {
       ok: false,

--- a/backend/src/lib/booruEngines/gelbooru.ts
+++ b/backend/src/lib/booruEngines/gelbooru.ts
@@ -78,15 +78,17 @@ const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
       reject(new Error('Favorites fetch aborted'));
       return;
     }
-    const id = setTimeout(resolve, ms);
-    signal?.addEventListener(
-      'abort',
-      () => {
-        clearTimeout(id);
-        reject(new Error('Favorites fetch aborted'));
-      },
-      { once: true }
-    );
+    const onAbort = () => {
+      clearTimeout(id);
+      reject(new Error('Favorites fetch aborted'));
+    };
+    // Drop the abort listener when the timer wins, otherwise a large favorites
+    // sync (thousands of sleeps on one signal) leaks a handler per call.
+    const id = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
   });
 
 // Scrape post IDs from the HTML favorites page (paginated by pid).
@@ -332,37 +334,49 @@ export const gelbooruEngine: BooruEngineModule = {
   async checkSessionCookie(site) {
     if (!site.sessionCookie)
       return { ok: false, error: 'no session cookie saved' };
-    // Account pages are login-gated. We send the cookie and look for the logout
-    // link, which only renders when authenticated. Never echo the cookie value.
-    const url = `${site.baseUrl.replace(/\/+$/, '')}/index.php?page=account&s=home`;
-    const res = await fetch(url, {
-      headers: buildAuthHeaders(site),
-      redirect: 'manual'
-    });
-    // Logged out, the account page bounces to the login screen.
-    if (res.status >= 300 && res.status < 400) {
+    try {
+      // Account pages are login-gated. We send the cookie and look for the
+      // logout link, which only renders when authenticated. Never echo the
+      // cookie value.
+      const url = `${site.baseUrl.replace(/\/+$/, '')}/index.php?page=account&s=home`;
+      const res = await fetch(url, {
+        headers: buildAuthHeaders(site),
+        redirect: 'manual'
+      });
+      // Logged out, the account page bounces to the login screen.
+      if (res.status >= 300 && res.status < 400) {
+        return {
+          ok: false,
+          error: 'not authenticated (redirected) — cookie expired or incomplete'
+        };
+      }
+      if (!res.ok) {
+        return { ok: false, error: `account page returned ${res.status}` };
+      }
+      const html = await res.text();
+      // Rule34/Gelbooru's logout link is `page=account&s=login&code=01` — the
+      // `code=01` is what distinguishes logout from the plain login form. It's
+      // in the nav on every page once authenticated, so its presence proves the
+      // cookie works. (Confirmed against rule34.xxx — issue #144.) Tolerate HTML
+      // entity-encoded ampersands (`&amp;`). Other Gelbooru forks may render the
+      // logout link differently — there this advisory may false-negative, but
+      // the authoritative removal proof is the favorites re-fetch in
+      // unfavorite(), which is fork-agnostic, so a wrong answer never blocks a
+      // real delete.
+      if (/s=login&(?:amp;)?code=01/i.test(html)) return { ok: true };
       return {
         ok: false,
-        error: 'not authenticated (redirected) — cookie expired or incomplete'
+        error: 'not authenticated — cookie expired, incomplete, or wrong'
+      };
+    } catch (err) {
+      // Transport/parse failure: report it as a cookie-status failure so the
+      // /test route stays a 200 with a status object (never a 500). The message
+      // can't contain the cookie — it's only in the request headers.
+      return {
+        ok: false,
+        error: `cookie check failed: ${(err as Error).message}`
       };
     }
-    if (!res.ok) {
-      return { ok: false, error: `account page returned ${res.status}` };
-    }
-    const html = await res.text();
-    // Rule34/Gelbooru's logout link is `page=account&s=login&code=01` — the
-    // `code=01` is what distinguishes logout from the plain login form. It's in
-    // the nav on every page once authenticated, so its presence proves the
-    // cookie works. (Confirmed against rule34.xxx — issue #144.) Tolerate HTML
-    // entity-encoded ampersands (`&amp;`). Other Gelbooru forks may render the
-    // logout link differently — there this advisory may false-negative, but the
-    // authoritative removal proof is the favorites re-fetch in unfavorite(),
-    // which is fork-agnostic, so a wrong answer here never blocks a real delete.
-    if (/s=login&(?:amp;)?code=01/i.test(html)) return { ok: true };
-    return {
-      ok: false,
-      error: 'not authenticated — cookie expired, incomplete, or wrong'
-    };
   },
 
   extractIdFromUrl(url, site) {

--- a/backend/src/lib/booruEngines/gelbooru.ts
+++ b/backend/src/lib/booruEngines/gelbooru.ts
@@ -4,7 +4,12 @@ import { config } from '../../config';
 import type { BooruSiteRecord } from '../../db/types';
 
 import { normalizeTag, safeJoin } from './helpers';
-import type { BooruEngineModule, BooruRemoteFavorite, FetchFavoritesContext, TagResult } from './types';
+import type {
+  BooruEngineModule,
+  BooruRemoteFavorite,
+  FetchFavoritesContext,
+  TagResult
+} from './types';
 
 type GelbooruPost = {
   id?: number | string | null;
@@ -25,9 +30,23 @@ type GelbooruResponse = GelbooruPost[] | GelbooruEnvelope | GelbooruPost;
 
 const userAgent = () => config.e621.userAgent;
 
-const buildHeaders = (): Record<string, string> => ({ 'User-Agent': userAgent() });
+const buildHeaders = (): Record<string, string> => ({
+  'User-Agent': userAgent()
+});
 
-const buildBaseQuery = (site: BooruSiteRecord, extra: Record<string, string>): URLSearchParams => {
+// Like buildHeaders, but attaches the optional session cookie for authenticated
+// actions (issue #144). The Cookie value is a sensitive credential: never log
+// this header or include it in error messages.
+const buildAuthHeaders = (site: BooruSiteRecord): Record<string, string> => {
+  const headers = buildHeaders();
+  if (site.sessionCookie) headers.Cookie = site.sessionCookie;
+  return headers;
+};
+
+const buildBaseQuery = (
+  site: BooruSiteRecord,
+  extra: Record<string, string>
+): URLSearchParams => {
   const params = new URLSearchParams({
     page: 'dapi',
     s: 'post',
@@ -55,9 +74,19 @@ const FAV_MAX_HTML_PAGES = 1000;
 
 const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
   new Promise((resolve, reject) => {
-    if (signal?.aborted) { reject(new Error('Favorites fetch aborted')); return; }
+    if (signal?.aborted) {
+      reject(new Error('Favorites fetch aborted'));
+      return;
+    }
     const id = setTimeout(resolve, ms);
-    signal?.addEventListener('abort', () => { clearTimeout(id); reject(new Error('Favorites fetch aborted')); }, { once: true });
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(id);
+        reject(new Error('Favorites fetch aborted'));
+      },
+      { once: true }
+    );
   });
 
 // Scrape post IDs from the HTML favorites page (paginated by pid).
@@ -79,7 +108,13 @@ const scrapeFavoritePostIds = async (
       throw new Error(`${site.name} favorites page failed (${res.status})`);
     }
     const html = await res.text();
-    const ids = [...new Set([...html.matchAll(/page=post&amp;s=view&amp;id=(\d+)/g)].map((m) => m[1]))];
+    const ids = [
+      ...new Set(
+        [...html.matchAll(/page=post&amp;s=view&amp;id=(\d+)/g)].map(
+          (m) => m[1]
+        )
+      )
+    ];
     const fresh = ids.filter((id) => !seen.has(id));
     if (fresh.length === 0) break;
     fresh.forEach((id) => seen.add(id));
@@ -88,6 +123,18 @@ const scrapeFavoritePostIds = async (
     await sleep(FAV_HTML_SLEEP_MS, signal);
   }
   return Array.from(seen);
+};
+
+// Re-fetch the user's public favorites page and report whether `postId` is
+// still listed. The delete endpoint redirects without proving removal (issue
+// #144), so this is how we confirm a reverse-delete actually took effect.
+// Reads the public page (no cookie needed); the page is keyed by user_id.
+const isFavoritedRemotely = async (
+  site: BooruSiteRecord,
+  postId: string
+): Promise<boolean> => {
+  const ids = await scrapeFavoritePostIds(site, buildHeaders(), undefined);
+  return ids.includes(postId);
 };
 
 const extractPosts = (data: GelbooruResponse): GelbooruPost[] => {
@@ -103,7 +150,13 @@ const extractPosts = (data: GelbooruResponse): GelbooruPost[] => {
 export const gelbooruEngine: BooruEngineModule = {
   type: 'gelbooru',
   credentialSchema: 'userid+apikey',
-  defaultCapabilities: { favorites: true, tags: true, sourceMatch: true, search: true },
+  supportsSessionCookie: true,
+  defaultCapabilities: {
+    favorites: true,
+    tags: true,
+    sourceMatch: true,
+    search: true
+  },
   defaultUserAgent: '',
   probePath: '/index.php?page=dapi&s=post&q=index&json=1&limit=1',
   probeMatches: (body: unknown): boolean => {
@@ -119,7 +172,10 @@ export const gelbooruEngine: BooruEngineModule = {
     const first = posts[0];
     if (!first || typeof first !== 'object') return false;
     const p = first as GelbooruPost;
-    return typeof p.tags === 'string' && (typeof p.file_url === 'string' || typeof p.sample_url === 'string');
+    return (
+      typeof p.tags === 'string' &&
+      (typeof p.file_url === 'string' || typeof p.sample_url === 'string')
+    );
   },
   probeSample: (body: unknown) => {
     const posts = extractPosts(body as GelbooruResponse);
@@ -137,12 +193,17 @@ export const gelbooruEngine: BooruEngineModule = {
 
   async fetchPostTags(site, postId): Promise<TagResult[]> {
     const params = buildBaseQuery(site, { id: postId, limit: '1' });
-    const res = await fetch(safeJoin(site.baseUrl, `/index.php?${params.toString()}`), {
-      headers: buildHeaders()
-    });
+    const res = await fetch(
+      safeJoin(site.baseUrl, `/index.php?${params.toString()}`),
+      {
+        headers: buildHeaders()
+      }
+    );
     const text = await res.text();
     if (!res.ok) {
-      console.warn(`[tags] gelbooru fetch failed (${res.status}): ${text.slice(0, 200)}`);
+      console.warn(
+        `[tags] gelbooru fetch failed (${res.status}): ${text.slice(0, 200)}`
+      );
       return [];
     }
     let data: GelbooruResponse;
@@ -163,7 +224,13 @@ export const gelbooruEngine: BooruEngineModule = {
       .map((tag) => ({ tag, category: 'general' }));
   },
 
-  async fetchFavorites(site, ctx?: FetchFavoritesContext): Promise<{ items: BooruRemoteFavorite[]; downloadHeaders: Record<string, string> }> {
+  async fetchFavorites(
+    site,
+    ctx?: FetchFavoritesContext
+  ): Promise<{
+    items: BooruRemoteFavorite[];
+    downloadHeaders: Record<string, string>;
+  }> {
     if (!site.username || !site.apiKey) {
       throw new Error(`${site.name} credentials missing`);
     }
@@ -173,12 +240,20 @@ export const gelbooruEngine: BooruEngineModule = {
     // (the fav: tag needs the login username, not the numeric ID, and there's
     // no public lookup from ID to username). The HTML favorites page IS keyed
     // by user_id, so scrape that for post IDs, then resolve each via the API.
-    const postIds = await scrapeFavoritePostIds(site, headers, signal, ctx?.onPage);
+    const postIds = await scrapeFavoritePostIds(
+      site,
+      headers,
+      signal,
+      ctx?.onPage
+    );
     const items: BooruRemoteFavorite[] = [];
     for (const postId of postIds) {
       if (signal?.aborted) throw new Error('Favorites fetch aborted');
       const params = buildBaseQuery(site, { id: postId, limit: '1' });
-      const res = await fetch(safeJoin(site.baseUrl, `/index.php?${params.toString()}`), { headers, signal });
+      const res = await fetch(
+        safeJoin(site.baseUrl, `/index.php?${params.toString()}`),
+        { headers, signal }
+      );
       const text = await res.text();
       // Dead/deleted post → skip silently; the HTML page can list stale IDs.
       if (!res.ok || !text.trim()) continue;
@@ -192,7 +267,9 @@ export const gelbooruEngine: BooruEngineModule = {
       // (e.g. "Missing authentication") — surface it as a real failure so the
       // user knows credentials are bad, instead of silently producing 0 items.
       if (typeof data === 'string') {
-        throw new Error(`${site.name} favorites failed: ${(data as string).slice(0, 200)}`);
+        throw new Error(
+          `${site.name} favorites failed: ${(data as string).slice(0, 200)}`
+        );
       }
       const post = extractPosts(data)[0];
       const id = post?.id ? String(post.id) : null;
@@ -209,7 +286,8 @@ export const gelbooruEngine: BooruEngineModule = {
   },
 
   async unfavorite(site, postId) {
-    if (!site.username || !site.apiKey) throw new Error(`${site.name} credentials missing`);
+    if (!site.username || !site.apiKey)
+      throw new Error(`${site.name} credentials missing`);
     const params = new URLSearchParams({
       page: 'favorites',
       s: 'delete',
@@ -217,24 +295,79 @@ export const gelbooruEngine: BooruEngineModule = {
       user_id: site.username,
       api_key: site.apiKey
     });
-    const res = await fetch(safeJoin(site.baseUrl, `/index.php?${params.toString()}`), {
-      headers: buildHeaders(),
+    const res = await fetch(
+      safeJoin(site.baseUrl, `/index.php?${params.toString()}`),
+      {
+        headers: buildAuthHeaders(site),
+        redirect: 'manual'
+      }
+    );
+
+    // 404 = favorite already absent; remote state is already satisfied.
+    if (res.status === 404) return;
+    // Hard failures (auth rejected, server error) surface immediately and are
+    // never swallowed. A 3xx redirect is NOT treated as failure here: Gelbooru
+    // redirects back to the favorites page on both success and no-op, so the
+    // redirect alone proves nothing (issue #144) — verification decides.
+    if (res.status >= 400) {
+      const text = await res.text();
+      throw new Error(
+        `${site.name} unfavorite failed (${res.status}): ${text.slice(0, 200)}`
+      );
+    }
+
+    // The response can't prove the favorite was removed. Re-fetch the live
+    // favorites list and confirm before claiming success.
+    if (!(await isFavoritedRemotely(site, postId))) return;
+
+    // Still favorited: the delete didn't take. Surface an actionable reason
+    // without ever echoing the cookie value (issue #144).
+    throw new Error(
+      site.sessionCookie
+        ? `${site.name} remote unfavorite not confirmed — the session cookie may be expired or invalid. Re-copy it from your browser and save it again.`
+        : `${site.name} remote unfavorite not confirmed — add a session cookie for this site to enable remote delete.`
+    );
+  },
+
+  async checkSessionCookie(site) {
+    if (!site.sessionCookie)
+      return { ok: false, error: 'no session cookie saved' };
+    // Account pages are login-gated. We send the cookie and look for the logout
+    // link, which only renders when authenticated. Never echo the cookie value.
+    const url = `${site.baseUrl.replace(/\/+$/, '')}/index.php?page=account&s=home`;
+    const res = await fetch(url, {
+      headers: buildAuthHeaders(site),
       redirect: 'manual'
     });
+    // Logged out, the account page bounces to the login screen.
     if (res.status >= 300 && res.status < 400) {
-      const location = res.headers.get('location') ?? '';
-      throw new Error(`${site.name} unfavorite redirected (${res.status}) to ${location || 'unknown location'}`);
+      return {
+        ok: false,
+        error: 'not authenticated (redirected) — cookie expired or incomplete'
+      };
     }
-    // 404 means the favorite was already absent, so remote state is satisfied.
-    if (res.ok || res.status === 404) return;
-    const text = await res.text();
-    throw new Error(`${site.name} unfavorite failed (${res.status}): ${text.slice(0, 200)}`);
+    if (!res.ok) {
+      return { ok: false, error: `account page returned ${res.status}` };
+    }
+    const html = await res.text();
+    // Rule34/Gelbooru's logout link is `page=account&s=login&code=01` — the
+    // `code=01` is what distinguishes logout from the plain login form. It's in
+    // the nav on every page once authenticated, so its presence proves the
+    // cookie works. (Confirmed against rule34.xxx — issue #144.) Tolerate HTML
+    // entity-encoded ampersands (`&amp;`).
+    if (/s=login&(?:amp;)?code=01/i.test(html)) return { ok: true };
+    return {
+      ok: false,
+      error: 'not authenticated — cookie expired, incomplete, or wrong'
+    };
   },
 
   extractIdFromUrl(url, site) {
     try {
       const parsed = new URL(url);
-      const siteHost = new URL(site.baseUrl).hostname.replace(/^www\./, '').toLowerCase();
+      const siteHost = new URL(site.baseUrl).hostname
+        .replace(/^www\./, '')
+        .toLowerCase();
       const host = parsed.hostname.replace(/^www\./, '').toLowerCase();
       if (host !== siteHost) return null;
       const idParam = parsed.searchParams.get('id');

--- a/backend/src/lib/booruEngines/types.ts
+++ b/backend/src/lib/booruEngines/types.ts
@@ -45,6 +45,14 @@ export type BooruEngineModule = {
   credentialSchema: CredentialSchema;
   defaultCapabilities: EngineCapabilityDefaults;
 
+  /**
+   * Whether the engine accepts an optional session cookie for authenticated
+   * actions. Gelbooru-style sites redirect their API-key delete endpoint
+   * without proving removal (issue #144), so a browser cookie is needed for
+   * reliable reverse-delete. The UI shows a cookie field only when this is set.
+   */
+  supportsSessionCookie?: boolean;
+
   /** Default UA used for outgoing HTTP if site config doesn't override */
   defaultUserAgent: string;
 
@@ -67,13 +75,28 @@ export type BooruEngineModule = {
   fetchFavorites?(
     site: BooruSiteRecord,
     ctx?: FetchFavoritesContext
-  ): Promise<{ items: BooruRemoteFavorite[]; downloadHeaders: Record<string, string> }>;
+  ): Promise<{
+    items: BooruRemoteFavorite[];
+    downloadHeaders: Record<string, string>;
+  }>;
 
   favorite?(site: BooruSiteRecord, postId: string): Promise<void>;
   unfavorite?(site: BooruSiteRecord, postId: string): Promise<void>;
 
+  /**
+   * Best-effort check that the saved session cookie still authenticates a
+   * logged-in session. Only meaningful when supportsSessionCookie is true and a
+   * cookie is saved. The result must never echo the cookie value.
+   */
+  checkSessionCookie?(
+    site: BooruSiteRecord
+  ): Promise<{ ok: boolean; error?: string }>;
+
   /** Extracts remote post id from a sauce URL if it belongs to this engine. */
-  extractIdFromUrl(url: string, site: BooruSiteRecord): { remoteId: string } | null;
+  extractIdFromUrl(
+    url: string,
+    site: BooruSiteRecord
+  ): { remoteId: string } | null;
 
   /** Canonical URL for a post id on this site. */
   buildPostUrl(site: BooruSiteRecord, postId: string): string;

--- a/backend/src/lib/booruSitesStore.test.ts
+++ b/backend/src/lib/booruSitesStore.test.ts
@@ -149,3 +149,41 @@ test("deleteBooruSite does not touch another user's favorites that share a remot
     1
   );
 });
+
+test('session cookie survives insert, read, update, and clear', async () => {
+  const seeded = await seedUser({ username: 'session-cookie-roundtrip' });
+
+  const site = await booruSitesRepo.insertBooruSite(
+    {
+      name: 'Rule34',
+      engine: 'gelbooru',
+      baseUrl: 'https://rule34.example.com',
+      sessionCookie: 'sess=abc123',
+      isPreset: false,
+      presetKey: null,
+      enabled: true
+    },
+    seeded.user.id
+  );
+  assert.equal(site.sessionCookie, 'sess=abc123');
+
+  // Read path round-trips the stored value.
+  const fetched = await booruSitesRepo.getBooruSite(site.id, seeded.user.id);
+  assert.equal(fetched?.sessionCookie, 'sess=abc123');
+
+  // An update that omits sessionCookie must leave it untouched.
+  const renamed = await booruSitesRepo.updateBooruSite(
+    site.id,
+    { name: 'Rule34 renamed' },
+    seeded.user.id
+  );
+  assert.equal(renamed?.sessionCookie, 'sess=abc123');
+
+  // Explicit null clears it.
+  const cleared = await booruSitesRepo.updateBooruSite(
+    site.id,
+    { sessionCookie: null },
+    seeded.user.id
+  );
+  assert.equal(cleared?.sessionCookie, null);
+});

--- a/backend/src/routes/booruSites.ts
+++ b/backend/src/routes/booruSites.ts
@@ -149,7 +149,8 @@ export const registerBooruSiteRoutes = (app: FastifyInstance) => {
     engines: listEngines().map((engine) => ({
       type: engine.type,
       credentialSchema: engine.credentialSchema,
-      defaultCapabilities: engine.defaultCapabilities
+      defaultCapabilities: engine.defaultCapabilities,
+      supportsSessionCookie: engine.supportsSessionCookie ?? false
     })),
     presets: BOORU_PRESETS.map((preset) => ({
       key: preset.key,
@@ -184,6 +185,7 @@ export const registerBooruSiteRoutes = (app: FastifyInstance) => {
         confidence: result.confidence,
         credentialSchema: engine?.credentialSchema ?? 'none',
         defaultCapabilities: engine?.defaultCapabilities ?? null,
+        supportsSessionCookie: engine?.supportsSessionCookie ?? false,
         sample,
         attempts: result.attempts
       };

--- a/backend/src/routes/booruSites.ts
+++ b/backend/src/routes/booruSites.ts
@@ -26,6 +26,7 @@ const createSchema = z.object({
   baseUrl: z.string().url(),
   username: z.string().optional().nullable(),
   apiKey: z.string().optional().nullable(),
+  sessionCookie: z.string().optional().nullable(),
   siteAutoSyncMidnight: z.boolean().optional(),
   siteReverseSyncEnabled: z.boolean().optional(),
   siteAutoFavEnabled: z.boolean().optional(),
@@ -36,6 +37,7 @@ const updateSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   username: z.string().nullable().optional(),
   apiKey: z.string().nullable().optional(),
+  sessionCookie: z.string().nullable().optional(),
   enabled: z.boolean().optional(),
   siteAutoSyncMidnight: z.boolean().optional(),
   siteReverseSyncEnabled: z.boolean().optional(),
@@ -66,6 +68,7 @@ const toPublic = (site: BooruSiteRecord) => ({
   baseUrl: site.baseUrl,
   username: site.username,
   hasApiKey: Boolean(site.apiKey),
+  hasSessionCookie: Boolean(site.sessionCookie),
   isPreset: site.isPreset,
   presetKey: site.presetKey,
   enabled: site.enabled,
@@ -75,7 +78,9 @@ const toPublic = (site: BooruSiteRecord) => ({
   sortOrder: site.sortOrder,
   createdAt: site.createdAt,
   updatedAt: site.updatedAt,
-  engineCredentialSchema: getEngine(site.engine)?.credentialSchema ?? 'none'
+  engineCredentialSchema: getEngine(site.engine)?.credentialSchema ?? 'none',
+  engineSupportsSessionCookie:
+    getEngine(site.engine)?.supportsSessionCookie ?? false
 });
 
 const trimOrUndefined = (
@@ -221,6 +226,8 @@ export const registerBooruSiteRoutes = (app: FastifyInstance) => {
         baseUrl,
         username: trimOrUndefined(parsed.data.username ?? undefined) ?? null,
         apiKey: trimOrUndefined(parsed.data.apiKey ?? undefined) ?? null,
+        sessionCookie:
+          trimOrUndefined(parsed.data.sessionCookie ?? undefined) ?? null,
         isPreset: false,
         presetKey: null,
         enabled: parsed.data.enabled ?? true,
@@ -264,6 +271,9 @@ export const registerBooruSiteRoutes = (app: FastifyInstance) => {
       }
       if (updates.apiKey !== undefined) {
         updates.apiKey = trimOrUndefined(updates.apiKey);
+      }
+      if (updates.sessionCookie !== undefined) {
+        updates.sessionCookie = trimOrUndefined(updates.sessionCookie);
       }
       const site = await booruSitesRepo.updateBooruSite(
         request.params.id,
@@ -312,6 +322,18 @@ export const registerBooruSiteRoutes = (app: FastifyInstance) => {
         return { error: 'Site not found' };
       }
       const result = await probeTestConnection(site);
+      // When a session cookie is saved for a cookie-capable engine, also report
+      // whether it still authenticates a logged-in session — so the user finds
+      // out here, not on the first failed remote delete (issue #144).
+      const engine = getEngine(site.engine);
+      if (
+        site.sessionCookie &&
+        engine?.supportsSessionCookie &&
+        engine.checkSessionCookie
+      ) {
+        const cookie = await engine.checkSessionCookie(site);
+        return { ...result, cookie };
+      }
       return result;
     }
   );

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -5,6 +5,7 @@ import { FastifyInstance } from 'fastify';
 import { lookup as lookupMime } from 'mime-types';
 import { z } from 'zod';
 
+import { config } from '../config';
 import { booruSitesRepo } from '../db/repos/booruSitesRepo';
 import { favoritesRepo } from '../db/repos/favoritesRepo';
 import { filesRepo } from '../db/repos/filesRepo';
@@ -120,13 +121,6 @@ const resolveSafeLocalPath = (folderPath: string, filePath: string) => {
   }
   if (!isPathInside(filePath, folderPath)) {
     throw new Error('Unsafe file path: outside folder root');
-  }
-  return path.resolve(filePath);
-};
-
-const resolveSafeAbsolutePath = (filePath: string) => {
-  if (!path.isAbsolute(filePath)) {
-    throw new Error('Unsafe path: expected absolute path');
   }
   return path.resolve(filePath);
 };
@@ -561,10 +555,20 @@ export const registerFilesRoutes = (app: FastifyInstance) => {
       }
       if (file.thumbPath) {
         try {
-          const safeThumbPath = resolveSafeAbsolutePath(file.thumbPath);
-          await fs.promises.unlink(safeThumbPath);
+          // Thumbs live in thumbnailsDir keyed by basename — same contract as
+          // how they're served and stored. thumbPath is relative, so resolve
+          // against the thumbnails root; using basename also keeps the unlink
+          // inside that directory (no path traversal).
+          const thumbAbs = path.join(
+            path.resolve(config.storage.thumbnailsDir),
+            path.basename(file.thumbPath)
+          );
+          await fs.promises.unlink(thumbAbs);
         } catch (err) {
-          errors.push(`Thumb delete: ${(err as Error).message}`);
+          // Already gone = goal met (idempotent delete); anything else is real.
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+            errors.push(`Thumb delete: ${(err as Error).message}`);
+          }
         }
       }
       for (const favoriteItem of favoriteItems) {

--- a/backend/test/files.test.ts
+++ b/backend/test/files.test.ts
@@ -9,6 +9,7 @@ import path from 'path';
 
 import type { FastifyInstance } from 'fastify';
 
+import { config } from '../src/config';
 import { booruSitesRepo } from '../src/db/repos/booruSitesRepo';
 import { favoritesRepo } from '../src/db/repos/favoritesRepo';
 import { foldersRepo } from '../src/db/repos/foldersRepo';
@@ -309,6 +310,11 @@ test('DELETE /files/:id reverse-syncs custom Gelbooru favorites', async (t) => {
     },
     { status: 200, body: '' }
   );
+  // Verification re-fetch: favorites page no longer lists 123 → delete confirmed.
+  fm.intercept((url) => url.includes('s=view') && url.includes('pid='), {
+    status: 200,
+    body: '<a href="index.php?page=post&amp;s=view&amp;id=999">x</a>'
+  });
 
   const seeded = await seedUser({ username: 'files_delete_gelbooru_reverse' });
   const cookie = await cookieFor(seeded.user.id);
@@ -357,8 +363,9 @@ test('DELETE /files/:id reverse-syncs custom Gelbooru favorites', async (t) => {
   assert.match(capturedUrl, /id=123/);
 });
 
-test('DELETE /files/:id reports Gelbooru unfavorite redirects', async (t) => {
+test('DELETE /files/:id reports an unconfirmed Gelbooru unfavorite', async (t) => {
   const fm = setupFetchMock(t);
+  // Rule34 redirects on delete without proving removal (issue #144).
   fm.intercept(
     (url) =>
       url.includes('page=favorites') &&
@@ -370,6 +377,11 @@ test('DELETE /files/:id reports Gelbooru unfavorite redirects', async (t) => {
       headers: { location: '/index.php?page=favorites&s=view&id=' }
     }
   );
+  // Verification re-fetch still finds 123 → the delete did not take.
+  fm.intercept((url) => url.includes('s=view') && url.includes('pid='), {
+    status: 200,
+    body: '<a href="index.php?page=post&amp;s=view&amp;id=123">x</a>'
+  });
 
   const seeded = await seedUser({ username: 'files_delete_rule34_redirect' });
   const cookie = await cookieFor(seeded.user.id);
@@ -412,8 +424,43 @@ test('DELETE /files/:id reports Gelbooru unfavorite redirects', async (t) => {
   assert.equal(res.statusCode, 200);
   const body = res.json() as { status: string; errors?: string[] };
   assert.equal(body.status, 'deleted');
-  assert.match(body.errors?.join('\n') ?? '', /unfavorite redirected/);
+  // No cookie configured → actionable message telling the user to add one.
+  assert.match(body.errors?.join('\n') ?? '', /not confirmed/);
+  assert.match(body.errors?.join('\n') ?? '', /add a session cookie/);
+  // Local delete still proceeds even though the remote unfavorite is unconfirmed.
   assert.equal(fs.existsSync(filePath), false);
+});
+
+test('DELETE /files/:id deletes the thumbnail by basename from the thumbnails dir', async () => {
+  const seeded = await seedUser({ username: 'files_delete_thumb' });
+  const cookie = await cookieFor(seeded.user.id);
+  const folders = await foldersRepo.listFolders(seeded.user.id);
+  const filePath = writeFixtureFile(
+    folders[0].path,
+    'with-thumb.png',
+    ONE_BY_ONE_PNG
+  );
+  // Real thumb in the thumbnails dir; store a RELATIVE thumbPath like
+  // production does. The delete must resolve it by basename, not assume it's
+  // already absolute (the bug: "Unsafe path: expected absolute path").
+  const thumbRoot = path.resolve(config.storage.thumbnailsDir);
+  fs.mkdirSync(thumbRoot, { recursive: true });
+  const thumbAbs = path.join(thumbRoot, 'with-thumb-thumb.jpg');
+  fs.writeFileSync(thumbAbs, 'thumb-bytes');
+  const file = await registerFixtureFile(folders[0].id, filePath, {
+    thumbPath: 'storage/thumbnails/with-thumb-thumb.jpg'
+  });
+
+  const res = await app.inject({
+    method: 'DELETE',
+    url: `/files/${file.id}`,
+    headers: { cookie }
+  });
+  assert.equal(res.statusCode, 200);
+  const body = res.json() as { status: string; errors?: string[] };
+  assert.equal(body.status, 'deleted');
+  assert.equal(body.errors, undefined); // no "Unsafe path" error
+  assert.equal(fs.existsSync(thumbAbs), false); // thumb actually removed
 });
 
 test('DELETE /files/:id returns 404 for an unknown id', async () => {

--- a/backend/test/helpers/testApp.ts
+++ b/backend/test/helpers/testApp.ts
@@ -63,7 +63,9 @@ export const writeFixtureFile = (
 export const registerFixtureFile = async (
   folderId: string,
   filePath: string,
-  options: Partial<Pick<ScannedFile, 'mediaType' | 'width' | 'height'>> = {}
+  options: Partial<
+    Pick<ScannedFile, 'mediaType' | 'width' | 'height' | 'thumbPath'>
+  > = {}
 ) => {
   const stat = fs.statSync(filePath);
   return filesRepo.upsertFile(folderId, {
@@ -77,6 +79,6 @@ export const registerFixtureFile = async (
     height: options.height ?? 100,
     durationMs: null,
     phash: null,
-    thumbPath: null
+    thumbPath: options.thumbPath ?? null
   });
 };

--- a/backend/test/migrate.test.ts
+++ b/backend/test/migrate.test.ts
@@ -245,5 +245,5 @@ test('migrate command upgrades legacy drizzle metadata to checksum + name withou
     site_reverse_sync_enabled: 1,
     site_auto_fav_enabled: 1
   });
-  assert.equal(count.count, 3);
+  assert.equal(count.count, 4);
 });

--- a/frontend/src/BooruSitesPanel.tsx
+++ b/frontend/src/BooruSitesPanel.tsx
@@ -14,6 +14,7 @@ import {
   SUGGESTION_PRESETS,
   type SiteSettingKey
 } from '@/features/booru-sites/BooruSitesPanelText';
+import type { BooruCredentialUpdatePayload } from '@/features/booru-sites/formSchemas';
 import {
   ENGINE_LABELS,
   credentialFieldsForSchema
@@ -104,11 +105,7 @@ export const BooruSitesPanel = ({
 
   const saveCredentials = async (
     site: BooruSite,
-    payload: {
-      username: string | null;
-      apiKey?: string;
-      sessionCookie?: string;
-    }
+    payload: BooruCredentialUpdatePayload
   ) => {
     try {
       return await updateSiteMutation.mutateAsync({ id: site.id, payload });

--- a/frontend/src/BooruSitesPanel.tsx
+++ b/frontend/src/BooruSitesPanel.tsx
@@ -64,7 +64,7 @@ export const BooruSitesPanel = ({
     null;
   const [testingId, setTestingId] = useState<string | null>(null);
   const [testResults, setTestResults] = useState<
-    Record<string, { ok: boolean; message: string }>
+    Record<string, { ok: boolean; label: string }[]>
   >({});
   const [formPrefill, setFormPrefill] = useState<{
     name: string;
@@ -104,7 +104,11 @@ export const BooruSitesPanel = ({
 
   const saveCredentials = async (
     site: BooruSite,
-    payload: { username: string | null; apiKey: string | null }
+    payload: {
+      username: string | null;
+      apiKey?: string;
+      sessionCookie?: string;
+    }
   ) => {
     try {
       return await updateSiteMutation.mutateAsync({ id: site.id, payload });
@@ -127,19 +131,29 @@ export const BooruSitesPanel = ({
     setTestingId(site.id);
     try {
       const res = await testSiteMutation.mutateAsync(site.id);
-      setTestResults((prev) => ({
-        ...prev,
-        [site.id]: {
+      const lines = [
+        {
           ok: res.ok,
-          message: res.ok
-            ? `OK (HTTP ${res.status ?? '200'})`
-            : (res.error ?? `HTTP ${res.status ?? '?'}`)
+          label: res.ok
+            ? `Credentials: OK (HTTP ${res.status ?? '200'})`
+            : `Credentials: ${res.error ?? `HTTP ${res.status ?? '?'}`}`
         }
-      }));
+      ];
+      // The cookie line only appears when the backend actually tested it
+      // (cookie saved + engine supports it) — otherwise it stays hidden.
+      if (res.cookie) {
+        lines.push({
+          ok: res.cookie.ok,
+          label: res.cookie.ok
+            ? 'Session cookie: OK'
+            : `Session cookie: ${res.cookie.error ?? 'failed'}`
+        });
+      }
+      setTestResults((prev) => ({ ...prev, [site.id]: lines }));
     } catch (err) {
       setTestResults((prev) => ({
         ...prev,
-        [site.id]: { ok: false, message: (err as Error).message }
+        [site.id]: [{ ok: false, label: (err as Error).message }]
       }));
     } finally {
       setTestingId(null);
@@ -430,10 +444,17 @@ export const BooruSitesPanel = ({
                     )}
 
                     {test ? (
-                      <div
-                        className={`text-sm mt-2 ${test.ok ? 'text-success' : 'text-destructive'}`}
-                      >
-                        {test.ok ? '✓ ' : '✗ '} {test.message}
+                      <div className="text-sm mt-2">
+                        {test.map((line, idx) => (
+                          <div
+                            key={idx}
+                            className={
+                              line.ok ? 'text-success' : 'text-destructive'
+                            }
+                          >
+                            {line.ok ? '✓ ' : '✗ '} {line.label}
+                          </div>
+                        ))}
                       </div>
                     ) : null}
                   </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -190,6 +190,7 @@ export type BooruSite = {
   baseUrl: string;
   username: string | null;
   hasApiKey: boolean;
+  hasSessionCookie: boolean;
   isPreset: boolean;
   presetKey: string | null;
   enabled: boolean;
@@ -200,6 +201,7 @@ export type BooruSite = {
   createdAt: string;
   updatedAt: string;
   engineCredentialSchema: BooruCredentialSchema;
+  engineSupportsSessionCookie: boolean;
 };
 
 export type BooruDetectionAttemptStatus =
@@ -783,6 +785,7 @@ export const api = {
       name: string;
       username: string | null;
       apiKey: string | null;
+      sessionCookie: string | null;
       enabled: boolean;
       siteAutoSyncMidnight: boolean;
       siteReverseSyncEnabled: boolean;
@@ -809,7 +812,12 @@ export const api = {
     const res = await apiFetch(`${API_BASE}/booru-sites/${id}/test`, {
       method: 'POST'
     });
-    return handle<{ ok: boolean; status?: number; error?: string }>(res);
+    return handle<{
+      ok: boolean;
+      status?: number;
+      error?: string;
+      cookie?: { ok: boolean; error?: string };
+    }>(res);
   },
   reorderBooruSites: async (orderedIds: string[]) => {
     const res = await apiFetch(`${API_BASE}/booru-sites/reorder`, {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -235,6 +235,7 @@ export type BooruDetectionResult =
         sourceMatch: boolean;
         search: boolean;
       } | null;
+      supportsSessionCookie: boolean;
       sample: BooruDetectionSample | null;
       attempts: BooruDetectionAttempt[];
     }
@@ -259,6 +260,7 @@ export type BooruEngineCatalog = {
       sourceMatch: boolean;
       search: boolean;
     };
+    supportsSessionCookie: boolean;
   }>;
   presets: Array<{
     key: string;

--- a/frontend/src/features/booru-sites/BooruSiteCredentialForm.tsx
+++ b/frontend/src/features/booru-sites/BooruSiteCredentialForm.tsx
@@ -66,6 +66,11 @@ export function BooruSiteCredentialForm({
     });
   }, [reset, site.id, site.username]);
 
+  // Blank fields mean "keep" on save, so removing a stored secret needs an
+  // explicit null. This is the only path that clears one.
+  const clearSecret = (field: 'apiKey' | 'sessionCookie') =>
+    void onSave({ [field]: null });
+
   return (
     <form
       onSubmit={handleSubmit(async (values) => {
@@ -102,7 +107,17 @@ export function BooruSiteCredentialForm({
           >
             {fields.apiKeyLabel}
             {site.hasApiKey ? (
-              <span className="text-muted-foreground"> · saved</span>
+              <>
+                <span className="text-muted-foreground"> · saved</span>
+                <button
+                  type="button"
+                  className="btn btn-link btn-sm p-0 ms-2 align-baseline text-destructive"
+                  onClick={() => clearSecret('apiKey')}
+                  disabled={loading}
+                >
+                  clear
+                </button>
+              </>
             ) : null}
           </label>
           <input
@@ -122,7 +137,17 @@ export function BooruSiteCredentialForm({
           >
             Session cookie
             {site.hasSessionCookie ? (
-              <span className="text-muted-foreground"> · saved</span>
+              <>
+                <span className="text-muted-foreground"> · saved</span>
+                <button
+                  type="button"
+                  className="btn btn-link btn-sm p-0 ms-2 align-baseline text-destructive"
+                  onClick={() => clearSecret('sessionCookie')}
+                  disabled={loading}
+                >
+                  clear
+                </button>
+              </>
             ) : null}
             <span
               className="favorites-help-dot"

--- a/frontend/src/features/booru-sites/BooruSiteCredentialForm.tsx
+++ b/frontend/src/features/booru-sites/BooruSiteCredentialForm.tsx
@@ -11,6 +11,15 @@ import { credentialFieldsForSchema } from './shared';
 
 import type { BooruCredentialSchema, BooruSite } from '@/api';
 
+const SESSION_COOKIE_HELP = `Lets remote unfavorite work on Gelbooru-style sites (like rule34.xxx) where the API key alone redirects without actually deleting.
+
+How to get it:
+1. Log in to the site in your browser.
+2. Open DevTools (F12) → Network tab, reload the page, then click any request to the site.
+3. Under Request Headers, copy the whole "Cookie" value and paste it here as-is.
+
+It expires over time; re-paste it if remote delete starts failing.`;
+
 type BooruSiteCredentialFormProps = {
   site: BooruSite;
   schema: BooruCredentialSchema;
@@ -39,18 +48,21 @@ export function BooruSiteCredentialForm({
   );
   const usernameId = `site-${site.id}-username`;
   const apiKeyId = `site-${site.id}-api-key`;
+  const sessionCookieId = `site-${site.id}-session-cookie`;
   const { register, reset, handleSubmit } = useForm<BooruCredentialFormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       username: site.username ?? '',
-      apiKey: ''
+      apiKey: '',
+      sessionCookie: ''
     }
   });
 
   useEffect(() => {
     reset({
       username: site.username ?? '',
-      apiKey: ''
+      apiKey: '',
+      sessionCookie: ''
     });
   }, [reset, site.id, site.username]);
 
@@ -60,7 +72,8 @@ export function BooruSiteCredentialForm({
         const updated = await onSave(toBooruCredentialUpdatePayload(values));
         reset({
           username: updated.username ?? '',
-          apiKey: ''
+          apiKey: '',
+          sessionCookie: ''
         });
       })}
       className="row g-2 mt-2"
@@ -98,6 +111,34 @@ export function BooruSiteCredentialForm({
             className="form-control form-control-sm bg-background text-foreground border-secondary"
             placeholder={site.hasApiKey ? '••••••••' : ''}
             {...register('apiKey')}
+          />
+        </div>
+      ) : null}
+      {site.engineSupportsSessionCookie ? (
+        <div className="col-md-8">
+          <label
+            className="form-label text-sm mb-1 text-muted-foreground"
+            htmlFor={sessionCookieId}
+          >
+            Session cookie
+            {site.hasSessionCookie ? (
+              <span className="text-muted-foreground"> · saved</span>
+            ) : null}
+            <span
+              className="favorites-help-dot"
+              title={SESSION_COOKIE_HELP}
+              aria-label={SESSION_COOKIE_HELP}
+            >
+              ?
+            </span>
+          </label>
+          <input
+            id={sessionCookieId}
+            type="password"
+            autoComplete="off"
+            className="form-control form-control-sm bg-background text-foreground border-secondary"
+            placeholder={site.hasSessionCookie ? '••••••••' : ''}
+            {...register('sessionCookie')}
           />
         </div>
       ) : null}

--- a/frontend/src/features/booru-sites/formSchemas.ts
+++ b/frontend/src/features/booru-sites/formSchemas.ts
@@ -33,7 +33,8 @@ export const createBooruCredentialSchema = (credentialSchema: string) =>
       credentialSchema === 'userid+apikey'
         ? trimStringSchema
         : z.string().default(''),
-    apiKey: trimStringSchema
+    apiKey: trimStringSchema,
+    sessionCookie: z.string().default('')
   });
 
 export type BooruCredentialFormValues = z.infer<
@@ -59,7 +60,22 @@ export const toBooruSiteCreatePayload = (
 
 export const toBooruCredentialUpdatePayload = (
   values: BooruCredentialFormValues
-) => ({
-  username: toNullableTrimmed(values.username),
-  apiKey: toNullableTrimmed(values.apiKey)
-});
+) => {
+  // apiKey and sessionCookie are write-only: the form never renders the saved
+  // value, so it always loads blank. A blank field therefore means "leave
+  // unchanged", NOT "clear" — otherwise saving one secret (e.g. just the
+  // session cookie) would wipe the other. Only send a secret the user actually
+  // typed; omitting it makes the backend keep the stored value.
+  const payload: {
+    username: string | null;
+    apiKey?: string;
+    sessionCookie?: string;
+  } = {
+    username: toNullableTrimmed(values.username)
+  };
+  const apiKey = values.apiKey.trim();
+  if (apiKey) payload.apiKey = apiKey;
+  const sessionCookie = values.sessionCookie.trim();
+  if (sessionCookie) payload.sessionCookie = sessionCookie;
+  return payload;
+};

--- a/frontend/src/features/booru-sites/formSchemas.ts
+++ b/frontend/src/features/booru-sites/formSchemas.ts
@@ -58,9 +58,18 @@ export const toBooruSiteCreatePayload = (
   enabled: true
 });
 
+// `null` explicitly clears a stored value; an omitted field leaves it
+// unchanged. The normal save path only ever omits (keep) — `null` is reached
+// solely via the explicit "clear" affordance.
+export type BooruCredentialUpdatePayload = {
+  username?: string | null;
+  apiKey?: string | null;
+  sessionCookie?: string | null;
+};
+
 export const toBooruCredentialUpdatePayload = (
   values: BooruCredentialFormValues
-) => {
+): BooruCredentialUpdatePayload => {
   // apiKey and sessionCookie are write-only: the form never renders the saved
   // value, so it always loads blank. A blank field therefore means "leave
   // unchanged", NOT "clear" — otherwise saving one secret (e.g. just the

--- a/frontend/src/features/file-detail/FileDetailPanel.tsx
+++ b/frontend/src/features/file-detail/FileDetailPanel.tsx
@@ -590,11 +590,6 @@ export function FileDetailPanel(props: Props): React.ReactElement {
                 {favoriteState.error}
               </div>
             ) : null}
-            {deleteState.error ? (
-              <div className="text-destructive text-sm mb-2">
-                {deleteState.error}
-              </div>
-            ) : null}
             <div className="file-detail-topmatches mb-4">
               {matchRemoveState.error ? (
                 <div className="text-destructive text-sm mb-2">

--- a/frontend/src/features/file-detail/useFileDetailController.ts
+++ b/frontend/src/features/file-detail/useFileDetailController.ts
@@ -9,6 +9,7 @@ import {
   type ReactNode,
   type TouchEvent
 } from 'react';
+import { toast } from 'sonner';
 
 import type {
   FetchState,
@@ -752,9 +753,6 @@ export function useFileDetailController(
       setDeleteState({ loading: true, error: null });
       try {
         const result = await deleteFileMutation.mutateAsync(fileId);
-        const warning = result.errors?.length
-          ? `Deleted local file, but remote favorite update failed: ${result.errors.join('; ')}`
-          : null;
         if (selectedFile?.id === fileId) {
           if (nextFile) {
             setSelectedFile(nextFile);
@@ -762,9 +760,21 @@ export function useFileDetailController(
             closeFile();
           }
         }
-        setDeleteState({ loading: false, error: warning });
+        setDeleteState({ loading: false, error: null });
+        if (result.errors?.length) {
+          // The file IS deleted; these are post-delete cleanup issues. The
+          // backend prefixes each (e.g. "Unfavorite …", "Thumb delete …"), so
+          // surface them verbatim instead of mislabelling them all as a remote
+          // favorite failure.
+          toast.warning('Deleted, but some cleanup steps failed', {
+            description: result.errors.join('\n')
+          });
+        } else {
+          toast.success('File deleted');
+        }
       } catch (err) {
-        setDeleteState({ loading: false, error: (err as Error).message });
+        setDeleteState({ loading: false, error: null });
+        toast.error('Delete failed', { description: (err as Error).message });
       }
     },
     [selectedFile, gallery, deleteFileMutation, closeFile]

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 
 import App from './App';
+import { Toaster } from './components/ui/sonner';
 import { createQueryClient } from './lib/query-client';
 
 const container = document.getElementById('root');
@@ -21,6 +22,7 @@ root.render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <App />
+      <Toaster richColors closeButton />
       {import.meta.env.DEV ? (
         <ReactQueryDevtools buttonPosition="bottom-left" />
       ) : null}

--- a/frontend/test/formSchemas.test.ts
+++ b/frontend/test/formSchemas.test.ts
@@ -100,4 +100,26 @@ describe('booru form schemas', () => {
       apiKey: 'token'
     });
   });
+
+  it('omits blank secrets so saving one does not wipe the other', () => {
+    const result = createBooruCredentialSchema('userid+apikey').safeParse({
+      username: '42',
+      apiKey: '',
+      sessionCookie: 'user_id=42; pass_hash=abc'
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+
+    const payload = toBooruCredentialUpdatePayload(result.data);
+    // Cookie typed, API key left blank → only the cookie is sent; the backend
+    // keeps the stored API key because apiKey is absent from the payload.
+    expect(payload).toEqual({
+      username: '42',
+      sessionCookie: 'user_id=42; pass_hash=abc'
+    });
+    expect('apiKey' in payload).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
Implements #144 Option A: an optional per-site **session cookie** for Gelbooru-compatible engines (e.g. rule34.xxx), so deleting a local favorite with reverse-sync reliably removes the remote favorite.

- **Verified delete**: `unfavorite()` sends the cookie and confirms removal by re-fetching the live favorites list instead of trusting the redirect — never silently claims success after a 302 (the core #144 acceptance criterion). Actionable error when unconfirmed, without echoing the cookie value.
- **Cookie in the Test button**: validates the cookie via the rule34 logout-link signal; credentials and cookie status shown as separate lines. Explicit **clear** affordance to remove a saved secret.
- **Storage**: nullable `session_cookie` column (migration 0003) + repo/route plumbing. Stored like `api_key`, never returned (only `hasSessionCookie`) or logged.
- **Fix**: saving one secret no longer wipes the other — blank write-only fields mean "keep", not "clear".
- **Fix**: file delete now removes the thumbnail by basename from the thumbnails dir (was failing with "Unsafe path: expected absolute path"); cleanup errors surface via an auto-hiding toast instead of a mislabeled inline "remote favorite update failed".

## Test plan
- [x] Backend `bun test` — 207 pass
- [x] Frontend `vitest` — 28 pass (incl. new engine + payload + repo + thumb-delete cases)
- [x] `tsc --noEmit` + `eslint` clean both sides
- [x] Opus review pass (cookie never logged/returned/leaked; traversal-safe thumb delete; additive migration)
- [ ] Manual: save cookie on rule34 → Test shows `Session cookie: OK` → delete a favorite → remote favorite removed, toast "File deleted"

Closes #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)