### PR TITLE
fix(auth): stop empty library root from resolving to the backend cwd

### DIFF
--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -10,6 +10,8 @@ import { authRepo } from '../db/repos/authRepo';
 import { foldersRepo } from '../db/repos/foldersRepo';
 import type { UserRecord } from '../db/types';
 
+import { chooseLibraryRoot, resolveStoredRoot } from './libraryRoot';
+
 export type AuthenticatedUser = Omit<UserRecord, 'passwordHash'>;
 
 const sessionCookieName = config.auth.cookieName;
@@ -33,8 +35,14 @@ export const toPublicUser = (user: UserRecord | AuthenticatedUser) => ({
 });
 
 export const hashPassword = async (password: string) => {
-  if (password.length > 1024) throw new Error('Password exceeds maximum allowed length');
-  return argonHash(password, { type: argon2id, memoryCost: 65536, timeCost: 3, parallelism: 4 });
+  if (password.length > 1024)
+    throw new Error('Password exceeds maximum allowed length');
+  return argonHash(password, {
+    type: argon2id,
+    memoryCost: 65536,
+    timeCost: 3,
+    parallelism: 4
+  });
 };
 
 export const verifyPassword = async (hash: string, password: string) => {
@@ -49,7 +57,11 @@ const buildUserDirectorySuffix = (userId: string) => {
 
 export const buildUserLibraryRoot = (username: string, userId: string) => {
   const directoryName = `${username}-${buildUserDirectorySuffix(userId)}`;
-  return path.resolve(config.mediaPath, config.auth.usersRootDirName, directoryName);
+  return path.resolve(
+    config.mediaPath,
+    config.auth.usersRootDirName,
+    directoryName
+  );
 };
 
 const pathExists = async (candidatePath: string) => {
@@ -70,11 +82,21 @@ const directoryHasEntries = async (candidatePath: string) => {
   }
 };
 
-const ensureUserRootFolderRecord = async (userId: string, previousRoot: string, nextRoot: string) => {
-  const existingNextFolder = await foldersRepo.findFolderByPath(nextRoot, userId);
+const ensureUserRootFolderRecord = async (
+  userId: string,
+  previousRoot: string,
+  nextRoot: string
+) => {
+  const existingNextFolder = await foldersRepo.findFolderByPath(
+    nextRoot,
+    userId
+  );
   if (existingNextFolder) return;
 
-  const previousFolder = previousRoot === nextRoot ? null : await foldersRepo.findFolderByPath(previousRoot, userId);
+  const previousFolder =
+    previousRoot === nextRoot
+      ? null
+      : await foldersRepo.findFolderByPath(previousRoot, userId);
   if (previousFolder) {
     await foldersRepo.updateFolder(previousFolder.id, { path: nextRoot });
     return;
@@ -84,22 +106,31 @@ const ensureUserRootFolderRecord = async (userId: string, previousRoot: string, 
 };
 
 const syncUserLibraryRoot = async (user: UserRecord) => {
-  const storedRoot = path.resolve(user.libraryRoot);
+  const storedRoot = resolveStoredRoot(user.libraryRoot);
   const preferredRoot = buildUserLibraryRoot(user.username, user.id);
 
-  const storedExists = await pathExists(storedRoot);
-  const storedHasEntries = storedExists ? await directoryHasEntries(storedRoot) : false;
-  const preferredExists = preferredRoot === storedRoot ? storedExists : await pathExists(preferredRoot);
+  const storedExists = storedRoot ? await pathExists(storedRoot) : false;
+  const storedHasEntries =
+    storedRoot && storedExists ? await directoryHasEntries(storedRoot) : false;
+  const preferredExists =
+    storedRoot === preferredRoot
+      ? storedExists
+      : await pathExists(preferredRoot);
 
-  const effectiveRoot =
-    storedRoot !== preferredRoot && preferredExists && (!storedExists || !storedHasEntries)
-      ? preferredRoot
-      : storedExists
-        ? storedRoot
-        : preferredRoot;
+  const effectiveRoot = chooseLibraryRoot({
+    storedRoot,
+    preferredRoot,
+    storedExists,
+    storedHasEntries,
+    preferredExists
+  });
 
   await fs.promises.mkdir(effectiveRoot, { recursive: true });
-  await ensureUserRootFolderRecord(user.id, storedRoot, effectiveRoot);
+  await ensureUserRootFolderRecord(
+    user.id,
+    storedRoot ?? effectiveRoot,
+    effectiveRoot
+  );
 
   if (effectiveRoot === storedRoot) {
     return user;
@@ -115,14 +146,26 @@ const syncUserLibraryRoot = async (user: UserRecord) => {
 export const isPathInside = (candidatePath: string, basePath: string) => {
   const resolvedBase = path.resolve(basePath);
   const resolvedCandidate = path.resolve(candidatePath);
-  return resolvedCandidate === resolvedBase || resolvedCandidate.startsWith(`${resolvedBase}${path.sep}`);
+  return (
+    resolvedCandidate === resolvedBase ||
+    resolvedCandidate.startsWith(`${resolvedBase}${path.sep}`)
+  );
 };
 
-export const resolveUserManagedPath = async (libraryRoot: string, rawPath: string) => {
+export const resolveUserManagedPath = async (
+  libraryRoot: string,
+  rawPath: string
+) => {
   const requested = rawPath.trim();
-  const resolvedRoot = await fs.promises.realpath(libraryRoot).catch(() => path.resolve(libraryRoot));
-  const initial = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(resolvedRoot, requested);
-  const resolvedCandidate = await fs.promises.realpath(initial).catch(() => initial);
+  const resolvedRoot = await fs.promises
+    .realpath(libraryRoot)
+    .catch(() => path.resolve(libraryRoot));
+  const initial = path.isAbsolute(requested)
+    ? path.resolve(requested)
+    : path.resolve(resolvedRoot, requested);
+  const resolvedCandidate = await fs.promises
+    .realpath(initial)
+    .catch(() => initial);
   if (!isPathInside(resolvedCandidate, resolvedRoot)) {
     throw new Error('Folder path must stay inside your library root');
   }
@@ -131,7 +174,11 @@ export const resolveUserManagedPath = async (libraryRoot: string, rawPath: strin
 
 export const createSessionToken = () => randomBytes(32).toString('hex');
 
-export const setSessionCookie = (reply: FastifyReply, token: string, expiresAt: string) => {
+export const setSessionCookie = (
+  reply: FastifyReply,
+  token: string,
+  expiresAt: string
+) => {
   reply.setCookie(sessionCookieName, token, {
     path: '/',
     httpOnly: true,
@@ -153,7 +200,9 @@ export const clearSessionCookie = (reply: FastifyReply) => {
 export const createSessionForUser = async (userId: string) => {
   await authRepo.deleteExpiredSessions();
   const token = createSessionToken();
-  const expiresAt = new Date(Date.now() + config.auth.sessionTtlMs).toISOString();
+  const expiresAt = new Date(
+    Date.now() + config.auth.sessionTtlMs
+  ).toISOString();
   const session = await authRepo.createSession(userId, token, expiresAt);
   await authRepo.updateUserLastLogin(userId);
   return session;

--- a/backend/src/services/libraryRoot.test.ts
+++ b/backend/src/services/libraryRoot.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+
+import { test } from 'bun:test';
+
+import { chooseLibraryRoot, resolveStoredRoot } from './libraryRoot';
+
+test('resolveStoredRoot treats empty / whitespace as unset', () => {
+  // Regression: path.resolve('') === process.cwd(), which would make uploads
+  // land next to the backend instead of in the user's library.
+  assert.equal(resolveStoredRoot(''), null);
+  assert.equal(resolveStoredRoot('   '), null);
+});
+
+test('resolveStoredRoot resolves a real path', () => {
+  assert.equal(resolveStoredRoot('/srv/library'), path.resolve('/srv/library'));
+});
+
+test('chooseLibraryRoot uses the preferred root when stored is unset', () => {
+  assert.equal(
+    chooseLibraryRoot({
+      storedRoot: null,
+      preferredRoot: '/media/users/alice',
+      storedExists: false,
+      storedHasEntries: false,
+      preferredExists: false
+    }),
+    '/media/users/alice'
+  );
+});
+
+test('chooseLibraryRoot keeps an existing populated stored root', () => {
+  assert.equal(
+    chooseLibraryRoot({
+      storedRoot: '/custom/lib',
+      preferredRoot: '/media/users/alice',
+      storedExists: true,
+      storedHasEntries: true,
+      preferredExists: false
+    }),
+    '/custom/lib'
+  );
+});
+
+test('chooseLibraryRoot migrates an empty stored root to the preferred one', () => {
+  assert.equal(
+    chooseLibraryRoot({
+      storedRoot: '/custom/lib',
+      preferredRoot: '/media/users/alice',
+      storedExists: true,
+      storedHasEntries: false,
+      preferredExists: true
+    }),
+    '/media/users/alice'
+  );
+});
+
+test('chooseLibraryRoot keeps the stored root when it equals the preferred one', () => {
+  assert.equal(
+    chooseLibraryRoot({
+      storedRoot: '/media/users/alice',
+      preferredRoot: '/media/users/alice',
+      storedExists: true,
+      storedHasEntries: true,
+      preferredExists: true
+    }),
+    '/media/users/alice'
+  );
+});
+
+test('chooseLibraryRoot falls back to preferred when neither root exists yet', () => {
+  assert.equal(
+    chooseLibraryRoot({
+      storedRoot: '/custom/lib',
+      preferredRoot: '/media/users/alice',
+      storedExists: false,
+      storedHasEntries: false,
+      preferredExists: false
+    }),
+    '/media/users/alice'
+  );
+});

--- a/backend/src/services/libraryRoot.ts
+++ b/backend/src/services/libraryRoot.ts
@@ -1,0 +1,43 @@
+import path from 'node:path';
+
+/**
+ * Resolve a stored library root, treating empty/whitespace as "unset".
+ *
+ * `path.resolve('')` returns the process cwd, so a blank stored root (e.g. the
+ * placeholder used when seeding a user) would otherwise be mistaken for a real,
+ * existing directory and uploads would land next to the running backend.
+ */
+export const resolveStoredRoot = (libraryRoot: string): string | null => {
+  const trimmed = libraryRoot.trim();
+  return trimmed ? path.resolve(trimmed) : null;
+};
+
+/**
+ * Pick the effective library root. An unset stored root always yields the
+ * preferred (canonical) location; otherwise the preferred location wins only
+ * when the stored one is missing or empty.
+ */
+export const chooseLibraryRoot = (input: {
+  storedRoot: string | null;
+  preferredRoot: string;
+  storedExists: boolean;
+  storedHasEntries: boolean;
+  preferredExists: boolean;
+}): string => {
+  const {
+    storedRoot,
+    preferredRoot,
+    storedExists,
+    storedHasEntries,
+    preferredExists
+  } = input;
+  if (!storedRoot) return preferredRoot;
+  if (
+    storedRoot !== preferredRoot &&
+    preferredExists &&
+    (!storedExists || !storedHasEntries)
+  ) {
+    return preferredRoot;
+  }
+  return storedExists ? storedRoot : preferredRoot;
+};


### PR DESCRIPTION
## What

A user whose stored `libraryRoot` is empty had their uploads written into the backend's working directory (e.g. `backend/scroll-*.png`) instead of under `mediaPath`.

## Why

`syncUserLibraryRoot` ran `path.resolve(user.libraryRoot)`. When `libraryRoot` is `''` — as `smoke-seed.ts` deliberately sets it, relying on the sync to fix it on first login — `path.resolve('')` returns `process.cwd()`. The cwd exists and is non-empty, so the sync logic treated it as a valid, populated library root and kept it. Every upload then landed next to the running backend.

Real registration (`registerLocalUser`) sets a proper `mediaPath`-based root, so production users are unaffected; the bug surfaces in the seeded/e2e environment. But `path.resolve('')` → cwd is a footgun worth removing at the source.

## Fix

- Treat a blank stored root as **unset** so the preferred `mediaPath`-based root always wins.
- Extract the decision into pure, unit-tested helpers (`resolveStoredRoot` + `chooseLibraryRoot`) in `backend/src/services/libraryRoot.ts`, mirroring the existing "extract pure logic" pattern.

Behavior for users with a valid existing root is unchanged (covered by tests).

## Verification

- 7 unit tests for the helpers (unset / populated / migration / equal-to-preferred / neither-exists branches).
- Full backend suite: 233 pass.
- Reproduced with the Playwright upload flow: before, `backend/` accumulated the uploaded PNGs; after, uploads go to the tmp `mediaPath` and `backend/` stays clean.

No new path-traversal vector: `resolveUserManagedPath` / `isPathInside` are unchanged, and the decision chooses only between server-computed/stored trusted paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)