### PR TITLE
fix: deferred findings batch (security, sync, dedup, sqlite limit)

### DIFF
--- a/backend/src/db/repos/files/providerRuns.ts
+++ b/backend/src/db/repos/files/providerRuns.ts
@@ -11,7 +11,9 @@ import {
 
 export const listProviderRuns = async (fileId: string) => {
   const rows = sqlite
-    .prepare('SELECT * FROM provider_runs WHERE file_id = ? ORDER BY COALESCE(completed_at, created_at) DESC')
+    .prepare(
+      'SELECT * FROM provider_runs WHERE file_id = ? ORDER BY COALESCE(completed_at, created_at) DESC'
+    )
     .all(fileId) as ProviderRunRow[];
   return rows.map(mapProviderRunRow);
 };
@@ -49,16 +51,28 @@ export const createProviderRunWithLimit = async (
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   );
   const tx = sqlite.transaction(() => {
+    // Quota is counted globally per provider, not per user, on purpose: the
+    // SauceNAO/Fluffle limit is tied to the API key (one key per provider for
+    // this single-user app), so a per-user window would let the real upstream
+    // limit be exceeded. Keep this global. (issue #200 finding 3)
     const countRow = sqlite
-      .prepare('SELECT COUNT(1) AS count FROM provider_runs WHERE provider = ? AND created_at >= ? AND cached_hit = 0')
+      .prepare(
+        'SELECT COUNT(1) AS count FROM provider_runs WHERE provider = ? AND created_at >= ? AND cached_hit = 0'
+      )
       .get(provider, windowStart) as { count?: number } | undefined;
     const count = Number(countRow?.count ?? 0);
     if (count >= limit) {
       const oldestRow = sqlite
-        .prepare('SELECT created_at FROM provider_runs WHERE provider = ? AND created_at >= ? AND cached_hit = 0 ORDER BY created_at ASC LIMIT 1')
+        .prepare(
+          'SELECT created_at FROM provider_runs WHERE provider = ? AND created_at >= ? AND cached_hit = 0 ORDER BY created_at ASC LIMIT 1'
+        )
         .get(provider, windowStart) as { created_at?: string } | undefined;
-      const oldest = oldestRow?.created_at ? new Date(oldestRow.created_at) : null;
-      const retryAt = oldest ? new Date(oldest.getTime() + windowMs).toISOString() : null;
+      const oldest = oldestRow?.created_at
+        ? new Date(oldestRow.created_at)
+        : null;
+      const retryAt = oldest
+        ? new Date(oldest.getTime() + windowMs).toISOString()
+        : null;
       return { run: null, rateLimited: true, retryAt, count };
     }
 
@@ -95,7 +109,10 @@ export const createProviderRunWithLimit = async (
   return withSqliteRetry(() => tx());
 };
 
-export const createProviderRun = async (fileId: string, provider: 'SAUCENAO' | 'FLUFFLE') => {
+export const createProviderRun = async (
+  fileId: string,
+  provider: 'SAUCENAO' | 'FLUFFLE'
+) => {
   const now = new Date().toISOString();
   const run: ProviderRunRecord = {
     id: randomUUID(),
@@ -112,63 +129,79 @@ export const createProviderRun = async (fileId: string, provider: 'SAUCENAO' | '
     error: null
   };
   await withSqliteRetry(() => {
-    sqlite.prepare(
-      `INSERT INTO provider_runs (id, file_id, provider, status, cached_hit, score, source_url, thumb_url, results, created_at, completed_at, error)
+    sqlite
+      .prepare(
+        `INSERT INTO provider_runs (id, file_id, provider, status, cached_hit, score, source_url, thumb_url, results, created_at, completed_at, error)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      run.id,
-      run.fileId,
-      run.provider,
-      run.status,
-      run.cachedHit ? 1 : 0,
-      run.score,
-      run.sourceUrl,
-      run.thumbUrl,
-      JSON.stringify(run.results ?? []),
-      run.createdAt,
-      run.completedAt,
-      run.error
-    );
+      )
+      .run(
+        run.id,
+        run.fileId,
+        run.provider,
+        run.status,
+        run.cachedHit ? 1 : 0,
+        run.score,
+        run.sourceUrl,
+        run.thumbUrl,
+        JSON.stringify(run.results ?? []),
+        run.createdAt,
+        run.completedAt,
+        run.error
+      );
   });
   return run;
 };
 
-export const updateProviderRun = async (id: string, updates: Partial<Omit<ProviderRunRecord, 'id' | 'fileId'>>) =>
+export const updateProviderRun = async (
+  id: string,
+  updates: Partial<Omit<ProviderRunRecord, 'id' | 'fileId'>>
+) =>
   withSqliteRetry(() => {
-    const existingRow = sqlite.prepare('SELECT * FROM provider_runs WHERE id = ?').get(id) as ProviderRunRow | undefined;
+    const existingRow = sqlite
+      .prepare('SELECT * FROM provider_runs WHERE id = ?')
+      .get(id) as ProviderRunRow | undefined;
     if (!existingRow) return null;
     const existing = mapProviderRunRow(existingRow);
     const run: ProviderRunRecord = {
       ...existing,
       ...updates
     };
-    sqlite.prepare(
-      `UPDATE provider_runs SET provider = ?, status = ?, cached_hit = ?, score = ?, source_url = ?, thumb_url = ?, results = ?, created_at = ?, completed_at = ?, error = ? WHERE id = ?`
-    ).run(
-      run.provider,
-      run.status,
-      run.cachedHit ? 1 : 0,
-      run.score,
-      run.sourceUrl,
-      run.thumbUrl,
-      JSON.stringify(run.results ?? []),
-      run.createdAt,
-      run.completedAt,
-      run.error,
-      run.id
-    );
+    sqlite
+      .prepare(
+        `UPDATE provider_runs SET provider = ?, status = ?, cached_hit = ?, score = ?, source_url = ?, thumb_url = ?, results = ?, created_at = ?, completed_at = ?, error = ? WHERE id = ?`
+      )
+      .run(
+        run.provider,
+        run.status,
+        run.cachedHit ? 1 : 0,
+        run.score,
+        run.sourceUrl,
+        run.thumbUrl,
+        JSON.stringify(run.results ?? []),
+        run.createdAt,
+        run.completedAt,
+        run.error,
+        run.id
+      );
     return run;
   });
 
-export const removeProviderRunResultForFile = async (fileId: string, sourceUrl: string) => {
-  const rows = sqlite.prepare('SELECT * FROM provider_runs WHERE file_id = ?').all(fileId) as ProviderRunRow[];
+export const removeProviderRunResultForFile = async (
+  fileId: string,
+  sourceUrl: string
+) => {
+  const rows = sqlite
+    .prepare('SELECT * FROM provider_runs WHERE file_id = ?')
+    .all(fileId) as ProviderRunRow[];
   let removed = 0;
   for (const row of rows) {
     const run = mapProviderRunRow(row);
     const results = Array.isArray(run.results) ? run.results : [];
     if (!results.some((result) => result.sourceUrl === sourceUrl)) continue;
     const filtered = results.filter((result) => result.sourceUrl !== sourceUrl);
-    const sorted = [...filtered].sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+    const sorted = [...filtered].sort(
+      (a, b) => (b.score ?? 0) - (a.score ?? 0)
+    );
     const top = sorted[0];
     await updateProviderRun(run.id, {
       results: filtered,

--- a/backend/src/db/repos/files/tags.ts
+++ b/backend/src/db/repos/files/tags.ts
@@ -51,11 +51,24 @@ export const removeManualTag = async (fileId: string, tag: string) => {
   sqlite.prepare('DELETE FROM file_tags WHERE file_id = ? AND tag = ? AND source = ?').run(fileId, tag, 'MANUAL');
 };
 
+// SQLite caps the number of bound parameters per statement
+// (SQLITE_MAX_VARIABLE_NUMBER). Splitting id lists into batches keeps every IN
+// clause under that limit even when reordering a very large library.
+const SQLITE_PARAM_CHUNK = 500;
+
+const chunk = <T>(items: T[], size: number): T[][] => {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+};
+
 export const saveManualOrder = async (fileIds: string[], userId?: string) =>
   withSqliteRetry(() => {
     const now = new Date().toISOString();
     const tx = sqlite.transaction((order: string[], scopedUserId?: string) => {
-      if (order.length === 0) {
+      const clearAll = () => {
         if (scopedUserId) {
           sqlite.prepare(
             `DELETE FROM file_manual_order
@@ -64,31 +77,31 @@ export const saveManualOrder = async (fileIds: string[], userId?: string) =>
         } else {
           sqlite.prepare('DELETE FROM file_manual_order').run();
         }
+      };
+
+      if (order.length === 0) {
+        clearAll();
         return { saved: 0 };
       }
 
-      const placeholders = order.map(() => '?').join(',');
-      const existingRows = (scopedUserId
-        ? sqlite
-            .prepare(
-              `SELECT id FROM files
-               WHERE id IN (${placeholders})
-                 AND folder_id IN (SELECT id FROM folders WHERE user_id = ?)`
-            )
-            .all(...order, scopedUserId)
-        : sqlite.prepare(`SELECT id FROM files WHERE id IN (${placeholders})`).all(...order)) as { id: string }[];
-      const existing = new Set(existingRows.map((row) => row.id));
+      const existing = new Set<string>();
+      for (const batch of chunk(order, SQLITE_PARAM_CHUNK)) {
+        const placeholders = batch.map(() => '?').join(',');
+        const rows = (scopedUserId
+          ? sqlite
+              .prepare(
+                `SELECT id FROM files
+                 WHERE id IN (${placeholders})
+                   AND folder_id IN (SELECT id FROM folders WHERE user_id = ?)`
+              )
+              .all(...batch, scopedUserId)
+          : sqlite.prepare(`SELECT id FROM files WHERE id IN (${placeholders})`).all(...batch)) as { id: string }[];
+        for (const row of rows) existing.add(row.id);
+      }
       const validOrder = order.filter((id) => existing.has(id));
 
       if (validOrder.length === 0) {
-        if (scopedUserId) {
-          sqlite.prepare(
-            `DELETE FROM file_manual_order
-             WHERE file_id IN (SELECT id FROM files WHERE folder_id IN (SELECT id FROM folders WHERE user_id = ?))`
-          ).run(scopedUserId);
-        } else {
-          sqlite.prepare('DELETE FROM file_manual_order').run();
-        }
+        clearAll();
         return { saved: 0 };
       }
 
@@ -101,16 +114,29 @@ export const saveManualOrder = async (fileIds: string[], userId?: string) =>
         insert.run(id, index + 1, now);
       });
 
-      if (scopedUserId) {
-        const validPlaceholders = validOrder.map(() => '?').join(',');
-        sqlite.prepare(
-          `DELETE FROM file_manual_order
-           WHERE file_id IN (SELECT id FROM files WHERE folder_id IN (SELECT id FROM folders WHERE user_id = ?))
-             AND file_id NOT IN (${validPlaceholders})`
-        ).run(scopedUserId, ...validOrder);
-      } else {
-        const validPlaceholders = validOrder.map(() => '?').join(',');
-        sqlite.prepare(`DELETE FROM file_manual_order WHERE file_id NOT IN (${validPlaceholders})`).run(...validOrder);
+      // Drop any previously-ordered rows that are not in the new order. Compute
+      // the stale set in code and delete it in batches, rather than a single
+      // NOT IN (...) — the kept list can be as large as the user's library and
+      // would otherwise blow the parameter limit.
+      const currentRows = (scopedUserId
+        ? sqlite
+            .prepare(
+              `SELECT file_id FROM file_manual_order
+               WHERE file_id IN (SELECT id FROM files WHERE folder_id IN (SELECT id FROM folders WHERE user_id = ?))`
+            )
+            .all(scopedUserId)
+        : sqlite.prepare('SELECT file_id FROM file_manual_order').all()) as {
+        file_id: string;
+      }[];
+      const keep = new Set(validOrder);
+      const stale = currentRows
+        .map((row) => row.file_id)
+        .filter((id) => !keep.has(id));
+      for (const batch of chunk(stale, SQLITE_PARAM_CHUNK)) {
+        const placeholders = batch.map(() => '?').join(',');
+        sqlite
+          .prepare(`DELETE FROM file_manual_order WHERE file_id IN (${placeholders})`)
+          .run(...batch);
       }
 
       return { saved: validOrder.length };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -22,6 +22,7 @@ import { registerFolderRoutes } from './routes/folders';
 import { registerHealthRoutes } from './routes/health';
 import { registerSauceRoutes } from './routes/sauces';
 import { clearSessionCookie, getUserFromSessionToken } from './services/auth';
+import { resetFavoritesSyncOnStartup } from './services/favorites';
 
 const protectedRoutePrefixes = [
   '/folders',
@@ -165,6 +166,7 @@ const start = async () => {
   const app = createServer();
   try {
     runMigrations();
+    resetFavoritesSyncOnStartup();
     const seedResult = await seedBooruSitesFromLegacyCredentials();
     if (seedResult.insertedRows > 0) {
       app.log.info(

--- a/backend/src/lib/booruEngines/helpers.ts
+++ b/backend/src/lib/booruEngines/helpers.ts
@@ -27,3 +27,24 @@ export const basicAuthHeader = (username: string, apiKey: string): string =>
 
 export const escapeRegex = (value: string): string =>
   value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+
+// Query params that carry a credential or session token. Gelbooru-style
+// engines require api_key/user_id in the URL itself, so the URL can't avoid
+// them — but the URL must never reach a log or an error returned to the client
+// with the secret intact (issue #200 finding 1).
+const SECRET_QUERY_KEYS = ['api_key', 'pass_hash', 'login', 'token'];
+
+// Replace the value of any secret-bearing query param with `***` in an
+// arbitrary string (a bare URL, or an error message that embeds one). Operates
+// textually so it also redacts URLs nested inside undici/fetch error messages,
+// not just well-formed standalone URLs.
+export const redactUrlSecrets = (value: string): string => {
+  let redacted = value;
+  for (const key of SECRET_QUERY_KEYS) {
+    redacted = redacted.replace(
+      new RegExp(`([?&]${escapeRegex(key)}=)[^&\\s'"]+`, 'gi'),
+      '$1***'
+    );
+  }
+  return redacted;
+};

--- a/backend/src/lib/providerThresholds.ts
+++ b/backend/src/lib/providerThresholds.ts
@@ -1,0 +1,17 @@
+import type { ProviderRunRecord } from '../db/types';
+
+type Provider = ProviderRunRecord['provider'];
+
+// Minimum match score for a reverse-image provider result to be trusted as a
+// real source: used to gate auto-favorite (favorites.ts), tag import
+// (tagging.ts) and the Sources aggregation (sauces.ts). SauceNAO scores are a
+// 0-100 confidence; Fluffle is stricter so it needs a higher bar. Single
+// source of truth — keep all three callers reading from here (issue #200
+// finding 4).
+export const PROVIDER_MATCH_THRESHOLDS: Record<Provider, number> = {
+  SAUCENAO: 90,
+  FLUFFLE: 95
+};
+
+export const providerMatchThreshold = (provider: Provider): number =>
+  PROVIDER_MATCH_THRESHOLDS[provider] ?? 0;

--- a/backend/src/lib/sauces.ts
+++ b/backend/src/lib/sauces.ts
@@ -1,5 +1,7 @@
 import type { ProviderRunRecord } from '../db/types';
 
+import { providerMatchThreshold } from './providerThresholds';
+
 export type SauceSource = {
   key: string;
   label: string;
@@ -33,11 +35,6 @@ const canonicalizeSauceKey = (value: string) => {
   if (key.endsWith('.e621.net')) return 'e621';
   return key;
 };
-const targetScoreThresholds: Record<string, number> = {
-  SAUCENAO: 90,
-  FLUFFLE: 95
-};
-
 const labelFromUrl = (url: string) => {
   try {
     return new URL(url).hostname.replace(/^www\./, '');
@@ -64,7 +61,10 @@ const looksLikeFilename = (value: string) => {
   return /\.[a-z0-9]{2,5}$/.test(lower);
 };
 
-export const extractSauceKey = (sourceUrl: string | null, sourceName: string | null) => {
+export const extractSauceKey = (
+  sourceUrl: string | null,
+  sourceName: string | null
+) => {
   if (sourceName) {
     const cleaned = normalizeSourceName(sourceName);
     if (cleaned && !looksLikeFilename(cleaned)) {
@@ -74,7 +74,9 @@ export const extractSauceKey = (sourceUrl: string | null, sourceName: string | n
   }
   if (sourceUrl) {
     try {
-      const key = canonicalizeSauceKey(new URL(sourceUrl).hostname.replace(/^www\./, ''));
+      const key = canonicalizeSauceKey(
+        new URL(sourceUrl).hostname.replace(/^www\./, '')
+      );
       if (ignoredSauceKeys.has(key)) return null;
       return key;
     } catch {
@@ -86,7 +88,10 @@ export const extractSauceKey = (sourceUrl: string | null, sourceName: string | n
   return null;
 };
 
-export const extractSauceLabel = (sourceUrl: string | null, sourceName: string | null) => {
+export const extractSauceLabel = (
+  sourceUrl: string | null,
+  sourceName: string | null
+) => {
   if (sourceName) {
     const cleaned = normalizeSourceName(sourceName);
     if (cleaned && !looksLikeFilename(cleaned)) {
@@ -131,19 +136,25 @@ const resolveResultScore = (run: ProviderRunRecord, result: ResultLike) => {
   return score;
 };
 
-export const collectSaucesFromRuns = (runs: ProviderRunRecord[]): SauceSource[] => {
-  const perSourceFiles = new Map<string, { label: string; files: Set<string> }>();
+export const collectSaucesFromRuns = (
+  runs: ProviderRunRecord[]
+): SauceSource[] => {
+  const perSourceFiles = new Map<
+    string,
+    { label: string; files: Set<string> }
+  >();
 
   for (const run of runs) {
     if (run.status !== 'COMPLETED') continue;
-    const threshold = targetScoreThresholds[run.provider] ?? 0;
+    const threshold = providerMatchThreshold(run.provider);
     const bestByKey = new Map<string, { label: string; score: number }>();
     for (const result of resultsFromRun(run)) {
       const score = resolveResultScore(run, result);
       if (score === null || score < threshold) continue;
       const key = extractSauceKey(result.sourceUrl, result.sourceName);
       if (!key) continue;
-      const label = extractSauceLabel(result.sourceUrl, result.sourceName) || key;
+      const label =
+        extractSauceLabel(result.sourceUrl, result.sourceName) || key;
       const existing = bestByKey.get(key);
       if (!existing || score > existing.score) {
         bestByKey.set(key, { label, score });
@@ -154,24 +165,34 @@ export const collectSaucesFromRuns = (runs: ProviderRunRecord[]): SauceSource[] 
       if (existing) {
         existing.files.add(run.fileId);
       } else {
-        perSourceFiles.set(key, { label: value.label, files: new Set([run.fileId]) });
+        perSourceFiles.set(key, {
+          label: value.label,
+          files: new Set([run.fileId])
+        });
       }
     }
   }
 
   return Array.from(perSourceFiles.entries())
-    .map(([key, value]) => ({ key, label: value.label, count: value.files.size }))
+    .map(([key, value]) => ({
+      key,
+      label: value.label,
+      count: value.files.size
+    }))
     .sort((a, b) => {
       if (b.count !== a.count) return b.count - a.count;
       return a.label.localeCompare(b.label);
     });
 };
 
-export const hasTargetSauce = (runs: ProviderRunRecord[], targetKeys: Set<string>) => {
+export const hasTargetSauce = (
+  runs: ProviderRunRecord[],
+  targetKeys: Set<string>
+) => {
   if (targetKeys.size === 0) return false;
   for (const run of runs) {
     if (run.status === 'PENDING' || run.status === 'RUNNING') continue;
-    const threshold = targetScoreThresholds[run.provider] ?? 0;
+    const threshold = providerMatchThreshold(run.provider);
     for (const result of resultsFromRun(run)) {
       let score = result.score;
       if (run.provider === 'FLUFFLE' && score === null) {

--- a/backend/src/routes/booruSites.ts
+++ b/backend/src/routes/booruSites.ts
@@ -6,6 +6,7 @@ import { booruSitesRepo } from '../db/repos/booruSitesRepo';
 import { BooruSiteRecord } from '../db/types';
 import { getEngine, listEngines } from '../lib/booruEngines';
 import { detectEngine } from '../lib/booruEngines/detect';
+import { redactUrlSecrets } from '../lib/booruEngines/helpers';
 import { BOORU_PRESETS } from '../lib/booruEngines/presets';
 import {
   assertUrlAllowed,
@@ -151,7 +152,10 @@ const probeTestConnection = async (
     }
     return { ok: true, status: res.status };
   } catch (err) {
-    return { ok: false, error: (err as Error).message };
+    // The probe URL can embed user_id/api_key (userid+apikey engines). A fetch
+    // failure message may quote that URL back, so redact before it reaches the
+    // client or the logs (issue #200 finding 1).
+    return { ok: false, error: redactUrlSecrets((err as Error).message) };
   }
 };
 

--- a/backend/src/services/favorites.ts
+++ b/backend/src/services/favorites.ts
@@ -18,6 +18,7 @@ import type {
 import { engineSupports, getEngine } from '../lib/booruEngines';
 import { extractFavoriteRemoteFromSiteList } from '../lib/favoriteSourceMatch';
 import { ensureDirectoryWritable } from '../lib/fsAccess';
+import { providerMatchThreshold } from '../lib/providerThresholds';
 import {
   detectMediaKind,
   isUploadContentValid,
@@ -198,16 +199,10 @@ const favoriteSourceName = (provider: FavoriteProvider): string => {
   return provider;
 };
 
-const FLUFFLE_MATCH_THRESHOLD = 95;
-const SAUCENAO_MATCH_THRESHOLD = 90;
-
-const providerThreshold = (provider: 'SAUCENAO' | 'FLUFFLE') =>
-  provider === 'FLUFFLE' ? FLUFFLE_MATCH_THRESHOLD : SAUCENAO_MATCH_THRESHOLD;
-
 const hasHighConfidenceSource = (file: FileRecord, sourceUrl: string) => {
   return filesRepo.listProviderRuns(file.id).then((runs) =>
     runs.some((run) => {
-      const threshold = providerThreshold(run.provider);
+      const threshold = providerMatchThreshold(run.provider);
       const results =
         Array.isArray(run.results) && run.results.length
           ? run.results
@@ -452,7 +447,7 @@ const findBestFavoritableMatch = async (
   let best: { match: ScoredFavoritableMatch; score: number } | null = null;
   for (const run of runs) {
     if (run.status !== 'COMPLETED') continue;
-    const threshold = providerThreshold(run.provider);
+    const threshold = providerMatchThreshold(run.provider);
     const candidates = run.results?.length
       ? run.results
       : run.sourceUrl
@@ -941,6 +936,28 @@ const runFavoritesSync = async (userId: string, options: SyncOptions) => {
     debugLog(`sync failed: ${(err as Error).message}`);
   } finally {
     syncRunningByUser.set(userId, false);
+  }
+};
+
+// Sync progress lives only in process memory (syncStateByUser /
+// syncRunningByUser). A crash mid-sync leaves no persisted "running" flag to
+// clear, but a graceful restart that reuses module state (tests, hot reload) or
+// any future move to persistence could. Reset any non-idle state to idle at
+// boot so a previously-interrupted sync never strands the UI on "running"
+// (issue #200 finding 2). Decision: status-only reset, no progress persistence.
+export const resetFavoritesSyncOnStartup = () => {
+  syncRunningByUser.clear();
+  for (const userId of syncStateByUser.keys()) {
+    const current = syncStateByUser.get(userId);
+    if (current && current.status === 'running') {
+      syncStateByUser.set(userId, {
+        ...current,
+        status: 'idle',
+        message: 'Idle',
+        progress: null,
+        updatedAt: new Date().toISOString()
+      });
+    }
   }
 };
 

--- a/backend/src/services/tagging.ts
+++ b/backend/src/services/tagging.ts
@@ -14,6 +14,7 @@ import { filesRepo } from '../db/repos/filesRepo';
 import { BooruSiteRecord, SPECIAL_TAG_SOURCES, TagSource } from '../db/types';
 import type { FileRecord, ProviderRunRecord } from '../db/types';
 import { engineSupports, getEngine } from '../lib/booruEngines';
+import { redactUrlSecrets } from '../lib/booruEngines/helpers';
 import { providerMatchThreshold } from '../lib/providerThresholds';
 
 type TagCandidate = {
@@ -419,8 +420,11 @@ export const refreshTagsFromProviderRun = async (
     const candidates = collectCandidatesFromRuns(runs, sites);
     await applyCombinedTags(file, candidates);
   } catch (err) {
+    // The error can originate from a booru fetch whose URL carries
+    // user_id/api_key (gelbooru-style engines); undici embeds that URL in the
+    // message on network/DNS failures, so redact before logging (§10).
     console.warn(
-      `[tags] refresh failed for ${file.id}: ${(err as Error).message}`
+      `[tags] refresh failed for ${file.id}: ${redactUrlSecrets((err as Error).message)}`
     );
   }
 };

--- a/backend/src/services/tagging.ts
+++ b/backend/src/services/tagging.ts
@@ -14,6 +14,7 @@ import { filesRepo } from '../db/repos/filesRepo';
 import { BooruSiteRecord, SPECIAL_TAG_SOURCES, TagSource } from '../db/types';
 import type { FileRecord, ProviderRunRecord } from '../db/types';
 import { engineSupports, getEngine } from '../lib/booruEngines';
+import { providerMatchThreshold } from '../lib/providerThresholds';
 
 type TagCandidate = {
   site: BooruSiteRecord;
@@ -41,11 +42,6 @@ type Wd14Tag = {
 
 type Wd14Response = {
   tags?: Wd14Tag[] | null;
-};
-
-const providerScoreThresholds: Record<ProviderRunRecord['provider'], number> = {
-  SAUCENAO: 90,
-  FLUFFLE: 95
 };
 
 const resolveFileUserId = async (fileId: string) => {
@@ -141,7 +137,7 @@ const extractCandidates = (
   run: ProviderRunRecord,
   sites: BooruSiteRecord[]
 ): TagCandidate[] => {
-  const minScore = providerScoreThresholds[run.provider] ?? 0;
+  const minScore = providerMatchThreshold(run.provider);
   const results =
     run.results && run.results.length
       ? run.results
@@ -208,10 +204,6 @@ const fetchTagsBySite = async (
     tags,
     sourceUrl: candidate.url || engine.buildPostUrl(site, candidate.id)
   };
-};
-
-const resolveLocalPath = async (file: FileRecord) => {
-  return { path: file.path, cleanup: async () => undefined };
 };
 
 const runWd14Tagger = async (imagePath: string) => {
@@ -453,11 +445,9 @@ export const ensureWd14Tags = async (
   )
     return;
 
-  const resolved = await resolveLocalPath(file);
-  if (!resolved) return;
   try {
     if (file.mediaType === 'VIDEO') {
-      const { frames, cleanup } = await extractVideoFrames(resolved.path, 3);
+      const { frames, cleanup } = await extractVideoFrames(file.path, 3);
       try {
         const results = await Promise.all(
           frames.map((frame) => runWd14Tagger(frame))
@@ -468,15 +458,13 @@ export const ensureWd14Tags = async (
         await cleanup();
       }
     } else {
-      const tagsFromModel = await runWd14Tagger(resolved.path);
+      const tagsFromModel = await runWd14Tagger(file.path);
       await replaceTags(file.id, 'WD14', tagsFromModel);
     }
   } catch (err) {
     console.warn(
       `[tags] wd14 failed for ${file.id}: ${(err as Error).message}`
     );
-  } finally {
-    await resolved.cleanup();
   }
 };
 

--- a/backend/test/booruEngineHelpers.test.ts
+++ b/backend/test/booruEngineHelpers.test.ts
@@ -1,0 +1,55 @@
+// Pure-function contract for the booru engine helpers. The redaction helper is
+// a security boundary (issue #200 finding 1): credential query params must
+// never survive into a log line or a client-facing error.
+import assert from 'node:assert/strict';
+
+import { test } from 'bun:test';
+
+import { redactUrlSecrets } from '../src/lib/booruEngines/helpers';
+
+test('redactUrlSecrets masks api_key in a bare URL', () => {
+  const url =
+    'https://gelbooru.com/index.php?page=dapi&user_id=42&api_key=SECRET123';
+  const out = redactUrlSecrets(url);
+  assert.equal(
+    out,
+    'https://gelbooru.com/index.php?page=dapi&user_id=42&api_key=***'
+  );
+  assert.ok(!out.includes('SECRET123'));
+});
+
+test('redactUrlSecrets keeps non-secret params intact', () => {
+  const url = 'https://gelbooru.com/index.php?page=dapi&user_id=42&id=99';
+  assert.equal(redactUrlSecrets(url), url);
+});
+
+test('redactUrlSecrets masks api_key when it is the first param', () => {
+  const url = 'https://booru.example/posts.json?api_key=abc&page=1';
+  assert.equal(
+    redactUrlSecrets(url),
+    'https://booru.example/posts.json?api_key=***&page=1'
+  );
+});
+
+test('redactUrlSecrets masks pass_hash, login and token', () => {
+  const url =
+    'https://booru.example/?login=user&pass_hash=deadbeef&token=zzz&q=cat';
+  assert.equal(
+    redactUrlSecrets(url),
+    'https://booru.example/?login=***&pass_hash=***&token=***&q=cat'
+  );
+});
+
+test('redactUrlSecrets redacts a URL embedded in an error message', () => {
+  const message =
+    'fetch failed: https://gelbooru.com/index.php?api_key=TOPSECRET&id=1 (ECONNREFUSED)';
+  const out = redactUrlSecrets(message);
+  assert.ok(!out.includes('TOPSECRET'));
+  assert.ok(out.includes('api_key=***'));
+  assert.ok(out.includes('(ECONNREFUSED)'));
+});
+
+test('redactUrlSecrets is case-insensitive on the key', () => {
+  const url = 'https://booru.example/?API_KEY=secret';
+  assert.equal(redactUrlSecrets(url), 'https://booru.example/?API_KEY=***');
+});

--- a/backend/test/booruEngineHelpers.test.ts
+++ b/backend/test/booruEngineHelpers.test.ts
@@ -53,3 +53,15 @@ test('redactUrlSecrets is case-insensitive on the key', () => {
   const url = 'https://booru.example/?API_KEY=secret';
   assert.equal(redactUrlSecrets(url), 'https://booru.example/?API_KEY=***');
 });
+
+test('redactUrlSecrets masks creds in an undici-style network error message', () => {
+  // Shape mirrors how undici surfaces the request URL when a provider tag
+  // fetch fails (the error logged from refreshTagsFromProviderRun), keeping the
+  // non-secret user_id visible but never the api_key.
+  const message =
+    'TypeError: fetch failed (https://gelbooru.com/index.php?page=dapi&s=post&id=42&user_id=9000&api_key=abcdEF123)';
+  const out = redactUrlSecrets(message);
+  assert.ok(!out.includes('abcdEF123'));
+  assert.ok(out.includes('user_id=9000'));
+  assert.ok(out.includes('api_key=***'));
+});

--- a/backend/test/saveManualOrder.test.ts
+++ b/backend/test/saveManualOrder.test.ts
@@ -1,0 +1,103 @@
+// Contract for saveManualOrder, with focus on the SQLite parameter-limit fix
+// (issue #200 finding 5): a reorder spanning more ids than
+// SQLITE_MAX_VARIABLE_NUMBER must not throw and must persist the full order.
+import './helpers/setupEnv';
+
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+
+import { afterEach, test } from 'bun:test';
+
+import { sqlite } from '../src/db/repos/files/shared';
+import { filesRepo } from '../src/db/repos/filesRepo';
+
+const now = new Date().toISOString();
+
+const seedUser = () => {
+  const userId = randomUUID();
+  const folderId = randomUUID();
+  sqlite
+    .prepare(
+      `INSERT INTO users (id, username, password_hash, library_root, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .run(userId, `u-${userId}`, 'x', '/tmp', now, now);
+  sqlite
+    .prepare(
+      `INSERT INTO folders (id, user_id, path, type, created_at, updated_at, status)
+       VALUES (?, ?, ?, 'LOCAL', ?, ?, 'READY')`
+    )
+    .run(folderId, userId, `/tmp/${folderId}`, now, now);
+  return { userId, folderId };
+};
+
+const seedFiles = (folderId: string, count: number): string[] => {
+  const insert = sqlite.prepare(
+    `INSERT INTO files (id, folder_id, location_type, path, size_bytes, mtime, sha256, media_type, created_at, updated_at)
+     VALUES (?, ?, 'LOCAL', ?, 0, ?, ?, 'IMAGE', ?, ?)`
+  );
+  const ids: string[] = [];
+  const tx = sqlite.transaction(() => {
+    for (let i = 0; i < count; i += 1) {
+      const id = randomUUID();
+      ids.push(id);
+      insert.run(id, folderId, `/tmp/${id}.jpg`, now, id, now, now);
+    }
+  });
+  tx();
+  return ids;
+};
+
+afterEach(() => {
+  sqlite.prepare('DELETE FROM file_manual_order').run();
+  sqlite.prepare('DELETE FROM files').run();
+  sqlite.prepare('DELETE FROM folders').run();
+  sqlite.prepare('DELETE FROM users').run();
+});
+
+test('saveManualOrder persists an order larger than the SQLite param limit', async () => {
+  const { userId, folderId } = seedUser();
+  // > 500 (chunk size) and > the historical 999-variable default, so the
+  // pre-fix single IN clause would have failed here.
+  const ids = seedFiles(folderId, 1200);
+
+  const result = await filesRepo.saveManualOrder(ids, userId);
+  assert.equal(result.saved, 1200);
+
+  const rows = sqlite
+    .prepare('SELECT file_id, position FROM file_manual_order ORDER BY position ASC')
+    .all() as { file_id: string; position: number }[];
+  assert.equal(rows.length, 1200);
+  assert.equal(rows[0].file_id, ids[0]);
+  assert.equal(rows[rows.length - 1].file_id, ids[ids.length - 1]);
+});
+
+test('saveManualOrder drops stale rows not present in the new large order', async () => {
+  const { userId, folderId } = seedUser();
+  const ids = seedFiles(folderId, 800);
+
+  await filesRepo.saveManualOrder(ids, userId);
+  // Reorder to a subset: the other 400 must be removed from file_manual_order.
+  const subset = ids.slice(0, 400);
+  const result = await filesRepo.saveManualOrder(subset, userId);
+  assert.equal(result.saved, 400);
+
+  const remaining = sqlite
+    .prepare('SELECT COUNT(1) AS c FROM file_manual_order')
+    .get() as { c: number };
+  assert.equal(remaining.c, 400);
+});
+
+test('saveManualOrder ignores ids that do not belong to the user', async () => {
+  const { userId, folderId } = seedUser();
+  const ids = seedFiles(folderId, 3);
+  const stranger = randomUUID();
+
+  const result = await filesRepo.saveManualOrder([...ids, stranger], userId);
+  assert.equal(result.saved, 3);
+
+  const stored = sqlite
+    .prepare('SELECT file_id FROM file_manual_order WHERE file_id = ?')
+    .get(stranger);
+  assert.equal(stored, null);
+});

--- a/frontend/src/features/library/useGalleryController.ts
+++ b/frontend/src/features/library/useGalleryController.ts
@@ -409,6 +409,13 @@ export function useGalleryController(
     }
   }, [folderMap, galleryFolderId, setGalleryFolderId]);
 
+  // Drop the page cache when the media/favorites filter changes. The cache is
+  // keyed by filter combination, so without this every toggle leaves its old
+  // entry behind and the Map grows unbounded over a long session.
+  useEffect(() => {
+    galleryCacheRef.current.clear();
+  }, [galleryMediaFilter, galleryFavoritesOnly]);
+
   // Refetch on gallery params change — only when gallery is active (verbatim logic)
   useEffect(() => {
     if (!authUser) return;


### PR DESCRIPTION
Part of #200

Implements the approved deferred findings from the codebase review. Each is a focused commit.

## Findings addressed

1. **API key in cleartext booru URL (security).** Gelbooru-style engines require `user_id`+`api_key` as query params, so the URL can't drop them. A connection-test fetch failure could quote that URL back into the error returned to the client and the logs. Added `redactUrlSecrets()` (masks `api_key`/`pass_hash`/`login`/`token`) and applied it to the probe error path. Unit-tested.
2. **Sync state diverges on crash (HIGH).** Favorites sync status is process-memory only; an interrupted run (or reused module state) can strand the UI on "running". Reset any non-idle status to idle at boot. No progress persistence by design.
3. **Provider rate-limit window global vs per-user.** Kept global on purpose (quota is per provider API key, single-user app). Added a documenting comment so the global `COUNT` isn't mistaken for a bug.
4. **providerThreshold duplicated (HIGH).** The three backend copies (favorites, tagging, sauces) had **identical** semantics (`SAUCENAO=90`, `FLUFFLE=95`). Deduped into `backend/src/lib/providerThresholds.ts`. Frontend left as-is (it must not import a backend module; it keeps its own mirrored copy).
5. **IN clause may exceed SQLite variable limit.** `saveManualOrder` bound every file id into one IN clause. Chunked the validation SELECT and the stale-row delete into batches of 500; the cleanup is now a computed delete of the stale set instead of `NOT IN (...)` (same overflow risk). Integration test reorders 1200 ids.
6. **galleryCacheRef grows unbounded.** Clear the page cache when the media/favorites filter changes (simple, not LRU).
7. **resolveLocalPath no-op async wrapper.** Removed; inlined `file.path` directly. Verified the single caller didn't depend on the async/cleanup contract (cleanup was a no-op; video frames have their own cleanup which is preserved).

Not done (still deferred per scope): G6 (ORDER BY RANDOM), G8 (DNS rebinding ssrfGuard).

## Verify
- backend: `bun run build` ✓, `bun test` 244 pass ✓, `bun run lint` ✓
- frontend: `bun run build` ✓, `bun run test` 40 pass ✓, `bun run lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)