### PR TITLE
security: address HIGH deferred findings from #191 (auth scope, path guard, magic bytes)

### DIFF
--- a/backend/src/services/duplicateResolver.ts
+++ b/backend/src/services/duplicateResolver.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { authRepo } from '../db/repos/authRepo';
+import { config } from '../config';
 import { favoritesRepo } from '../db/repos/favoritesRepo';
 import { filesRepo } from '../db/repos/filesRepo';
 import { foldersRepo } from '../db/repos/foldersRepo';
@@ -20,17 +20,28 @@ const resolveFavoriteRank = (providers: FavoriteProvider[]) => {
   return rank;
 };
 
-const resolveFavoriteOverlap = (a: FavoriteProvider[], b: FavoriteProvider[]) => {
+const resolveFavoriteOverlap = (
+  a: FavoriteProvider[],
+  b: FavoriteProvider[]
+) => {
   if (!a.length || !b.length) return true;
   return a.some((provider) => b.includes(provider));
 };
 
-const compareQuality = (a: { width: number | null; height: number | null; sizeBytes: number; path: string }, b: {
-  width: number | null;
-  height: number | null;
-  sizeBytes: number;
-  path: string;
-}) => {
+const compareQuality = (
+  a: {
+    width: number | null;
+    height: number | null;
+    sizeBytes: number;
+    path: string;
+  },
+  b: {
+    width: number | null;
+    height: number | null;
+    sizeBytes: number;
+    path: string;
+  }
+) => {
   const areaA = (a.width ?? 0) * (a.height ?? 0);
   const areaB = (b.width ?? 0) * (b.height ?? 0);
   if (areaA !== areaB) return areaB - areaA;
@@ -39,8 +50,20 @@ const compareQuality = (a: { width: number | null; height: number | null; sizeBy
 };
 
 const comparePreference = (
-  a: { favoriteProviders: FavoriteProvider[]; width: number | null; height: number | null; sizeBytes: number; path: string },
-  b: { favoriteProviders: FavoriteProvider[]; width: number | null; height: number | null; sizeBytes: number; path: string }
+  a: {
+    favoriteProviders: FavoriteProvider[];
+    width: number | null;
+    height: number | null;
+    sizeBytes: number;
+    path: string;
+  },
+  b: {
+    favoriteProviders: FavoriteProvider[];
+    width: number | null;
+    height: number | null;
+    sizeBytes: number;
+    path: string;
+  }
 ) => {
   const rankA = resolveFavoriteRank(a.favoriteProviders);
   const rankB = resolveFavoriteRank(b.favoriteProviders);
@@ -48,11 +71,17 @@ const comparePreference = (
   return compareQuality(a, b);
 };
 
-const pickSuggestion = (a: { id: string; favoriteProviders: FavoriteProvider[] }, b: {
-  id: string;
-  favoriteProviders: FavoriteProvider[];
-}) => {
-  const conflict = a.favoriteProviders.length > 0 && b.favoriteProviders.length > 0 && !resolveFavoriteOverlap(a.favoriteProviders, b.favoriteProviders);
+const pickSuggestion = (
+  a: { id: string; favoriteProviders: FavoriteProvider[] },
+  b: {
+    id: string;
+    favoriteProviders: FavoriteProvider[];
+  }
+) => {
+  const conflict =
+    a.favoriteProviders.length > 0 &&
+    b.favoriteProviders.length > 0 &&
+    !resolveFavoriteOverlap(a.favoriteProviders, b.favoriteProviders);
   if (conflict) {
     return { keepId: null as string | null };
   }
@@ -64,17 +93,33 @@ const pickSuggestion = (a: { id: string; favoriteProviders: FavoriteProvider[] }
   return { keepId: a.id };
 };
 
-const deleteFileRecord = async (fileId: string, userId: string) => {
+const isPathInsideRoot = (candidate: string, root: string) => {
+  const resolvedRoot = path.resolve(root);
+  const resolvedCandidate = path.resolve(candidate);
+  return (
+    resolvedCandidate === resolvedRoot ||
+    resolvedCandidate.startsWith(`${resolvedRoot}${path.sep}`)
+  );
+};
+
+export const deleteFileRecord = async (fileId: string, userId: string) => {
   const file = await filesRepo.findFileById(fileId, userId);
   if (!file) return false;
   const folder = await foldersRepo.findFolderById(file.folderId, userId);
   if (!folder || folder.type !== 'LOCAL') return false;
-  const favoriteItems = await favoritesRepo.listFavoriteItemsByPath(file.path, userId);
+  const favoriteItems = await favoritesRepo.listFavoriteItemsByPath(
+    file.path,
+    userId
+  );
   if (favoriteItems.length > 0) return false;
   // Verify file path is within its folder root before deleting
   const resolvedBase = path.resolve(folder.path);
   const resolvedFile = path.resolve(file.path);
-  if (!resolvedFile.startsWith(`${resolvedBase}${path.sep}`) && resolvedFile !== resolvedBase) return false;
+  if (
+    !resolvedFile.startsWith(`${resolvedBase}${path.sep}`) &&
+    resolvedFile !== resolvedBase
+  )
+    return false;
   const errors: string[] = [];
   try {
     await fs.promises.unlink(resolvedFile);
@@ -82,10 +127,19 @@ const deleteFileRecord = async (fileId: string, userId: string) => {
     errors.push((err as Error).message);
   }
   if (file.thumbPath) {
-    try {
-      await fs.promises.unlink(file.thumbPath);
-    } catch (err) {
-      errors.push((err as Error).message);
+    // A corrupted/forged thumbPath in the DB must never escape the configured
+    // thumbnails dir — otherwise unlink could delete arbitrary files. Resolve
+    // the real path and confirm containment before touching the FS. Skip (not
+    // throw) so one bad record can't abort the whole auto-resolve batch.
+    const resolvedThumb = path.resolve(file.thumbPath);
+    if (!isPathInsideRoot(resolvedThumb, config.storage.thumbnailsDir)) {
+      errors.push(`thumbPath outside thumbnails dir: ${file.id}`);
+    } else {
+      try {
+        await fs.promises.unlink(resolvedThumb);
+      } catch (err) {
+        errors.push((err as Error).message);
+      }
     }
   }
   if (errors.length) return false;
@@ -95,21 +149,11 @@ const deleteFileRecord = async (fileId: string, userId: string) => {
 
 let autoResolveRunning = false;
 
-export const autoResolveDuplicates = async () => {
+export const autoResolveDuplicates = async (userId: string) => {
   if (autoResolveRunning) return { status: 'busy' } as const;
   autoResolveRunning = true;
   try {
-    const firstUser = (await authRepo.listUsers())[0];
-    if (!firstUser) {
-      return {
-        status: 'done',
-        deleted: 0,
-        keptBoth: 0,
-        skippedFavorites: 0,
-        groups: 0
-      } as const;
-    }
-    const result = await findDuplicates(firstUser.id);
+    const result = await findDuplicates(userId);
     let keptBoth = 0;
     let deleted = 0;
     let skippedFavorites = 0;
@@ -129,7 +173,7 @@ export const autoResolveDuplicates = async () => {
           skippedFavorites += 1;
           continue;
         }
-        const ok = await deleteFileRecord(discard.id, firstUser.id);
+        const ok = await deleteFileRecord(discard.id, userId);
         if (ok) deleted += 1;
       }
     }

--- a/backend/test/duplicateResolver.test.ts
+++ b/backend/test/duplicateResolver.test.ts
@@ -1,0 +1,85 @@
+// Unit contract for deleteFileRecord — the worker that auto-resolve uses to
+// delete a losing duplicate. Two security properties live here:
+//   1. ownership scope: a file is only deletable by its owner (userId).
+//   2. thumbPath containment: a forged/corrupted thumbPath in the DB must
+//      never let unlink escape the configured thumbnails dir.
+import './helpers/setupEnv';
+
+import fs from 'fs';
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+import path from 'path';
+
+import { config } from '../src/config';
+import { filesRepo } from '../src/db/repos/filesRepo';
+import { deleteFileRecord } from '../src/services/duplicateResolver';
+
+import {
+  registerFixtureFile,
+  seedUser,
+  writeFixtureFile
+} from './helpers/testApp';
+
+const folderIdFor = async (userId: string) => {
+  const { foldersRepo } = await import('../src/db/repos/foldersRepo');
+  const folders = await foldersRepo.listFolders(userId);
+  return folders[0].id;
+};
+
+let thumbsDir: string;
+
+before(async () => {
+  thumbsDir = path.resolve(config.storage.thumbnailsDir);
+  await fs.promises.mkdir(thumbsDir, { recursive: true });
+});
+
+after(() => undefined);
+
+test('deleteFileRecord refuses to act on another user’s file', async () => {
+  const alice = await seedUser({ username: 'dr_owner_a' });
+  const bob = await seedUser({ username: 'dr_owner_b' });
+  const aliceFolder = await folderIdFor(alice.user.id);
+  const filePath = writeFixtureFile(alice.libraryRoot, 'owned.png', 'data');
+  const record = await registerFixtureFile(aliceFolder, filePath);
+
+  // Bob tries to delete Alice's file: must be denied and the file must survive.
+  const ok = await deleteFileRecord(record.id, bob.user.id);
+  assert.equal(ok, false);
+  assert.equal(fs.existsSync(filePath), true);
+  assert.notEqual(await filesRepo.findFileById(record.id, alice.user.id), null);
+});
+
+test('deleteFileRecord blocks a thumbPath pointing outside the thumbnails dir', async () => {
+  const user = await seedUser({ username: 'dr_thumb_evil' });
+  const folderId = await folderIdFor(user.user.id);
+  const filePath = writeFixtureFile(user.libraryRoot, 'evil.png', 'data');
+
+  // A sentinel "victim" file outside the thumbnails dir that must NOT be
+  // deleted, even though the DB record points at it via a traversal path.
+  const victim = writeFixtureFile(user.libraryRoot, 'victim.txt', 'keep me');
+  const traversal = path.relative(process.cwd(), victim);
+  const record = await registerFixtureFile(folderId, filePath, {
+    thumbPath: traversal
+  });
+
+  const ok = await deleteFileRecord(record.id, user.user.id);
+  assert.equal(ok, false);
+  // Guard tripped: victim untouched and the DB row is still present.
+  assert.equal(fs.existsSync(victim), true);
+  assert.notEqual(await filesRepo.findFileById(record.id, user.user.id), null);
+});
+
+test('deleteFileRecord unlinks a thumbPath that is inside the thumbnails dir', async () => {
+  const user = await seedUser({ username: 'dr_thumb_ok' });
+  const folderId = await folderIdFor(user.user.id);
+  const filePath = writeFixtureFile(user.libraryRoot, 'good.png', 'data');
+  const thumbName = `good-${Date.now()}.jpg`;
+  const thumbPath = writeFixtureFile(thumbsDir, thumbName, 'thumb');
+  const record = await registerFixtureFile(folderId, filePath, { thumbPath });
+
+  const ok = await deleteFileRecord(record.id, user.user.id);
+  assert.equal(ok, true);
+  assert.equal(fs.existsSync(filePath), false);
+  assert.equal(fs.existsSync(thumbPath), false);
+  assert.equal(await filesRepo.findFileById(record.id, user.user.id), null);
+});

--- a/tagger/app.py
+++ b/tagger/app.py
@@ -5,7 +5,7 @@ import os
 
 import numpy as np
 import onnxruntime as ort
-from fastapi import FastAPI, File, Request, UploadFile
+from fastapi import FastAPI, File, HTTPException, Request, UploadFile
 from fastapi.responses import JSONResponse
 from huggingface_hub import hf_hub_download
 from PIL import Image
@@ -137,6 +137,23 @@ else:
     SESSION, INPUT_NAME, TAGS, CATEGORIES = load_model()
 
 
+# Server-side magic-byte (file signature) validation. The client-reported
+# content type and filename are untrusted; a renamed HTML/script payload must
+# never reach PIL. We sniff the first bytes against known image signatures
+# before any decode. A 12-byte read covers WEBP, whose `WEBP` marker sits at
+# offset 8 inside the RIFF container.
+def is_supported_image(header: bytes) -> bool:
+    if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        return True
+    if header.startswith(b"\xff\xd8\xff"):  # JPEG
+        return True
+    if header.startswith(b"GIF87a") or header.startswith(b"GIF89a"):
+        return True
+    if header.startswith(b"RIFF") and header[8:12] == b"WEBP":
+        return True
+    return False
+
+
 def prepare_image(file_obj):
     with Image.open(file_obj) as image:
         image = image.convert("RGB")
@@ -149,10 +166,12 @@ def prepare_image(file_obj):
 
 @app.post("/tag")
 async def tag_image(file: UploadFile = File(...)):
-    head = await file.read(1)
+    head = await file.read(12)
+    await file.seek(0)
     if not head:
         return {"tags": []}
-    await file.seek(0)
+    if not is_supported_image(head):
+        raise HTTPException(status_code=400, detail="Unsupported image format")
     if SESSION is None:
         return {"tags": []}
     input_tensor = prepare_image(file.file)

--- a/tagger/test_app.py
+++ b/tagger/test_app.py
@@ -21,6 +21,13 @@ def _png_bytes(width: int = 4, height: int = 4) -> bytes:
     return buf.getvalue()
 
 
+def _image_bytes(fmt: str, width: int = 4, height: int = 4) -> bytes:
+    """Return a valid payload of the requested PIL format (JPEG/GIF/WEBP)."""
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color=(0, 128, 255)).save(buf, format=fmt)
+    return buf.getvalue()
+
+
 def test_health_returns_ok(client_factory: Any) -> None:
     client = client_factory()
     response = client.get("/health")
@@ -155,6 +162,41 @@ def test_tag_open_when_secret_unset(client_factory: Any, monkeypatch: Any) -> No
         "/tag", files={"file": ("sample.png", _png_bytes(), "image/png")}
     )
     assert response.status_code == 200
+
+
+def test_tag_rejects_html_renamed_as_jpg(client_factory: Any) -> None:
+    """An HTML payload renamed `.jpg` is rejected by magic-byte validation.
+
+    The client-reported filename and content type are untrusted; only the
+    file signature decides. A non-image must never reach PIL.
+    """
+    client = client_factory()
+    response = client.post(
+        "/tag",
+        files={
+            "file": (
+                "evil.jpg",
+                b"<!DOCTYPE html><html><body>nope</body></html>",
+                "image/jpeg",
+            )
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported image format"
+
+
+def test_tag_accepts_known_image_signatures(
+    client_factory: Any, tag_app: Any
+) -> None:
+    """JPEG, GIF and WEBP signatures all pass the magic-byte guard."""
+    tag_app._test_session.output = np.array([[0.9, 0.1]], dtype=np.float32)
+    client = client_factory()
+    for fmt, mime in (("JPEG", "image/jpeg"), ("GIF", "image/gif"), ("WEBP", "image/webp")):
+        response = client.post(
+            "/tag",
+            files={"file": (f"sample.{fmt.lower()}", _image_bytes(fmt), mime)},
+        )
+        assert response.status_code == 200, fmt
 
 
 def test_tag_calls_onnx_session_once_per_request(


### PR DESCRIPTION
## Summary

Three HIGH-severity security deferred findings from #191:

1. **Authorization bypass in `autoResolveDuplicates`** — replaced the global `authRepo.listUsers()[0]` lookup with an explicit `userId` parameter; `findDuplicates` and every `deleteFileRecord` call now scope to that user (file/folder/favorites queries all take userId). A user can no longer resolve/delete another user's files.
2. **Unguarded `thumbPath` delete** — before `unlink`, the path is `path.resolve`'d and verified to be inside `config.storage.thumbnailsDir` (mirrors `isPathInsideRoot` in `favorites.ts`). Out-of-root paths are recorded as an error and skipped.
3. **No magic-byte validation in tagger** — `is_supported_image()` sniffs PNG/JPEG/GIF/WEBP signatures from the first 12 bytes; `/tag` rejects non-images with HTTP 400 before PIL. No new dependency.

## Verification

- TDD: each fix has a test that fails before / passes after.
- backend `bun run build` ✓, `bun run test` = 228 pass / 0 fail
- tagger `pytest` = 13 passed
- Adversarial security review by subagent: **pass**, no bypass found (verified ../ traversal, startsWith prefix-sibling pitfall, absolute escapes all rejected; auth scope threaded through every query; magic-byte check runs after auth + before decode with seek(0) reset).

## Follow-ups (non-blocking)

- `autoResolveDuplicates` currently has no server-side caller (frontend does client-side resolution) — the fix is correct and forward-safe, but the function is effectively dead backend code worth a separate cleanup.

## Scope

Addresses #191 (the issue's lower-severity findings remain open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)