### PR TITLE
perf(frontend): split vendor deps into a separate chunk

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,20 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src')
     }
   },
+  build: {
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          groups: [
+            {
+              name: 'vendor',
+              test: /node_modules/
+            }
+          ]
+        }
+      }
+    }
+  },
   server: {
     port: 5174
   }


### PR DESCRIPTION
## What

Reduce the frontend's main JS chunk, which was **563 kB** (gzip 165 kB) and tripped Rolldown's 500 kB chunk-size warning at build time.

## Approach chosen + why

The original ask offered two options: route-level `React.lazy` + Suspense, or just raising `chunkSizeWarningLimit`. I went with a third, strictly better option: a **pure-config vendor chunk split** via Rolldown's `output.codeSplitting`.

**Why not `React.lazy`:** `AppShell` instantiates all five feature controllers (`useGalleryController`, `useFileDetailController`, `useFoldersController`, `useDuplicatesController`, `useSauceFavoritesController`) unconditionally and shares them through a single React context that every route consumes. The route views are thin consumers. Lazy-loading the views would **not** defer the heavy controller/panel code — that code runs eagerly in the parent route. Making lazy-loading actually pay off would require inverting the controller wiring (cross-controller callbacks like `goRelativeWrapper`, `filePanelProps`, `duplicatesViewProps` all need multiple controllers alive at once). That's a high-risk rewrite of the app's core state for an app where 165 kB gzip already loads instantly on LAN/Tailscale.

**Why this is better than just raising the limit:** the vendor split genuinely reduces the main app chunk and, because framework code rarely changes, the vendor chunk caches across app deploys. Zero behavior change, no Suspense/loading-state complexity.

## Before / after (main chunk)

| | Before | After |
|---|---|---|
| Main app JS | **563.06 kB** (gzip 165.30) | **131.48 kB** (gzip 33.28) |
| Vendor JS | — | 431.13 kB (gzip 131.71) — under the 500 kB limit |
| Build warning | over 500 kB | none |

## Verify

- `bun run build` — clean, no chunk-size or deprecation warnings
- `bun run test` — 40/40 pass
- `bun run lint` — clean
- `vite preview` — app boots, all chunks serve HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)